### PR TITLE
feat(bmmexport): Add SHA of title to the end of VX-ID

### DIFF
--- a/workflows/export/vx_export_bmm.go
+++ b/workflows/export/vx_export_bmm.go
@@ -1,6 +1,7 @@
 package export
 
 import (
+	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -126,8 +127,7 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	jsonData.Length = int(params.MergeResult.Duration)
 	jsonData.MediabankenID = params.ParentParams.VXID
 
-	// TODO: Title is messy, we should have "Human readable" variant
-	jsonData.Title = params.ExportData.Title
+	jsonData.Title = fmt.Sprintf("%s-%s", params.ExportData.Title, HashTitle(params.ExportData.Title))
 
 	marshalled, err := json.Marshal(jsonData)
 	if err != nil {
@@ -233,4 +233,9 @@ func prepareBMMData(audioFiles map[string][]common.AudioResult, analysis map[str
 
 	return out
 
+}
+
+func HashTitle(title string) string {
+	hash := sha1.Sum([]byte(title))
+	return fmt.Sprintf("%x", hash)[0:8]
 }

--- a/workflows/export/vx_export_bmm.go
+++ b/workflows/export/vx_export_bmm.go
@@ -125,9 +125,9 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	// Prepare data for the JSON file
 	jsonData := prepareBMMData(audioResults, normalizedResults)
 	jsonData.Length = int(params.MergeResult.Duration)
-	jsonData.MediabankenID = params.ParentParams.VXID
+	jsonData.MediabankenID = fmt.Sprintf("%s-%s", params.ParentParams.VXID, HashTitle(params.ExportData.Title))
 
-	jsonData.Title = fmt.Sprintf("%s-%s", params.ExportData.Title, HashTitle(params.ExportData.Title))
+	jsonData.Title = params.ExportData.Title
 
 	marshalled, err := json.Marshal(jsonData)
 	if err != nil {


### PR DESCRIPTION
BMM "thinks" that all files that have the same VX-ID are the same file so it updates the files. This prevents subclips from working