### PR TITLE
feat(normalize-audio): move the workflow to an activity

### DIFF
--- a/activities/queues.go
+++ b/activities/queues.go
@@ -18,6 +18,7 @@ func GetAudioTranscodeActivities() []any {
 		AnalyzeEBUR128Activity,
 		AdjustAudioLevelActivity,
 		AnalyzeFile,
+		NormalizeAudioActivity,
 	}
 }
 

--- a/workflows/export/vx_export_bmm.go
+++ b/workflows/export/vx_export_bmm.go
@@ -13,7 +13,6 @@ import (
 	"github.com/bcc-code/bccm-flows/common"
 	"github.com/bcc-code/bccm-flows/utils"
 	"github.com/bcc-code/bccm-flows/utils/wfutils"
-	"github.com/bcc-code/bccm-flows/workflows"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -41,22 +40,35 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 		return nil, fmt.Errorf("failed to get audio file keys: %w", err)
 	}
 
+	tempDir, err := wfutils.GetWorkflowTempFolder(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workflow temp folder: %w", err)
+	}
+
+	// We don't want to upload folders from other workflows that can be triggered at the same export.
+	outputFolder := path.Join(tempDir, "bmm")
+	err = wfutils.CreateFolder(ctx, outputFolder)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create output folder: %w", err)
+	}
+
 	// Normalize audio
 	for _, lang := range langs {
 		audio := params.MergeResult.AudioFiles[lang]
 		ctx = workflow.WithChildOptions(ctx, wfutils.GetDefaultWorkflowOptions())
-		future := workflow.ExecuteChildWorkflow(ctx, workflows.NormalizeAudioLevelWorkflow, workflows.NormalizeAudioParams{
+		future := wfutils.ExecuteWithQueue(ctx, activities.NormalizeAudioActivity, activities.NormalizeAudioParams{
 			FilePath:              audio,
 			TargetLUFS:            targetLufs,
 			PerformOutputAnalysis: true,
+			OutputPath:            outputFolder,
 		})
 		normalizedFutures[lang] = future
 	}
 
-	normalizedResults := map[string]workflows.NormalizeAudioResult{}
+	normalizedResults := map[string]activities.NormalizeAudioResult{}
 	for _, lang := range langs {
 		future := normalizedFutures[lang]
-		normalizedRes := workflows.NormalizeAudioResult{}
+		normalizedRes := activities.NormalizeAudioResult{}
 		err := future.Get(ctx, &normalizedRes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to normalize audio for language %s: %w", lang, err)
@@ -67,17 +79,12 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 		params.MergeResult.AudioFiles[lang] = normalizedRes.FilePath
 	}
 
-	outputFolder, err := wfutils.GetWorkflowTempFolder(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get workflow temp folder: %w", err)
-	}
-
 	// Encode to AAC and MP3
 
 	encodingFutures := map[string][]workflow.Future{}
 	for _, lang := range langs {
 		audio := normalizedResults[lang]
-		encodings := []workflow.Future{}
+		var encodings []workflow.Future
 		for _, bitrate := range aacBitrates {
 			f := wfutils.ExecuteWithQueue(ctx, activities.TranscodeToAudioAac, common.AudioInput{
 				Path:            audio.FilePath,
@@ -102,7 +109,7 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	audioResults := map[string][]common.AudioResult{}
 	for _, lang := range langs {
 		futures := encodingFutures[lang]
-		encodings := []common.AudioResult{}
+		var encodings []common.AudioResult
 		for _, future := range futures {
 			var res common.AudioResult
 			err := future.Get(ctx, &res)
@@ -190,7 +197,7 @@ type BMMAudioFile struct {
 	MimeType        string  `json:"mime_type"`
 }
 
-func prepareBMMData(audioFiles map[string][]common.AudioResult, analysis map[string]workflows.NormalizeAudioResult) BMMData {
+func prepareBMMData(audioFiles map[string][]common.AudioResult, analysis map[string]activities.NormalizeAudioResult) BMMData {
 	out := BMMData{
 		AudioFiles: map[string][]BMMAudioFile{},
 	}


### PR DESCRIPTION
Also fixes a part of the bmm export where everything is copied with Rclone, not just the audio files.