### PR TITLE
Feature/multitrack from brunstad

### DIFF
--- a/cmd/httpin/watchers.go
+++ b/cmd/httpin/watchers.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/bcc-code/bccm-flows/environment"
@@ -41,7 +42,9 @@ func watchersHandler(ctx *gin.Context) {
 		return
 	}
 
-	multitrackPath, err := filepath.Match("/mnt/isilon/system/multitrack/Ingest/tempFraBrunstad/*", result.Path)
+	// This needs to match any subfolder
+	multitrackPath := strings.HasPrefix(result.Path, "/mnt/isilon/system/multitrack/Ingest/tempFraBrunstad/")
+
 	if err != nil {
 		fmt.Println(err.Error())
 		ctx.String(500, err.Error())

--- a/cmd/httpin/watchers.go
+++ b/cmd/httpin/watchers.go
@@ -71,7 +71,16 @@ func doMultitrackCopy(ctx context.Context, path string) error {
 		return err
 	}
 
-	return nil
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        uuid.NewString(),
+		TaskQueue: environment.GetWorkerQueue(),
+	}
+
+	_, err = c.ExecuteWorkflow(ctx, workflowOptions, workflows.HandleMultitrackFile, workflows.HandleMultitrackFileInput{
+		Path: path,
+	})
+
+	return err
 }
 
 var exp = regexp.MustCompile(fmt.Sprintf("(?:%s/)(?P<encoding>[\\w-]*)(?:/in/)", TranscodeRootPath))

--- a/paths/paths_test.go
+++ b/paths/paths_test.go
@@ -1,8 +1,10 @@
 package paths
 
 import (
-	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_GetSiblingFolder(t *testing.T) {
@@ -27,4 +29,26 @@ func Test_ParsePath(t *testing.T) {
 	assert.Equal(t, "test.xml", path.Path)
 
 	assert.Equal(t, "isilon:isilon/test.xml", path.Rclone())
+}
+
+func Test_Lucid(t *testing.T) {
+	pathString := "/mnt/isilon/system/multitrack/Ingest/tempFraBrunstad/Felles/Opptak1/lkajhdwid-323.wav"
+
+	path, err := Parse(pathString)
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, IsilonDrive, path.Drive)
+	assert.Equal(t, "system/multitrack/Ingest/tempFraBrunstad/Felles/Opptak1/lkajhdwid-323.wav", path.Path)
+
+	assert.Equal(t, "isilon:isilon/system/multitrack/Ingest/tempFraBrunstad/Felles/Opptak1/lkajhdwid-323.wav", path.Rclone())
+
+	lucidPath := Path{
+		Drive: LucidLinkDrive,
+		Path:  strings.Replace(path.Dir().Path, "system/multitrack/Ingest/tempFraBrunstad", "", 1),
+	}
+
+	lucidPath = lucidPath.Append(path.Base()).Prepend("/tesing/test/test")
+
+	assert.Equal(t, "lucid:lucidlink/tesing/test/test/Felles/Opptak1/lkajhdwid-323.wav", lucidPath.Rclone())
 }

--- a/workflows/handle_multitrack.go
+++ b/workflows/handle_multitrack.go
@@ -14,8 +14,7 @@ import (
 )
 
 type HandleMultitrackFileInput struct {
-	Path       string
-	FolderName string
+	Path string
 }
 
 func HandleMultitrackFile(

--- a/workflows/handle_multitrack.go
+++ b/workflows/handle_multitrack.go
@@ -1,0 +1,77 @@
+package workflows
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/bcc-code/bccm-flows/activities"
+	"github.com/bcc-code/bccm-flows/environment"
+	"github.com/bcc-code/bccm-flows/paths"
+	wfutils "github.com/bcc-code/bccm-flows/utils/workflows"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+type HandleMultitrackFileInput struct {
+	Path       string
+	FolderName string
+}
+
+func HandleMultitrackFile(
+	ctx workflow.Context,
+	params HandleMultitrackFileInput,
+) error {
+	logger := workflow.GetLogger(ctx)
+	options := workflow.ActivityOptions{
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval: time.Minute * 1,
+			MaximumAttempts: 1,
+			MaximumInterval: time.Hour * 1,
+		},
+		StartToCloseTimeout:    time.Hour * 4,
+		ScheduleToCloseTimeout: time.Hour * 48,
+		HeartbeatTimeout:       time.Minute * 1,
+		TaskQueue:              environment.GetWorkerQueue(),
+	}
+
+	ctx = workflow.WithActivityOptions(ctx, options)
+	logger.Info("Starting HandleMultitrackFile workflow")
+
+	path, err := paths.Parse(params.Path)
+	if err != nil {
+		return err
+	}
+
+	path, err = wfutils.StandardizeFileName(ctx, path)
+	if err != nil {
+		return err
+	}
+
+	lucidPath := paths.Path{
+		Drive: paths.LucidLinkDrive,
+		Path:  strings.Replace(path.Dir().Path, "system/multitrack/Ingest/tempFraBrunstad", "", 1),
+	}
+
+	lucidPath = lucidPath.Append(path.Base()).Prepend("01 Liveopptak fra Brunstad/01 RAW")
+
+	err = workflow.ExecuteActivity(ctx, activities.CopyFile, activities.MoveFileInput{
+		Source:      path,
+		Destination: lucidPath,
+	}).Get(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	isilonArchivePath := paths.Path{
+		Drive: paths.IsilonDrive,
+		Path:  strings.Replace(path.Dir().Path, "system/multitrack/Ingest/tempFraBrunstad", "", 1),
+	}.Prepend(fmt.Sprintf("AudioArchive/%d/%d", time.Now().Year(), time.Now().Month())).Append(path.Base())
+
+	err = workflow.ExecuteActivity(ctx, activities.MoveFile, activities.MoveFileInput{
+		Source:      path,
+		Destination: isilonArchivePath,
+	}).Get(ctx, nil)
+
+	return err
+}


### PR DESCRIPTION
I have already added `lucid` but have not tested the flow.

The goal is to watch for files in `/mnt/isilon/system/multitrack/Ingest/tempFraBrunstad/` and first copy them to LucidLink and then move them to `/mnt/isilon/AudioArchive/` preserving the folder structure.

The prepend stuff is probably not needed, seemed more clear at the start but I'm not so sure now.