### PR TITLE
fix(audio-norm): Fix crash on -inf for silent audio files

### DIFF
--- a/activities/normalize.go
+++ b/activities/normalize.go
@@ -2,6 +2,8 @@ package activities
 
 import (
 	"context"
+	"math"
+
 	"github.com/bcc-code/bccm-flows/common"
 	"github.com/bcc-code/bccm-flows/paths"
 	"github.com/bcc-code/bccm-flows/services/ffmpeg"
@@ -42,6 +44,11 @@ func AnalyzeEBUR128Activity(ctx context.Context, input AnalyzeEBUR128Params) (*c
 
 	if analyzeResult.TruePeak+out.SuggestedAdjustment > -0.9 {
 		out.SuggestedAdjustment = -0.9 - analyzeResult.TruePeak
+	}
+
+	// Don't suggest adjustments below .5 dB
+	if math.Abs(out.SuggestedAdjustment) < 0.5 {
+		out.SuggestedAdjustment = 0.0
 	}
 
 	return out, nil

--- a/activities/normalize.go
+++ b/activities/normalize.go
@@ -46,8 +46,8 @@ func AnalyzeEBUR128Activity(ctx context.Context, input AnalyzeEBUR128Params) (*c
 		out.SuggestedAdjustment = -0.9 - analyzeResult.TruePeak
 	}
 
-	// Don't suggest adjustments below .5 dB
-	if math.Abs(out.SuggestedAdjustment) < 0.5 {
+	// Don't suggest adjustments below .5 dB, or for peaks below -69 dBTP
+	if math.Abs(out.SuggestedAdjustment) < 0.5 || out.TruePeak <= -69 {
 		out.SuggestedAdjustment = 0.0
 	}
 

--- a/utils/execute_command.go
+++ b/utils/execute_command.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 // ExecuteCmd executes the cmd and returns through outputCallback line-by-line before returning the whole stdout at the end.
@@ -85,6 +86,12 @@ func ExecuteAnalysisCmd(cmd *exec.Cmd, outputCallback func(string)) (string, err
 		}
 
 	}
+
+	// replace -Inf with -99 if the audio was silent
+	result = strings.ReplaceAll(result, "\"-inf\"", "-99")
+
+	// replace inf with 0 target_offset if the audio was silent
+	result = strings.ReplaceAll(result, "\"inf\"", "0")
 
 	err = cmd.Wait()
 	if err != nil {


### PR DESCRIPTION
Also do not suggest or perform adjustments for small values or silent files

Example output that was problematic:

```json
{
	"input_i" : "-inf",
	"input_tp" : "-inf",
	"input_lra" : "0.00",
	"input_thresh" : "-70.00",
	"output_i" : "-inf",
	"output_tp" : "-inf",
	"output_lra" : "0.00",
	"output_thresh" : "-70.00",
	"normalization_type" : "dynamic",
	"target_offset" : "inf"
}
```