### PR TITLE
feat: create multitrack order form

### DIFF
--- a/activities/files.go
+++ b/activities/files.go
@@ -177,7 +177,7 @@ func ReadFile(ctx context.Context, input FileInput) ([]byte, error) {
 	return os.ReadFile(input.Path.Local())
 }
 
-func ListFiles(ctx context.Context, input FileInput) ([]paths.Path, error) {
+func ListFiles(ctx context.Context, input FileInput) (paths.Files, error) {
 	log := activity.GetLogger(ctx)
 	activity.RecordHeartbeat(ctx, "ListFiles")
 	log.Info("Starting ListFilesActivity")

--- a/activities/queues.go
+++ b/activities/queues.go
@@ -21,6 +21,7 @@ func GetAudioTranscodeActivities() []any {
 		AdjustAudioLevelActivity,
 		AnalyzeFile,
 		NormalizeAudioActivity,
+		AudioSplitFile,
 	}
 }
 
@@ -37,6 +38,7 @@ func GetVideoTranscodeActivities() []any {
 		TranscodePlayoutMux,
 		TranscodeMuxToSimpleMXF,
 		ExecuteFFmpeg,
+		MultitrackMux,
 	}
 }
 

--- a/activities/queues.go
+++ b/activities/queues.go
@@ -21,7 +21,7 @@ func GetAudioTranscodeActivities() []any {
 		AdjustAudioLevelActivity,
 		AnalyzeFile,
 		NormalizeAudioActivity,
-		AudioSplitFile,
+		SplitAudioChannels,
 	}
 }
 

--- a/activities/transcode.go
+++ b/activities/transcode.go
@@ -263,3 +263,44 @@ func ExecuteFFmpeg(ctx context.Context, input ExecuteFFmpegInput) error {
 	}
 	return nil
 }
