### PR TITLE
feat: playout mux function

### DIFF
--- a/common/transcode.go
+++ b/common/transcode.go
@@ -35,3 +35,17 @@ type MuxInput struct {
 type MuxResult struct {
 	Path string
 }
+
+type PlayoutMuxInput struct {
+	FileName          string
+	VideoFilePath     string
+	StereoLanguages   []string
+	AudioFilePaths    map[string]string
+	SubtitleFilePaths map[string]string
+	DestinationPath   string
+	FallbackLanguage  string
+}
+
+type PlayoutMuxResult struct {
+	Path string
+}

--- a/services/transcode/merge.go
+++ b/services/transcode/merge.go
@@ -2,15 +2,16 @@ package transcode
 
 import (
 	"fmt"
-	"github.com/bcc-code/bccm-flows/common"
-	"github.com/bcc-code/bccm-flows/services/ffmpeg"
-	"github.com/bcc-code/bccm-flows/utils"
-	"github.com/samber/lo"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/bcc-code/bccm-flows/common"
+	"github.com/bcc-code/bccm-flows/services/ffmpeg"
+	"github.com/bcc-code/bccm-flows/utils"
+	"github.com/samber/lo"
 )
 
 // MergeVideo takes a list of video files and merges them into one file.
@@ -18,7 +19,7 @@ func MergeVideo(input common.MergeInput, progressCallback ffmpeg.ProgressCallbac
 	var params []string
 
 	for _, i := range input.Items {
-		params = append(params, "-i", i.Path)
+		params = append(params, "-i", utils.IsilonPathFix(i.Path))
 	}
 
 	var filterComplex string
@@ -130,7 +131,7 @@ func MergeAudio(input common.MergeInput, progressCallback ffmpeg.ProgressCallbac
 	}
 
 	for _, i := range input.Items {
-		params = append(params, "-i", i.Path)
+		params = append(params, "-i", utils.IsilonPathFix(i.Path))
 	}
 
 	params = append(params,
@@ -172,7 +173,8 @@ func MergeSubtitles(input common.MergeInput, progressCallback ffmpeg.ProgressCal
 	// for each file, extract the specified range and save the result to a file.
 	for index, item := range input.Items {
 		file := filepath.Join(input.WorkDir, fmt.Sprintf("%d.srt", index))
-		cmd := exec.Command("ffmpeg", "-i", item.Path, "-ss", fmt.Sprintf("%f", item.Start), "-to", fmt.Sprintf("%f", item.End), "-y", file)
+		path := utils.IsilonPathFix(item.Path)
+		cmd := exec.Command("ffmpeg", "-i", path, "-ss", fmt.Sprintf("%f", item.Start), "-to", fmt.Sprintf("%f", item.End), "-y", file)
 
 		_, err := utils.ExecuteCmd(cmd, nil)
 		if err != nil {

--- a/services/transcode/playout_mux.go
+++ b/services/transcode/playout_mux.go
@@ -1,0 +1,274 @@
+package transcode
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bcc-code/bccm-flows/common"
+	"github.com/bcc-code/bccm-flows/services/ffmpeg"
+	"github.com/samber/lo"
+)
+
+/***
+
+# Playout mux
+
+The playout system has these known requirements:
+- Exactly 16 audio tracks representing 12 languages
+- The audio tracks are all mono
+- The first 8 audio tracks are stereo pairs (L and R) for the 4 first languages
+- The next 8 audio tracks are mono for the 8 next languages
+
+It's not known if this is a requirement, but we also:
+- resample audio to 48khz (ffmpeg anyway cant use 44.1khz for pcm? got an error)
+- reencode audio to 24bit pcm_s24le
+
+## Example ffmpeg command
+The following is a simpler version, to make it easier to understand the filter.
+
+- Resample all audio to 48khz (aresample=48000)
+- It creates 5 audio tracks.
+  - Track 1 and 2 will be norwegian L and R (channelsplit=channel_layout=stereo)
+  - Track 3 and 4 will be english L and R. (channelsplit=channel_layout=stereo)
+  - Track 5 will be finnish L (pan=1c|c0=c0)
+  - Track 6 will be norwegian L (the norwegian L is split into two streams: `asplit=2[nor_l_copy1][nor_l_copy2]`)
+- Subtitles are not included.
+
+```bash
+
+ffmpeg \
+  -i BERG_TS01_ISRAEL_VOD.mxf \
+  -i BERG_TS01_ISRAEL_VOD-nor.wav \
+  -i BERG_TS01_ISRAEL_VOD-eng.wav \
+  -i BERG_TS01_ISRAEL_VOD-fin.wav \
+  -filter_complex "[1:a]aresample=48000,channelsplit=channel_layout=stereo[nor_l][nor_r]; [nor_l]asplit=2[nor_l_copy1][nor_l_copy2]; [2:a]aresample=48000,channelsplit=channel_layout=stereo[eng_l][eng_r]; [3:a]aresample=48000,pan=1c|c0=c0[fin_l]" \
+  -map "0:v" -map "[nor_l_copy1]" -map "[nor_r]" -map "[eng_l]" -map "[eng_r]" -map "[fin_l]" -map "[nor_l_copy2]" \
+  -c:v copy -c:a pcm_s24le \
+  -y transcoded/output.mxf
+
+```
+
+**/
+
+var playoutLanguages = [12]string{
+	"nor",
+	"deu",
+	"nld",
+	"eng",
+	"fra",
+	"spa",
+	"fin",
+	"rus",
+	"por",
+	"ron",
+	"tur",
+	"pol",
+}
+
+func createStereoFilter(input string, leftOutput string, rightOutput string) string {
+	return fmt.Sprintf("[%s]aresample=48000,channelsplit=channel_layout=stereo[%s][%s]", input, leftOutput, rightOutput)
+}
+
+func createMonoFilter(input string, output string) string {
+	return fmt.Sprintf("[%s]aresample=48000[%s]", input, output)
+}
+
+func createSplitFilter(input string, splitCount int) string {
+	filter := fmt.Sprintf("[%s]asplit=%d", input, splitCount)
+	for i := 0; i < splitCount; i++ {
+		filter += fmt.Sprintf("[%s_copy_%d]", input, i)
+	}
+	return filter
+}
+
+type inputFile struct {
+	languageFile
+	inputIndex int
+}
+
+type trackMap struct {
+	file        inputFile
+	stereo      bool
+	copyFrom    string
+	streamLabel string
+}
+
+func generateAudioSplitFilter(input string, count int) (string, []string) {
+	filter := fmt.Sprintf("[%s]asplit=%d", input, count)
+	labels := []string{}
+
+	for i := 0; i < count; i++ {
+		copyLabel := fmt.Sprintf("%s_copy_%d", input, i)
+		filter += fmt.Sprintf("[%s]", copyLabel)
+		labels = append(labels, copyLabel)
+	}
+
+	return filter, labels
+}
+
+func generateFFmpegParamsForPlayoutMux(input common.PlayoutMuxInput, outputPath string) ([]string, error) {
+	const fallbackLanguage = "nor"
+
+	params := []string{
+		"-progress", "pipe:1",
+		"-hide_banner",
+	}
+	ffmpegInputCount := 0
+	addInput := func(path string) {
+		params = append(params, "-i", path)
+		ffmpegInputCount++
+	}
+	addInput(input.VideoFilePath)
+
+	audioFiles := lo.Reduce(languageFilesForPaths(input.AudioFilePaths), func(agg []inputFile, item languageFile, index int) []inputFile {
+		if item.Path == "" {
+			return agg
+		}
+		return append(agg, inputFile{
+			languageFile: item,
+			inputIndex:   -1,
+		})
+	}, []inputFile{})
+
+	_, fallbackLanguageFound := lo.Find(audioFiles, func(f inputFile) bool {
+		return f.Language == fallbackLanguage
+	})
+	if !fallbackLanguageFound {
+		return nil, fmt.Errorf("norwegian audio file not found")
+	}
+
+	trackMaps := [12]*trackMap{}
+	for i, lang := range playoutLanguages {
+		file, found := lo.Find(audioFiles, func(f inputFile) bool {
+			return f.Language == lang
+		})
+		copyFrom := ""
+		if !found {
+			copyFrom = "nor"
+		}
+		trackMaps[i] = &trackMap{
+			file:     file,
+			copyFrom: copyFrom,
+			stereo:   i < 4,
+		}
+	}
+
+	tracksWithInputFile := lo.Filter(trackMaps[:], func(f *trackMap, i int) bool {
+		return f.file.Path != ""
+	})
+
+	for _, f := range tracksWithInputFile {
+		f.file.inputIndex = ffmpegInputCount
+		addInput(f.file.Path)
+	}
+
+	leftStreams := map[string][]string{}
+	useLeftStream := func(lang string) string {
+		copy := leftStreams[lang][0]
+		leftStreams[lang] = leftStreams[lang][1:]
+		return copy
+	}
+	rightStreams := map[string][]string{}
+	useRightStream := func(lang string) string {
+		copy := rightStreams[lang][0]
+		rightStreams[lang] = rightStreams[lang][1:]
+		return copy
+	}
+
+	filterParts := []string{}
+	for _, track := range tracksWithInputFile {
+		input := fmt.Sprintf("%d:a", track.file.inputIndex)
+		outputL := fmt.Sprintf("%s_l", track.file.Language)
+		outputR := fmt.Sprintf("%s_r", track.file.Language)
+
+		leftStreamsNeeded := 1
+		rightStreamsNeeded := 0
+
+		if track.stereo {
+			filterParts = append(filterParts, createStereoFilter(input, outputL, outputR))
+			rightStreamsNeeded++
+		} else {
+			filterParts = append(filterParts, createMonoFilter(input, outputL))
+		}
+		for _, m := range trackMaps {
+			if m.copyFrom == track.file.Language {
+				leftStreamsNeeded++
+				if m.stereo {
+					rightStreamsNeeded++
+				}
+			}
+		}
+
+		if leftStreamsNeeded == 1 {
+			leftStreams[track.file.Language] = []string{outputL}
+		} else if leftStreamsNeeded > 1 {
+			filter, labels := generateAudioSplitFilter(outputL, leftStreamsNeeded)
+			filterParts = append(filterParts, filter)
+			leftStreams[track.file.Language] = labels
+		}
+
+		if rightStreamsNeeded == 1 {
+			rightStreams[track.file.Language] = []string{outputR}
+		} else if rightStreamsNeeded > 1 {
+			filter, labels := generateAudioSplitFilter(outputR, rightStreamsNeeded)
+			filterParts = append(filterParts, filter)
+			rightStreams[track.file.Language] = labels
+		}
+
+	}
+
+	params = append(params, "-filter_complex", strings.Join(filterParts, ";"))
+
+	// Video must be first in the map
+	params = append(params, "-map", "0:v")
+
+	for _, f := range trackMaps {
+		lang := f.file.Language
+		if f.copyFrom != "" {
+			lang = f.copyFrom
+		}
+		label := useLeftStream(lang)
+		params = append(params, "-map", fmt.Sprintf("[%s]", label))
+		if f.stereo {
+			label = useRightStream(lang)
+			params = append(params, "-map", fmt.Sprintf("[%s]", label))
+		}
+	}
+
+	params = append(params,
+		"-c:v", "copy",
+		"-c:a", "pcm_s24le",
+		"-y", outputPath,
+	)
+	return params, nil
+}
+
+func PlayoutMux(input common.PlayoutMuxInput, progressCallback ffmpeg.ProgressCallback) (*common.PlayoutMuxResult, error) {
+	outputPath := filepath.Join(input.DestinationPath, input.FileName+".mxf")
+
+	params, err := generateFFmpegParamsForPlayoutMux(input, outputPath)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := ffmpeg.GetStreamInfo(input.VideoFilePath)
+	if err != nil {
+		return nil, err
+	}
+	print(strings.Join(params, "\n"))
+	_, err = ffmpeg.Do(params, info, progressCallback)
+	if err != nil {
+		log.Default().Println("mux failed", err)
+		return nil, fmt.Errorf("mux failed, %s", strings.Join(params, " "))
+	}
+	err = os.Chmod(outputPath, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+	return &common.PlayoutMuxResult{
+		Path: outputPath,
+	}, nil
+}

--- a/services/transcode/playout_mux_test.go
+++ b/services/transcode/playout_mux_test.go
@@ -38,10 +38,11 @@ func Test_PlayoutMux(t *testing.T) {
 	printer, stop := printProgress()
 	defer close(stop)
 	_, err := PlayoutMux(common.PlayoutMuxInput{
-		FileName:        "BERG_TS01_ISRAEL_VOD",
-		StereoLanguages: []string{"nor", "eng", "fin"},
-		DestinationPath: "/Users/andreasgangso/dev/div/520a9155-2c8f-4560-868b-53be9c6e9b96/transcoded/",
-		VideoFilePath:   root + "BERG_TS01_ISRAEL_VOD.mxf",
+		FallbackLanguage: "nor",
+		FileName:         "BERG_TS01_ISRAEL_VOD",
+		StereoLanguages:  []string{"nor", "eng", "fin"},
+		DestinationPath:  "/Users/andreasgangso/dev/div/520a9155-2c8f-4560-868b-53be9c6e9b96/transcoded/",
+		VideoFilePath:    root + "BERG_TS01_ISRAEL_VOD.mxf",
 		SubtitleFilePaths: map[string]string{
 			"nor": root + "0.srt",
 			"nld": root + "1.srt",

--- a/services/transcode/playout_mux_test.go
+++ b/services/transcode/playout_mux_test.go
@@ -1,0 +1,57 @@
+package transcode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bcc-code/bccm-flows/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GenerateFFmpegParamsForPlayoutMux(t *testing.T) {
+	const golden = `-progress pipe:1 -hide_banner -i root/BERG_TS01_ISRAEL_VOD.mxf -i root/BERG_TS01_ISRAEL_VOD-nor.wav -i root/BERG_TS01_ISRAEL_VOD-eng.wav -i root/BERG_TS01_ISRAEL_VOD-fin.wav -filter_complex [1:a]aresample=48000,channelsplit=channel_layout=stereo[nor_l][nor_r];[nor_l]asplit=10[nor_l_copy_0][nor_l_copy_1][nor_l_copy_2][nor_l_copy_3][nor_l_copy_4][nor_l_copy_5][nor_l_copy_6][nor_l_copy_7][nor_l_copy_8][nor_l_copy_9];[nor_r]asplit=3[nor_r_copy_0][nor_r_copy_1][nor_r_copy_2];[2:a]aresample=48000,channelsplit=channel_layout=stereo[eng_l][eng_r];[3:a]aresample=48000[fin_l] -map 0:v -map [nor_l_copy_0] -map [nor_r_copy_0] -map [nor_l_copy_1] -map [nor_r_copy_1] -map [nor_l_copy_2] -map [nor_r_copy_2] -map [eng_l] -map [eng_r] -map [nor_l_copy_3] -map [nor_l_copy_4] -map [fin_l] -map [nor_l_copy_5] -map [nor_l_copy_6] -map [nor_l_copy_7] -map [nor_l_copy_8] -map [nor_l_copy_9] -c:v copy -c:a pcm_s24le -y something/something.mxf`
+
+	const root = "root/"
+	const outputPath = "something/something.mxf"
+	cmd, err := generateFFmpegParamsForPlayoutMux(common.PlayoutMuxInput{
+		FileName:        "BERG_TS01_ISRAEL_VOD",
+		StereoLanguages: []string{"nor", "eng", "fin"},
+		DestinationPath: "transcoded/",
+		VideoFilePath:   root + "BERG_TS01_ISRAEL_VOD.mxf",
+		SubtitleFilePaths: map[string]string{
+			"nor": root + "0.srt",
+			"nld": root + "1.srt",
+		},
+		AudioFilePaths: map[string]string{
+			"nor": root + "BERG_TS01_ISRAEL_VOD-nor.wav",
+			"eng": root + "BERG_TS01_ISRAEL_VOD-eng.wav",
+			"fin": root + "BERG_TS01_ISRAEL_VOD-fin.wav",
+		},
+	}, outputPath)
+
+	assert.Nil(t, err)
+	assert.Equal(t, strings.Join(cmd, " "), golden)
+}
+
+func Test_PlayoutMux(t *testing.T) {
+	root := "/Users/andreasgangso/dev/div/520a9155-2c8f-4560-868b-53be9c6e9b96/"
+	printer, stop := printProgress()
+	defer close(stop)
+	_, err := PlayoutMux(common.PlayoutMuxInput{
+		FileName:        "BERG_TS01_ISRAEL_VOD",
+		StereoLanguages: []string{"nor", "eng", "fin"},
+		DestinationPath: "/Users/andreasgangso/dev/div/520a9155-2c8f-4560-868b-53be9c6e9b96/transcoded/",
+		VideoFilePath:   root + "BERG_TS01_ISRAEL_VOD.mxf",
+		SubtitleFilePaths: map[string]string{
+			"nor": root + "0.srt",
+			"nld": root + "1.srt",
+		},
+		AudioFilePaths: map[string]string{
+			"nor": root + "BERG_TS01_ISRAEL_VOD-nor.wav",
+			"eng": root + "BERG_TS01_ISRAEL_VOD-eng.wav",
+			"fin": root + "BERG_TS01_ISRAEL_VOD-fin.wav",
+		},
+	}, printer)
+
+	assert.Nil(t, err)
+}

--- a/services/vidispine/vsapi/files_paths.go
+++ b/services/vidispine/vsapi/files_paths.go
@@ -21,8 +21,7 @@ func (c *Client) GetAbsoluteStoragePath(storageID string) (string, error) {
 	for _, m := range result.Result().(*StorageResult).Methods {
 		if strings.HasPrefix(m.URI, "file://") {
 			path := strings.TrimPrefix(m.URI, "file://")
-			path = strings.Replace(path, "/mnt/isilon", utils.GetIsilonPrefix(), 1)
-			return path, nil
+			return utils.IsilonPathFix(path), nil
 		}
 	}
 

--- a/utils/environment.go
+++ b/utils/environment.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"strings"
 
 	"github.com/bcc-code/bccm-flows/common"
 )
@@ -37,4 +38,8 @@ func GetIsilonPrefix() string {
 		return isilonPrefix
 	}
 	return "/mnt/isilon"
+}
+
+func IsilonPathFix(path string) string {
+	return strings.Replace(path, "/mnt/isilon", GetIsilonPrefix(), 1)
 }


### PR DESCRIPTION
To keep the PR small I'm submitting this one first.

**Discussion points**
- In the workflow that's coming, I am planning on sending the video through the "xdcam transcode" activity before passing it to this mux activity. I think that would be cleanest, but lmk if you think otherwise. Alternative is to do _everything_ in this one function...
- for subtitles I need to wait for Stian to send me some details.. but since it's not working today anyway I'm thinking to not include it in this sprint


ffprobe output on the transcoded file (ignore the prores)

```console
$ ffprobe transcoded/BERG_TS01_ISRAEL_VOD.mxf
ffprobe version 6.0 Copyright (c) 2007-2023 the FFmpeg developers
  built with Apple clang version 14.0.3 (clang-1403.0.22.14.1)
  configuration: --prefix=/opt/homebrew/Cellar/ffmpeg/6.0_1 --enable-shared --enable-pthreads --enable-version3 --cc=clang --host-cflags= --host-ldflags= --enable-ffplay --enable-gnutls --enable-gpl --enable-libaom --enable-libaribb24 --enable-libbluray --enable-libdav1d --enable-libjxl --enable-libmp3lame --enable-libopus --enable-librav1e --enable-librist --enable-librubberband --enable-libsnappy --enable-libsrt --enable-libsvtav1 --enable-libtesseract --enable-libtheora --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxml2 --enable-libxvid --enable-lzma --enable-libfontconfig --enable-libfreetype --enable-frei0r --enable-libass --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libspeex --enable-libsoxr --enable-libzmq --enable-libzimg --disable-libjack --disable-indev=jack --enable-videotoolbox --enable-audiotoolbox --enable-neon
  libavutil      58.  2.100 / 58.  2.100
  libavcodec     60.  3.100 / 60.  3.100
  libavformat    60.  3.100 / 60.  3.100
  libavdevice    60.  1.100 / 60.  1.100
  libavfilter     9.  3.100 /  9.  3.100
  libswscale      7.  1.100 /  7.  1.100
  libswresample   4. 10.100 /  4. 10.100
  libpostproc    57.  1.100 / 57.  1.100
[prores @ 0x12de05410] picture resolution change: 1920x1088 -> 1920x1080
Input #0, mxf, from 'transcoded/BERG_TS01_ISRAEL_VOD.mxf':
  Metadata:
    operational_pattern_ul: 060e2b34.04010101.0d010201.01010900
    uid             : adab4424-2f25-4dc7-92ff-000c00000000
    generation_uid  : adab4424-2f25-4dc7-92ff-000c00000001
    company_name    : FFmpeg
    product_name    : OP1a Muxer
    product_version_num: 60.3.100.0.0
    product_version : 60.3.100
    application_platform: Lavf (darwin)
    product_uid     : adab4424-2f25-4dc7-92ff-29bd000c0002
    toolkit_version_num: 60.3.100.0.0
    material_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E400
    timecode        : 00:00:00:00
  Duration: 00:01:19.88, start: 0.000000, bitrate: 253962 kb/s
  Stream #0:0: Video: prores (HQ) (apch / 0x68637061), yuv422p10le(tv, bt709, progressive), 1920x1080, SAR 1:1 DAR 16:9, 25 tbr, 25 tbn
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:1: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:2: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:3: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:4: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:5: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:6: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:7: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:8: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:9: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:10: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:11: Audio: pcm_s24le, 48000 Hz, 2 channels, s32 (24 bit), 2304 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:12: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:13: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:14: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:15: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
  Stream #0:16: Audio: pcm_s24le, 48000 Hz, 1 channels, s32 (24 bit), 1152 kb/s
    Metadata:
      file_package_umid: 0x060A2B340101010501010D0013E4AEFF5294713420E4AEFF005294713420E401
```