+
+func AudioSplitFiles(ctx context.Context, input transcode.AudioSplitFileInput) (paths.Files, error) {
+	log := activity.GetLogger(ctx)
+	activity.RecordHeartbeat(ctx, "AudioSplitFiles")
+	log.Info("Starting AudioSplitFiles")
+
+	stopChan, progressCallback := registerProgressCallback(ctx)
+	defer close(stopChan)
+
+	result, err := transcode.AudioSplitFile(input, progressCallback)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+type MultitrackMuxInput struct {
+	Files     paths.Files
+	OutputDir paths.Path
+}
+
+type MultitrackMuxResult struct {
+	OutputPath paths.Path
+}
+
+func MultitrackMux(ctx context.Context, input MultitrackMuxInput) (*MultitrackMuxResult, error) {
+	log := activity.GetLogger(ctx)
+	activity.RecordHeartbeat(ctx, "MultitrackMux")
+	log.Info("Starting MultitrackMux")
+
+	stopChan, progressCallback := registerProgressCallback(ctx)
+	defer close(stopChan)
+
+	result, err := transcode.MultitrackMux(input.Files, input.OutputDir, progressCallback)
+	if err != nil {
+		return nil, err
+	}
+	return &MultitrackMuxResult{
+		OutputPath: *result,
+	}, nil
+}

--- a/activities/transcode.go
+++ b/activities/transcode.go
@@ -264,15 +264,15 @@ func ExecuteFFmpeg(ctx context.Context, input ExecuteFFmpegInput) error {
 	return nil
 }
 
-type AudioSplitFileInput struct {
+type SplitAudioChannelsInput struct {
 	FilePath  paths.Path
 	OutputDir paths.Path
 }
 
-func AudioSplitFile(ctx context.Context, input AudioSplitFileInput) (paths.Files, error) {
+func SplitAudioChannels(ctx context.Context, input SplitAudioChannelsInput) (paths.Files, error) {
 	log := activity.GetLogger(ctx)
-	activity.RecordHeartbeat(ctx, "AudioSplitFile")
-	log.Info("Starting AudioSplitFile")
+	activity.RecordHeartbeat(ctx, "SplitAudioChannels")
+	log.Info("Starting SplitAudioChannels")
 
 	stopChan, progressCallback := registerProgressCallback(ctx)
 	defer close(stopChan)

--- a/activities/transcode.go
+++ b/activities/transcode.go
@@ -264,15 +264,20 @@ func ExecuteFFmpeg(ctx context.Context, input ExecuteFFmpegInput) error {
 	return nil
 }
 
-func AudioSplitFiles(ctx context.Context, input transcode.AudioSplitFileInput) (paths.Files, error) {
+type AudioSplitFileInput struct {
+	FilePath  paths.Path
+	OutputDir paths.Path
+}
+
+func AudioSplitFile(ctx context.Context, input AudioSplitFileInput) (paths.Files, error) {
 	log := activity.GetLogger(ctx)
-	activity.RecordHeartbeat(ctx, "AudioSplitFiles")
-	log.Info("Starting AudioSplitFiles")
+	activity.RecordHeartbeat(ctx, "AudioSplitFile")
+	log.Info("Starting AudioSplitFile")
 
 	stopChan, progressCallback := registerProgressCallback(ctx)
 	defer close(stopChan)
 
-	result, err := transcode.AudioSplitFile(input, progressCallback)
+	result, err := transcode.AudioSplitFile(input.FilePath, input.OutputDir, progressCallback)
 	if err != nil {
 		return nil, err
 	}

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -194,3 +194,17 @@ func New(drive Drive, path string) Path {
 		Path:  path,
 	}
 }
+
+type Files []Path
+
+func (f Files) Len() int {
+	return len(f)
+}
+
+func (f Files) Less(i, j int) bool {
+	return f[i].Drive.Value < f[j].Drive.Value || f[i].Path < f[j].Path
+}
+
+func (f Files) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}

--- a/services/transcode/audio.go
+++ b/services/transcode/audio.go
@@ -180,23 +180,14 @@ func AudioMP3(input common.AudioInput, cb ffmpeg.ProgressCallback) (*common.Audi
 	}, nil
 }
 
-type AudioSplitFileInput struct {
-	FilePath  paths.Path
-	OutputDir paths.Path
-}
-
-type AudioSplitFileResult struct {
-	Files paths.Files
-}
-
-func AudioSplitFile(input AudioSplitFileInput, cb ffmpeg.ProgressCallback) (paths.Files, error) {
-	info, err := ffmpeg.ProbeFile(input.FilePath.Local())
+func AudioSplitFile(filePath, outputDir paths.Path, cb ffmpeg.ProgressCallback) (paths.Files, error) {
+	info, err := ffmpeg.ProbeFile(filePath.Local())
 	if err != nil {
 		return nil, err
 	}
 
 	params := []string{
-		"-i", input.FilePath.Local(),
+		"-i", filePath.Local(),
 	}
 
 	var filter string
@@ -217,9 +208,9 @@ func AudioSplitFile(input AudioSplitFileInput, cb ffmpeg.ProgressCallback) (path
 	params = append(params, "-filter_complex", filter)
 
 	for i := 0; i < channels; i++ {
-		base := input.FilePath.Base()
+		base := filePath.Base()
 		fileName := fmt.Sprintf("%s-%d.wav", base[:len(base)-len(filepath.Ext(base))], i)
-		file := input.OutputDir.Append(fileName)
+		file := outputDir.Append(fileName)
 		files = append(files, file)
 		params = append(params,
 			"-map", fmt.Sprintf("[a%d]", i),

--- a/services/transcode/audio_test.go
+++ b/services/transcode/audio_test.go
@@ -21,10 +21,7 @@ func Test_Audio(t *testing.T) {
 }
 
 func Test_AudioSplit(t *testing.T) {
-	files, err := AudioSplitFile(AudioSplitFileInput{
-		OutputDir: paths.MustParse("/tmp/"),
-		FilePath:  paths.MustParse("/tmp/AS23_20231202_2000_PGM_MU1_Joy_to_the_world-eng_normalized-256k.mp3"),
-	}, nil)
+	files, err := AudioSplitFile(paths.MustParse("/tmp/AS23_20231202_2000_PGM_MU1_Joy_to_the_world-eng_normalized-256k.mp3"), paths.MustParse("/tmp/"), nil)
 
 	assert.Nil(t, err)
 

--- a/services/transcode/audio_test.go
+++ b/services/transcode/audio_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bcc-code/bccm-flows/common"
 	"github.com/bcc-code/bccm-flows/paths"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,4 +18,15 @@ func Test_Audio(t *testing.T) {
 		Bitrate:         "128k",
 	}, p)
 	assert.Nil(t, err)
+}
+
+func Test_AudioSplit(t *testing.T) {
+	files, err := AudioSplitFile(AudioSplitFileInput{
+		OutputDir: paths.MustParse("/tmp/"),
+		FilePath:  paths.MustParse("/tmp/AS23_20231202_2000_PGM_MU1_Joy_to_the_world-eng_normalized-256k.mp3"),
+	}, nil)
+
+	assert.Nil(t, err)
+
+	spew.Dump(files)
 }

--- a/services/transcode/multitrack.go
+++ b/services/transcode/multitrack.go
@@ -1,0 +1,54 @@
+package transcode
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bcc-code/bccm-flows/paths"
+	"github.com/bcc-code/bccm-flows/services/ffmpeg"
+)
+
+func MultitrackMux(files paths.Files, outputPath paths.Path, cb ffmpeg.ProgressCallback) (*paths.Path, error) {
+	lines := []string{
+		"Multitrack VB",
+		"",
+	}
+
+	for _, f := range files {
+		lines = append(lines, f.Base())
+	}
+
+	text := strings.Join(lines, "\n")
+
+	blankFile := paths.Path{
+		Drive: paths.IsilonDrive,
+		Path:  "system/assets/BlankVideo10h.mxf",
+	}
+
+	info, err := ffmpeg.GetStreamInfo(files[0].Local())
+	if err != nil {
+		return nil, err
+	}
+
+	params := []string{
+		"-i", blankFile.Local(),
+		"-t", fmt.Sprintf("%f", info.TotalSeconds),
+		"-vf", fmt.Sprintf("scale=960:540:force_original_aspect_ratio=decrease,pad=960:540:(ow-iw)/2:(oh-ih)/2,drawtext=text=%s:fontsize=36:fontcolor=white:x=100:y=100", text),
+		"-c:v", "libx264",
+		"-c:a", "copy",
+	}
+
+	for _, f := range files {
+		params = append(params, "-i", f.Local())
+	}
+
+	params = append(params,
+		outputPath.Local(),
+	)
+
+	_, err = ffmpeg.Do(params, ffmpeg.StreamInfo{}, cb)
+	if err != nil {
+		return nil, err
+	}
+	return &outputPath, nil
+}

--- a/services/transcode/multitrack_test.go
+++ b/services/transcode/multitrack_test.go
@@ -1,0 +1,17 @@
+package transcode
+
+import (
+	"testing"
+
+	"github.com/bcc-code/bccm-flows/paths"
+)
+
+func Test_MultitrackMux(t *testing.T) {
+	files := []paths.Path{
+		paths.MustParse("/mnt/temp/test1.wav"),
+		paths.MustParse("/mnt/temp/test2.wav"),
+		paths.MustParse("/mnt/temp/test3.wav"),
+	}
+
+	_, _ = MultitrackMux(files, files[0].Dir().Append("test_out2.mp4"), nil)
+}

--- a/utils/workflows/files.go
+++ b/utils/workflows/files.go
@@ -62,7 +62,7 @@ func ReadFile(ctx workflow.Context, file paths.Path) ([]byte, error) {
 	return res, err
 }
 
-func ListFiles(ctx workflow.Context, path paths.Path) ([]paths.Path, error) {
+func ListFiles(ctx workflow.Context, path paths.Path) (paths.Files, error) {
 	var res []paths.Path
 	err := workflow.ExecuteActivity(ctx, activities.ListFiles, activities.FileInput{
 		Path: path,

--- a/workflows/ingest/asset_ingest.go
+++ b/workflows/ingest/asset_ingest.go
@@ -24,6 +24,7 @@ var (
 	OrderFormOtherMaster  = OrderForm{Value: "Other_Masters"} // TODO: set correct value
 	OrderFormLEDMaterial  = OrderForm{Value: "LED-Material"}
 	OrderFormPodcast      = OrderForm{Value: "Podcast"}
+	OrderFormMultitrackPB = OrderForm{Value: "MultitrackPB"}
 	OrderForms            = enum.New(
 		OrderFormRawMaterial,
 		//OrderFormVBMaster, // commented out for supporting only raw material
@@ -105,6 +106,19 @@ func Asset(ctx workflow.Context, params AssetParams) (*AssetResult, error) {
 			return nil, err
 		}
 		err = workflow.ExecuteChildWorkflow(ctx, Masters, MasterParams{
+			Targets:   targets,
+			Metadata:  metadata,
+			OrderForm: *orderForm,
+			Directory: fcOutputDir,
+			OutputDir: outputDir,
+		}).Get(ctx, nil)
+	case OrderFormMultitrackPB:
+		var outputDir paths.Path
+		outputDir, err = wfutils.GetWorkflowRawOutputFolder(ctx)
+		if err != nil {
+			return nil, err
+		}
+		err = workflow.ExecuteChildWorkflow(ctx, Multitrack, MasterParams{
 			Targets:   targets,
 			Metadata:  metadata,
 			OrderForm: *orderForm,

--- a/workflows/ingest/masters.go
+++ b/workflows/ingest/masters.go
@@ -68,7 +68,6 @@ func Masters(ctx workflow.Context, params MasterParams) (*MasterResult, error) {
 			if err != nil {
 				return nil, err
 			}
-
 		}
 	}
 

--- a/workflows/ingest/multitrack.go
+++ b/workflows/ingest/multitrack.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bcc-code/bccm-flows/activities"
 	"github.com/bcc-code/bccm-flows/paths"
-	"github.com/bcc-code/bccm-flows/services/transcode"
 	wfutils "github.com/bcc-code/bccm-flows/utils/workflows"
 	"github.com/samber/lo"
 	"go.temporal.io/sdk/workflow"
@@ -54,7 +53,7 @@ func Multitrack(ctx workflow.Context, params MasterParams) (*MasterResult, error
 	var channels paths.Files
 	for _, f := range files {
 		var parts paths.Files
-		err = wfutils.ExecuteWithQueue(ctx, activities.AudioSplitFiles, transcode.AudioSplitFileInput{
+		err = wfutils.ExecuteWithQueue(ctx, activities.AudioSplitFile, activities.AudioSplitFileInput{
 			FilePath:  f,
 			OutputDir: tempDir,
 		}).Get(ctx, &parts)

--- a/workflows/ingest/multitrack.go
+++ b/workflows/ingest/multitrack.go
@@ -1,0 +1,153 @@
+package ingestworkflows
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/bcc-code/bccm-flows/activities"
+	"github.com/bcc-code/bccm-flows/paths"
+	"github.com/bcc-code/bccm-flows/services/transcode"
+	wfutils "github.com/bcc-code/bccm-flows/utils/workflows"
+	"github.com/samber/lo"
+	"go.temporal.io/sdk/workflow"
+)
+
+type channelSource struct {
+	Order   int
+	Channel int
+	Path    paths.Path
+}
+
+type channelSources []channelSource
+
+func (s channelSources) Len() int {
+	return len(s)
+}
+
+func (s channelSources) Less(i, j int) bool {
+	return s[i].Order < s[j].Order
+}
+
+func (s channelSources) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func Multitrack(ctx workflow.Context, params MasterParams) (*MasterResult, error) {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("Starting Multitrack workflow")
+
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
+
+	tempDir, err := wfutils.GetWorkflowTempFolder(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	files, err := wfutils.ListFiles(ctx, params.Directory)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Sort(files)
+
+	var channels paths.Files
+	for _, f := range files {
+		var parts paths.Files
+		err = wfutils.ExecuteWithQueue(ctx, activities.AudioSplitFiles, transcode.AudioSplitFileInput{
+			FilePath:  f,
+			OutputDir: tempDir,
+		}).Get(ctx, &parts)
+		if err != nil {
+			return nil, err
+		}
+		channels = append(channels, parts...)
+	}
+
+	// make sure the files are sorted
+	sort.Sort(channels)
+
+	var muxResult activities.MultitrackMuxResult
+	err = wfutils.ExecuteWithQueue(ctx, activities.MultitrackMux, activities.MultitrackMuxInput{
+		Files:     channels,
+		OutputDir: params.OutputDir,
+	}).Get(ctx, &muxResult)
+	if err != nil {
+		return nil, err
+	}
+
+	base := files[0].Base()
+	fileName := base[:len(base)-len(muxResult.OutputPath.Ext())]
+
+	result, err := importFileAsTag(ctx, "original", muxResult.OutputPath, fileName)
+	if err != nil {
+		return nil, err
+	}
+
+	err = addMetaTags(ctx, result.AssetID, params.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	err = wfutils.WaitForVidispineJob(ctx, result.ImportJobID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = notifyImportCompleted(ctx, params.Targets, params.Metadata.JobProperty.JobID, map[string]paths.Path{
+		result.AssetID: muxResult.OutputPath,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func filesToChannelSources(files []paths.Path) (channelSources, error) {
+	var sources channelSources
+	for _, f := range files {
+		r, err := getChannelSourcesFromFile(f)
+		if err != nil {
+			return nil, err
+		}
+		sources = append(sources, r...)
+	}
+
+	sort.Sort(sources)
+	return sources, nil
+}
+
+func getChannelSourcesFromFile(file paths.Path) ([]channelSource, error) {
+	base := file.Base()
+	name := base[:len(base)-len(file.Ext())]
+	parts := strings.Split(name, "_")
+	last, _ := lo.Last(parts)
+	if last == "" {
+		return nil, nil
+	}
+
+	channel1, err := strconv.Atoi(string(last[0]))
+	if err != nil {
+		return nil, err
+	}
+	sources := []channelSource{
+		{
+			Order:   channel1,
+			Channel: 0,
+			Path:    file,
+		},
+	}
+	if len(last) == 1 {
+		return sources, nil
+	}
+	channel2, err := strconv.Atoi(string(last[1]))
+	if err != nil {
+		return nil, err
+	}
+	return append(sources, channelSource{
+		Order:   channel2,
+		Channel: 1,
+		Path:    file,
+	}), nil
+}

--- a/workflows/ingest/multitrack.go
+++ b/workflows/ingest/multitrack.go
@@ -2,13 +2,10 @@ package ingestworkflows
 
 import (
 	"sort"
-	"strconv"
-	"strings"
 
 	"github.com/bcc-code/bccm-flows/activities"
 	"github.com/bcc-code/bccm-flows/paths"
 	wfutils "github.com/bcc-code/bccm-flows/utils/workflows"
-	"github.com/samber/lo"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -101,52 +98,4 @@ func Multitrack(ctx workflow.Context, params MasterParams) (*MasterResult, error
 	}
 
 	return nil, nil
-}
-
-func filesToChannelSources(files []paths.Path) (channelSources, error) {
-	var sources channelSources
-	for _, f := range files {
-		r, err := getChannelSourcesFromFile(f)
-		if err != nil {
-			return nil, err
-		}
-		sources = append(sources, r...)
-	}
-
-	sort.Sort(sources)
-	return sources, nil
-}
-
-func getChannelSourcesFromFile(file paths.Path) ([]channelSource, error) {
-	base := file.Base()
-	name := base[:len(base)-len(file.Ext())]
-	parts := strings.Split(name, "_")
-	last, _ := lo.Last(parts)
-	if last == "" {
-		return nil, nil
-	}
-
-	channel1, err := strconv.Atoi(string(last[0]))
-	if err != nil {
-		return nil, err
-	}
-	sources := []channelSource{
-		{
-			Order:   channel1,
-			Channel: 0,
-			Path:    file,
-		},
-	}
-	if len(last) == 1 {
-		return sources, nil
-	}
-	channel2, err := strconv.Atoi(string(last[1]))
-	if err != nil {
-		return nil, err
-	}
-	return append(sources, channelSource{
-		Order:   channel2,
-		Channel: 1,
-		Path:    file,
-	}), nil
 }

--- a/workflows/ingest/multitrack.go
+++ b/workflows/ingest/multitrack.go
@@ -50,7 +50,7 @@ func Multitrack(ctx workflow.Context, params MasterParams) (*MasterResult, error
 	var channels paths.Files
 	for _, f := range files {
 		var parts paths.Files
-		err = wfutils.ExecuteWithQueue(ctx, activities.AudioSplitFile, activities.AudioSplitFileInput{
+		err = wfutils.ExecuteWithQueue(ctx, activities.SplitAudioChannels, activities.SplitAudioChannelsInput{
 			FilePath:  f,
 			OutputDir: tempDir,
 		}).Get(ctx, &parts)


### PR DESCRIPTION
Handles the multitrack delivery track.

Instead of hardcoding filenames, this just appends the channels from each file after each other, sorted alphabetically.

Not sure if its a good idea, but it's definitely more flexible.