### PR TITLE
feat: queue based retry policies.

### DIFF
--- a/utils/workflows/common.go
+++ b/utils/workflows/common.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bcc-code/bcc-media-flows/environment"
 
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -16,21 +15,9 @@ type ResultOrError[T any] struct {
 
 func GetDefaultActivityOptions() workflow.ActivityOptions {
 	return workflow.ActivityOptions{
-		RetryPolicy: &temporal.RetryPolicy{
-			InitialInterval: time.Minute * 1,
-			MaximumAttempts: 10,
-			MaximumInterval: time.Hour * 1,
-		},
 		StartToCloseTimeout:    time.Hour * 4,
 		ScheduleToCloseTimeout: time.Hour * 48,
 		HeartbeatTimeout:       time.Minute * 1,
-		TaskQueue:              environment.GetWorkerQueue(),
-	}
-}
-
-func GetDefaultWorkflowOptions() workflow.ChildWorkflowOptions {
-	return workflow.ChildWorkflowOptions{
-		TaskQueue: environment.GetWorkerQueue(),
 	}
 }
 

--- a/utils/workflows/event.go
+++ b/utils/workflows/event.go
@@ -21,5 +21,5 @@ func PublishEvent[T any](ctx workflow.Context, eventName string, data T) error {
 		return err
 	}
 
-	return workflow.ExecuteActivity(ctx, activities.PubsubPublish, event).Get(ctx, nil)
+	return ExecuteWithQueue(ctx, activities.PubsubPublish, event).Get(ctx, nil)
 }

--- a/utils/workflows/execute.go
+++ b/utils/workflows/execute.go
@@ -1,7 +1,11 @@
 package wfutils
 
 import (
+	"time"
+
 	"github.com/bcc-code/bcc-media-flows/activities"
+	"github.com/bcc-code/bcc-media-flows/environment"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -9,6 +13,27 @@ import (
 func ExecuteWithQueue(ctx workflow.Context, activity any, params ...any) workflow.Future {
 	options := workflow.GetActivityOptions(ctx)
 	options.TaskQueue = activities.GetQueueForActivity(activity)
+
+	switch options.TaskQueue {
+	case environment.GetWorkerQueue():
+		if options.RetryPolicy == nil {
+			options.RetryPolicy = &temporal.RetryPolicy{
+				MaximumAttempts: 10,
+				InitialInterval: 30 * time.Second,
+				MaximumInterval: 60 * time.Minute,
+			}
+		}
+	// usual reason for this failing is invalid files or tweaks to ffmpeg commands
+	case environment.GetTranscodeQueue(), environment.GetAudioQueue():
+		if options.RetryPolicy == nil {
+			options.RetryPolicy = &temporal.RetryPolicy{
+				MaximumAttempts: 5,
+				InitialInterval: 30 * time.Second,
+				MaximumInterval: 30 * time.Second,
+			}
+		}
+	}
+
 	ctx = workflow.WithActivityOptions(ctx, options)
 	return workflow.ExecuteActivity(ctx, activity, params...)
 }

--- a/utils/workflows/files.go
+++ b/utils/workflows/files.go
@@ -14,28 +14,28 @@ import (
 )
 
 func CreateFolder(ctx workflow.Context, destination paths.Path) error {
-	return workflow.ExecuteActivity(ctx, activities.CreateFolder, activities.CreateFolderInput{
+	return ExecuteWithQueue(ctx, activities.CreateFolder, activities.CreateFolderInput{
 		Destination: destination,
 	}).Get(ctx, nil)
 }
 
 func StandardizeFileName(ctx workflow.Context, file paths.Path) (paths.Path, error) {
 	var result activities.FileResult
-	err := workflow.ExecuteActivity(ctx, activities.StandardizeFileName, activities.FileInput{
+	err := ExecuteWithQueue(ctx, activities.StandardizeFileName, activities.FileInput{
 		Path: file,
 	}).Get(ctx, &result)
 	return result.Path, err
 }
 
 func MoveFile(ctx workflow.Context, source, destination paths.Path) error {
-	return workflow.ExecuteActivity(ctx, activities.MoveFile, activities.MoveFileInput{
+	return ExecuteWithQueue(ctx, activities.MoveFile, activities.MoveFileInput{
 		Source:      source,
 		Destination: destination,
 	}).Get(ctx, nil)
 }
 
 func CopyFile(ctx workflow.Context, source, destination paths.Path) error {
-	return workflow.ExecuteActivity(ctx, activities.CopyFile, activities.MoveFileInput{
+	return ExecuteWithQueue(ctx, activities.CopyFile, activities.MoveFileInput{
 		Source:      source,
 		Destination: destination,
 	}).Get(ctx, nil)
@@ -48,7 +48,7 @@ func MoveToFolder(ctx workflow.Context, file, folder paths.Path) (paths.Path, er
 }
 
 func WriteFile(ctx workflow.Context, file paths.Path, data []byte) error {
-	return workflow.ExecuteActivity(ctx, activities.WriteFile, activities.WriteFileInput{
+	return ExecuteWithQueue(ctx, activities.WriteFile, activities.WriteFileInput{
 		Path: file,
 		Data: data,
 	}).Get(ctx, nil)
@@ -56,7 +56,7 @@ func WriteFile(ctx workflow.Context, file paths.Path, data []byte) error {
 
 func ReadFile(ctx workflow.Context, file paths.Path) ([]byte, error) {
 	var res []byte
-	err := workflow.ExecuteActivity(ctx, activities.ReadFile, activities.FileInput{
+	err := ExecuteWithQueue(ctx, activities.ReadFile, activities.FileInput{
 		Path: file,
 	}).Get(ctx, &res)
 	return res, err
@@ -64,7 +64,7 @@ func ReadFile(ctx workflow.Context, file paths.Path) ([]byte, error) {
 
 func ListFiles(ctx workflow.Context, path paths.Path) (paths.Files, error) {
 	var res []paths.Path
-	err := workflow.ExecuteActivity(ctx, activities.ListFiles, activities.FileInput{
+	err := ExecuteWithQueue(ctx, activities.ListFiles, activities.FileInput{
 		Path: path,
 	}).Get(ctx, &res)
 	return res, err
@@ -81,13 +81,13 @@ func UnmarshalXMLFile[T any](ctx workflow.Context, file paths.Path) (*T, error) 
 }
 
 func DeletePath(ctx workflow.Context, path paths.Path) error {
-	return workflow.ExecuteActivity(ctx, activities.DeletePath, activities.DeletePathInput{
+	return ExecuteWithQueue(ctx, activities.DeletePath, activities.DeletePathInput{
 		Path: path,
 	}).Get(ctx, nil)
 }
 
 func DeletePathRecursively(ctx workflow.Context, path paths.Path) error {
-	return workflow.ExecuteActivity(ctx, activities.DeletePath, activities.DeletePathInput{
+	return ExecuteWithQueue(ctx, activities.DeletePath, activities.DeletePathInput{
 		RemoveAll: true,
 		Path:      path,
 	}).Get(ctx, nil)

--- a/utils/workflows/vidispine.go
+++ b/utils/workflows/vidispine.go
@@ -16,13 +16,13 @@ func WaitForVidispineJob(ctx workflow.Context, jobID string) error {
 		NonRetryableErrorTypes: []string{"JOB_FAILED"},
 	}
 	ctx = workflow.WithActivityOptions(ctx, options)
-	return workflow.ExecuteActivity(ctx, vsactivity.JobCompleteOrErr, vsactivity.WaitForJobCompletionParams{
+	return ExecuteWithQueue(ctx, vsactivity.JobCompleteOrErr, vsactivity.WaitForJobCompletionParams{
 		JobID: jobID,
 	}).Get(ctx, nil)
 }
 
 func SetVidispineMeta(ctx workflow.Context, assetID, key, value string) error {
-	return workflow.ExecuteActivity(ctx, vsactivity.SetVXMetadataFieldActivity, vsactivity.SetVXMetadataFieldParams{
+	return ExecuteWithQueue(ctx, vsactivity.SetVXMetadataFieldActivity, vsactivity.SetVXMetadataFieldParams{
 		VXID:  assetID,
 		Key:   key,
 		Value: value,
@@ -30,7 +30,7 @@ func SetVidispineMeta(ctx workflow.Context, assetID, key, value string) error {
 }
 
 func AddVidispineMetaValue(ctx workflow.Context, assetID, key, value string) error {
-	return workflow.ExecuteActivity(ctx, vsactivity.AddVXMetadataFieldValueActivity, vsactivity.SetVXMetadataFieldParams{
+	return ExecuteWithQueue(ctx, vsactivity.AddVXMetadataFieldValueActivity, vsactivity.SetVXMetadataFieldParams{
 		VXID:  assetID,
 		Key:   key,
 		Value: value,

--- a/workflows/export/merge_export_data.go
+++ b/workflows/export/merge_export_data.go
@@ -3,7 +3,6 @@ package export
 import (
 	"github.com/bcc-code/bcc-media-flows/activities"
 	"github.com/bcc-code/bcc-media-flows/common"
-	"github.com/bcc-code/bcc-media-flows/environment"
 	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
@@ -37,9 +36,7 @@ func MergeExportData(ctx workflow.Context, params MergeExportDataParams) (*Merge
 
 	mergeInput, audioMergeInputs, subtitleMergeInputs, jsonTranscriptFile := exportDataToMergeInputs(data, params.TempDir, params.SubtitlesDir)
 
-	options := wfutils.GetDefaultActivityOptions()
-	options.TaskQueue = environment.GetTranscodeQueue()
-	ctx = workflow.WithActivityOptions(ctx, options)
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	var transcriptTask workflow.Future
 	if params.MakeTranscript && jsonTranscriptFile != nil {

--- a/workflows/export/vx_export.go
+++ b/workflows/export/vx_export.go
@@ -76,8 +76,7 @@ func VXExport(ctx workflow.Context, params VXExportParams) ([]wfutils.ResultOrEr
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting VXExport")
 
-	options := wfutils.GetDefaultActivityOptions()
-	ctx = workflow.WithActivityOptions(ctx, options)
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	var destinations []*AssetExportDestination
 	for _, dest := range params.Destinations {

--- a/workflows/export/vx_export.go
+++ b/workflows/export/vx_export.go
@@ -90,7 +90,7 @@ func VXExport(ctx workflow.Context, params VXExportParams) ([]wfutils.ResultOrEr
 
 	var errs []error
 	var data *vidispine.ExportData
-	err := workflow.ExecuteActivity(ctx, avidispine.GetExportDataActivity, avidispine.GetExportDataParams{
+	err := wfutils.ExecuteWithQueue(ctx, avidispine.GetExportDataActivity, avidispine.GetExportDataParams{
 		VXID:        params.VXID,
 		Languages:   params.Languages,
 		AudioSource: params.AudioSource,

--- a/workflows/export/vx_export_bmm.go
+++ b/workflows/export/vx_export_bmm.go
@@ -34,8 +34,7 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting ExportToBMM")
 
-	options := wfutils.GetDefaultActivityOptions()
-	ctx = workflow.WithActivityOptions(ctx, options)
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	normalizedFutures := map[string]workflow.Future{}
 

--- a/workflows/export/vx_export_bmm.go
+++ b/workflows/export/vx_export_bmm.go
@@ -168,7 +168,7 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	}
 
 	ingestFolder := params.ExportData.SafeTitle + "_" + workflow.GetInfo(ctx).OriginalRunID
-	err = workflow.ExecuteActivity(ctx, activities.RcloneCopyDir, activities.RcloneCopyDirInput{
+	err = wfutils.ExecuteWithQueue(ctx, activities.RcloneCopyDir, activities.RcloneCopyDirInput{
 		Source:      params.OutputDir.Rclone(),
 		Destination: fmt.Sprintf("bmms3:/prod-bmm-mediabanken/" + ingestFolder),
 	}).Get(ctx, nil)

--- a/workflows/export/vx_export_playout.go
+++ b/workflows/export/vx_export_playout.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bcc-code/bcc-media-flows/activities"
 	"github.com/bcc-code/bcc-media-flows/common"
-	"github.com/bcc-code/bcc-media-flows/environment"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"go.temporal.io/sdk/workflow"
 )
@@ -14,17 +13,13 @@ func VXExportToPlayout(ctx workflow.Context, params VXExportChildWorkflowParams)
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting ExportToPlayout")
 
-	options := wfutils.GetDefaultActivityOptions()
-	ctx = workflow.WithActivityOptions(ctx, options)
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	xdcamOutputDir := params.TempDir.Append("xdcam_output")
 	err := wfutils.CreateFolder(ctx, xdcamOutputDir)
 	if err != nil {
 		return nil, err
 	}
-
-	options.TaskQueue = environment.GetTranscodeQueue()
-	ctx = workflow.WithActivityOptions(ctx, options)
 
 	// Transcode video using playout encoding
 	var videoResult common.VideoResult
@@ -52,9 +47,6 @@ func VXExportToPlayout(ctx workflow.Context, params VXExportChildWorkflowParams)
 	if err != nil {
 		return nil, err
 	}
-
-	options.TaskQueue = environment.GetWorkerQueue()
-	ctx = workflow.WithActivityOptions(ctx, options)
 
 	// Rclone to playout
 	destination := "playout:/tmp"

--- a/workflows/export/vx_export_vod.go
+++ b/workflows/export/vx_export_vod.go
@@ -24,6 +24,8 @@ func VXExportToVOD(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting ExportToVOD")
 
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
+
 	// We start chapter export and pick the results up later when needed
 	var chapterDataWF workflow.Future
 	if params.ParentParams.WithChapters {

--- a/workflows/export/vx_export_vod.go
+++ b/workflows/export/vx_export_vod.go
@@ -17,7 +17,6 @@ import (
 	"github.com/bcc-code/bcc-media-platform/backend/asset"
 	"github.com/bcc-code/bcc-media-platform/backend/events"
 	"github.com/samber/lo"
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -25,16 +24,10 @@ func VXExportToVOD(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting ExportToVOD")
 
-	options := wfutils.GetDefaultActivityOptions()
-	options.RetryPolicy = &temporal.RetryPolicy{
-		MaximumAttempts: 1,
-	}
-	ctx = workflow.WithActivityOptions(ctx, options)
-
 	// We start chapter export and pick the results up later when needed
 	var chapterDataWF workflow.Future
 	if params.ParentParams.WithChapters {
-		chapterDataWF = workflow.ExecuteActivity(ctx, vsactivity.GetChapterDataActivity, vsactivity.GetChapterDataParams{
+		chapterDataWF = wfutils.ExecuteWithQueue(ctx, vsactivity.GetChapterDataActivity, vsactivity.GetChapterDataParams{
 			ExportData: &params.ExportData,
 		})
 	}
@@ -259,7 +252,7 @@ func (v *vxExportVodService) setMetadataAndPublishToVOD(
 
 	if v.params.Upload {
 		// Copies created files and any remaining files needed.
-		err = workflow.ExecuteActivity(ctx, activities.RcloneCopyDir, activities.RcloneCopyDirInput{
+		err = wfutils.ExecuteWithQueue(ctx, activities.RcloneCopyDir, activities.RcloneCopyDirInput{
 			Source:      outputDir.Rclone(),
 			Destination: fmt.Sprintf("s3prod:vod-asset-ingest-prod/" + v.ingestFolder),
 		}).Get(ctx, nil)

--- a/workflows/ffmpeg.go
+++ b/workflows/ffmpeg.go
@@ -1,11 +1,8 @@
 package workflows
 
 import (
-	"time"
-
 	"github.com/bcc-code/bcc-media-flows/activities"
-	"github.com/bcc-code/bcc-media-flows/environment"
-	"go.temporal.io/sdk/temporal"
+	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -18,23 +15,9 @@ func ExecuteFFmpeg(
 	params ExecuteFFmpegInput,
 ) error {
 	logger := workflow.GetLogger(ctx)
-	options := workflow.ActivityOptions{
-		RetryPolicy: &temporal.RetryPolicy{
-			InitialInterval: time.Minute * 1,
-			MaximumAttempts: 10,
-			MaximumInterval: time.Hour * 1,
-		},
-		StartToCloseTimeout:    time.Hour * 4,
-		ScheduleToCloseTimeout: time.Hour * 48,
-		HeartbeatTimeout:       time.Minute * 1,
-		TaskQueue:              environment.GetTranscodeQueue(),
-	}
-
-	ctx = workflow.WithActivityOptions(ctx, options)
-
 	logger.Info("Starting ExecuteFFmpeg")
 
-	err := workflow.ExecuteActivity(ctx, activities.ExecuteFFmpeg, activities.ExecuteFFmpegInput{
+	err := wfutils.ExecuteWithQueue(ctx, activities.ExecuteFFmpeg, activities.ExecuteFFmpegInput{
 		Arguments: params.Arguments,
 	}).Get(ctx, nil)
 

--- a/workflows/ffmpeg.go
+++ b/workflows/ffmpeg.go
@@ -17,6 +17,8 @@ func ExecuteFFmpeg(
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting ExecuteFFmpeg")
 
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
+
 	err := wfutils.ExecuteWithQueue(ctx, activities.ExecuteFFmpeg, activities.ExecuteFFmpegInput{
 		Arguments: params.Arguments,
 	}).Get(ctx, nil)

--- a/workflows/handle_multitrack.go
+++ b/workflows/handle_multitrack.go
@@ -20,8 +20,9 @@ func HandleMultitrackFile(
 	params HandleMultitrackFileInput,
 ) error {
 	logger := workflow.GetLogger(ctx)
-
 	logger.Info("Starting HandleMultitrackFile workflow")
+
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	path, err := paths.Parse(params.Path)
 	if err != nil {

--- a/workflows/ingest/asset_ingest.go
+++ b/workflows/ingest/asset_ingest.go
@@ -150,7 +150,7 @@ func copyToDir(ctx workflow.Context, dest paths.Path, files []ingest.File) error
 		return err
 	}
 
-	err = workflow.ExecuteActivity(ctx, activities.RcloneCopyDir, activities.RcloneCopyDirInput{
+	err = wfutils.ExecuteWithQueue(ctx, activities.RcloneCopyDir, activities.RcloneCopyDirInput{
 		Source:      dir.Rclone(),
 		Destination: dest.Rclone(),
 	}).Get(ctx, nil)

--- a/workflows/ingest/asset_ingest.go
+++ b/workflows/ingest/asset_ingest.go
@@ -41,8 +41,7 @@ func Asset(ctx workflow.Context, params AssetParams) (*AssetResult, error) {
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting Asset")
 
-	options := wfutils.GetDefaultActivityOptions()
-	ctx = workflow.WithActivityOptions(ctx, options)
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	xmlPath, err := paths.Parse(params.XMLPath)
 	if err != nil {

--- a/workflows/ingest/common.go
+++ b/workflows/ingest/common.go
@@ -22,14 +22,14 @@ type importTagResult struct {
 
 func importFileAsTag(ctx workflow.Context, tag string, path paths.Path, title string) (*importTagResult, error) {
 	var result vsactivity.CreatePlaceholderResult
-	err := workflow.ExecuteActivity(ctx, vsactivity.CreatePlaceholderActivity, vsactivity.CreatePlaceholderParams{
+	err := wfutils.ExecuteWithQueue(ctx, vsactivity.CreatePlaceholderActivity, vsactivity.CreatePlaceholderParams{
 		Title: title,
 	}).Get(ctx, &result)
 	if err != nil {
 		return nil, err
 	}
 	var job vsactivity.JobResult
-	err = workflow.ExecuteActivity(ctx, vsactivity.ImportFileAsShapeActivity, vsactivity.ImportFileAsShapeParams{
+	err = wfutils.ExecuteWithQueue(ctx, vsactivity.ImportFileAsShapeActivity, vsactivity.ImportFileAsShapeParams{
 		AssetID:  result.AssetID,
 		FilePath: path,
 		ShapeTag: tag,

--- a/workflows/ingest/incremental_ingest.go
+++ b/workflows/ingest/incremental_ingest.go
@@ -16,8 +16,7 @@ func Incremental(ctx workflow.Context, params IncrementalParams) error {
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting Incremental")
 
-	options := wfutils.GetDefaultActivityOptions()
-	ctx = workflow.WithActivityOptions(ctx, options)
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	in, err := paths.Parse(params.Path)
 	if err != nil {

--- a/workflows/ingest/raw_material.go
+++ b/workflows/ingest/raw_material.go
@@ -101,7 +101,7 @@ func RawMaterial(ctx workflow.Context, params RawMaterialParams) error {
 		}
 		// Only create thumbnails if the file has video
 		if result.HasVideo {
-			err = workflow.ExecuteActivity(ctx, vsactivity.CreateThumbnailsActivity, vsactivity.CreateThumbnailsParams{
+			err = wfutils.ExecuteWithQueue(ctx, vsactivity.CreateThumbnailsActivity, vsactivity.CreateThumbnailsParams{
 				AssetID: id,
 			}).Get(ctx, nil)
 			if err != nil {

--- a/workflows/ingest/raw_material.go
+++ b/workflows/ingest/raw_material.go
@@ -22,8 +22,10 @@ type RawMaterialParams struct {
 }
 
 func RawMaterial(ctx workflow.Context, params RawMaterialParams) error {
-	options := wfutils.GetDefaultActivityOptions()
-	ctx = workflow.WithActivityOptions(ctx, options)
+	logger := workflow.GetLogger(ctx)
+	logger.Info("Starting RawMaterial workflow")
+
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	outputFolder, err := wfutils.GetWorkflowRawOutputFolder(ctx)
 	if err != nil {

--- a/workflows/normalize_audio.go
+++ b/workflows/normalize_audio.go
@@ -1,15 +1,11 @@
 package workflows
 
 import (
-	"time"
-
-	"github.com/bcc-code/bcc-media-flows/environment"
 	"github.com/bcc-code/bcc-media-flows/paths"
 
 	"github.com/bcc-code/bcc-media-flows/activities"
 	"github.com/bcc-code/bcc-media-flows/common"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -31,17 +27,7 @@ func NormalizeAudioLevelWorkflow(
 ) (*NormalizeAudioResult, error) {
 
 	logger := workflow.GetLogger(ctx)
-	options := workflow.ActivityOptions{
-		RetryPolicy: &temporal.RetryPolicy{
-			InitialInterval: time.Minute * 1,
-			MaximumAttempts: 10,
-			MaximumInterval: time.Hour * 1,
-		},
-		StartToCloseTimeout:    time.Hour * 4,
-		ScheduleToCloseTimeout: time.Hour * 48,
-		HeartbeatTimeout:       time.Minute * 1,
-		TaskQueue:              environment.GetWorkerQueue(),
-	}
+	options := wfutils.GetDefaultActivityOptions()
 
 	ctx = workflow.WithActivityOptions(ctx, options)
 	out := &NormalizeAudioResult{}

--- a/workflows/normalize_audio.go
+++ b/workflows/normalize_audio.go
@@ -25,14 +25,11 @@ func NormalizeAudioLevelWorkflow(
 	ctx workflow.Context,
 	params NormalizeAudioParams,
 ) (*NormalizeAudioResult, error) {
-
 	logger := workflow.GetLogger(ctx)
-	options := wfutils.GetDefaultActivityOptions()
-
-	ctx = workflow.WithActivityOptions(ctx, options)
-	out := &NormalizeAudioResult{}
-
 	logger.Info("Starting NormalizeAudio workflow")
+
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
+	out := &NormalizeAudioResult{}
 
 	filePath, err := paths.Parse(params.FilePath)
 	if err != nil {

--- a/workflows/transcode_preview-file.go
+++ b/workflows/transcode_preview-file.go
@@ -19,13 +19,10 @@ func TranscodePreviewFile(
 	ctx workflow.Context,
 	params TranscodePreviewFileInput,
 ) error {
-
 	logger := workflow.GetLogger(ctx)
-	options := wfutils.GetDefaultActivityOptions()
-
-	ctx = workflow.WithActivityOptions(ctx, options)
-
 	logger.Info("Starting TranscodePreviewFile")
+
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	filePath, err := paths.Parse(params.FilePath)
 	if err != nil {

--- a/workflows/transcode_preview-file.go
+++ b/workflows/transcode_preview-file.go
@@ -2,11 +2,9 @@ package workflows
 
 import (
 	"github.com/bcc-code/bcc-media-flows/activities"
-	"github.com/bcc-code/bcc-media-flows/environment"
 	"github.com/bcc-code/bcc-media-flows/paths"
-	"time"
+	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -23,17 +21,7 @@ func TranscodePreviewFile(
 ) error {
 
 	logger := workflow.GetLogger(ctx)
-	options := workflow.ActivityOptions{
-		RetryPolicy: &temporal.RetryPolicy{
-			InitialInterval: time.Minute * 1,
-			MaximumAttempts: 10,
-			MaximumInterval: time.Hour * 1,
-		},
-		StartToCloseTimeout:    time.Hour * 4,
-		ScheduleToCloseTimeout: time.Hour * 48,
-		HeartbeatTimeout:       time.Minute * 1,
-		TaskQueue:              environment.GetTranscodeQueue(),
-	}
+	options := wfutils.GetDefaultActivityOptions()
 
 	ctx = workflow.WithActivityOptions(ctx, options)
 
@@ -45,7 +33,7 @@ func TranscodePreviewFile(
 	}
 
 	previewResponse := &activities.TranscodePreviewResponse{}
-	err = workflow.ExecuteActivity(ctx, activities.TranscodePreview, activities.TranscodePreviewParams{
+	err = wfutils.ExecuteWithQueue(ctx, activities.TranscodePreview, activities.TranscodePreviewParams{
 		FilePath:           filePath,
 		DestinationDirPath: filePath.Dir(),
 	}).Get(ctx, previewResponse)

--- a/workflows/transcode_preview-vx.go
+++ b/workflows/transcode_preview-vx.go
@@ -4,14 +4,11 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/bcc-code/bcc-media-flows/activities"
 	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
-	"github.com/bcc-code/bcc-media-flows/environment"
 	"github.com/bcc-code/bcc-media-flows/utils/workflows"
 
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -28,26 +25,11 @@ func TranscodePreviewVX(
 	ctx workflow.Context,
 	params TranscodePreviewVXInput,
 ) error {
-
 	logger := workflow.GetLogger(ctx)
-	options := workflow.ActivityOptions{
-		RetryPolicy: &temporal.RetryPolicy{
-			InitialInterval: time.Minute * 1,
-			MaximumAttempts: 10,
-			MaximumInterval: time.Hour * 1,
-		},
-		StartToCloseTimeout:    time.Hour * 4,
-		ScheduleToCloseTimeout: time.Hour * 48,
-		HeartbeatTimeout:       time.Minute * 1,
-		TaskQueue:              environment.GetWorkerQueue(),
-	}
-
-	ctx = workflow.WithActivityOptions(ctx, options)
-
 	logger.Info("Starting TranscodePreviewVX")
 
 	shapes := &vsactivity.GetFileFromVXResult{}
-	err := workflow.ExecuteActivity(ctx, vsactivity.GetFileFromVXActivity, vsactivity.GetFileFromVXParams{
+	err := wfutils.ExecuteWithQueue(ctx, vsactivity.GetFileFromVXActivity, vsactivity.GetFileFromVXParams{
 		Tags: []string{"original"},
 		VXID: params.VXID,
 	}).Get(ctx, shapes)
@@ -68,8 +50,7 @@ func TranscodePreviewVX(
 	}
 
 	previewResponse := &activities.TranscodePreviewResponse{}
-	ctx = workflow.WithTaskQueue(ctx, environment.GetTranscodeQueue())
-	err = workflow.ExecuteActivity(ctx, activities.TranscodePreview, activities.TranscodePreviewParams{
+	err = wfutils.ExecuteWithQueue(ctx, activities.TranscodePreview, activities.TranscodePreviewParams{
 		FilePath:           shapes.FilePath,
 		DestinationDirPath: destinationPath,
 	}).Get(ctx, previewResponse)
@@ -85,8 +66,7 @@ func TranscodePreviewVX(
 		shapeTag = "lowres_watermarked"
 	}
 
-	ctx = workflow.WithTaskQueue(ctx, environment.GetWorkerQueue())
-	err = workflow.ExecuteActivity(ctx, vsactivity.ImportFileAsShapeActivity,
+	err = wfutils.ExecuteWithQueue(ctx, vsactivity.ImportFileAsShapeActivity,
 		vsactivity.ImportFileAsShapeParams{
 			AssetID:  params.VXID,
 			FilePath: previewResponse.PreviewFilePath,

--- a/workflows/transcode_preview-vx.go
+++ b/workflows/transcode_preview-vx.go
@@ -28,6 +28,8 @@ func TranscodePreviewVX(
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting TranscodePreviewVX")
 
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
+
 	shapes := &vsactivity.GetFileFromVXResult{}
 	err := wfutils.ExecuteWithQueue(ctx, vsactivity.GetFileFromVXActivity, vsactivity.GetFileFromVXParams{
 		Tags: []string{"original"},

--- a/workflows/transcribe-file.go
+++ b/workflows/transcribe-file.go
@@ -51,12 +51,12 @@ func TranscribeFile(
 		return err
 	}
 
-	return wfutils.ExecuteWithQueue(ctx, activities.Transcribe, activities.TranscribeParams{
+	transcribeOutput := &activities.TranscribeResponse{}
+	err = wfutils.ExecuteWithQueue(ctx, activities.Transcribe, activities.TranscribeParams{
 		Language:        params.Language,
 		File:            wavFile.OutputPath,
 		DestinationPath: tempFolder,
 	}).Get(ctx, transcribeOutput)
-
 	if err != nil || transcribeOutput == nil {
 		return err
 	}

--- a/workflows/transcribe-vx.go
+++ b/workflows/transcribe-vx.go
@@ -26,10 +26,10 @@ func TranscribeVX(
 	ctx workflow.Context,
 	params TranscribeVXInput,
 ) error {
-
 	logger := workflow.GetLogger(ctx)
-
 	logger.Info("Starting TranscribeVX")
+
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	shapes := &vsactivity.GetFileFromVXResult{}
 	err := wfutils.ExecuteWithQueue(ctx, vsactivity.GetFileFromVXActivity, vsactivity.GetFileFromVXParams{

--- a/workflows/vb_export/vb_export.go
+++ b/workflows/vb_export/vb_export.go
@@ -59,8 +59,7 @@ func VBExport(ctx workflow.Context, params VBExportParams) ([]wfutils.ResultOrEr
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting VBExport")
 
-	options := wfutils.GetDefaultActivityOptions()
-	ctx = workflow.WithActivityOptions(ctx, options)
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	if params.VXID == "" {
 		return nil, fmt.Errorf("vxid is required")

--- a/workflows/vb_export/vb_export_abekas.go
+++ b/workflows/vb_export/vb_export_abekas.go
@@ -25,8 +25,7 @@ func VBExportToAbekas(ctx workflow.Context, params VBExportChildWorkflowParams) 
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting ExportToAbekas")
 
-	options := wfutils.GetDefaultActivityOptions()
-	ctx = workflow.WithActivityOptions(ctx, options)
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	abekasOutputDir := params.TempDir.Append("abekas_output")
 	err := wfutils.CreateFolder(ctx, abekasOutputDir)

--- a/workflows/vb_export/vb_export_bstage.go
+++ b/workflows/vb_export/vb_export_bstage.go
@@ -23,8 +23,7 @@ func VBExportToBStage(ctx workflow.Context, params VBExportChildWorkflowParams) 
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting ExportToBStage")
 
-	options := wfutils.GetDefaultActivityOptions()
-	ctx = workflow.WithActivityOptions(ctx, options)
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	bStageOutputDir := params.TempDir.Append("b-stage_output")
 	err := wfutils.CreateFolder(ctx, bStageOutputDir)

--- a/workflows/vb_export/vb_export_gfx.go
+++ b/workflows/vb_export/vb_export_gfx.go
@@ -23,8 +23,7 @@ func VBExportToGfx(ctx workflow.Context, params VBExportChildWorkflowParams) (*V
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting ExportToGFX")
 
-	options := wfutils.GetDefaultActivityOptions()
-	ctx = workflow.WithActivityOptions(ctx, options)
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	gfxOutputDir := params.TempDir.Append("gfx_output")
 	err := wfutils.CreateFolder(ctx, gfxOutputDir)

--- a/workflows/vb_export/vb_export_hippo.go
+++ b/workflows/vb_export/vb_export_hippo.go
@@ -39,8 +39,7 @@ func VBExportToHippo(ctx workflow.Context, params VBExportChildWorkflowParams) (
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting ExportToHippo")
 
-	options := wfutils.GetDefaultActivityOptions()
-	ctx = workflow.WithActivityOptions(ctx, options)
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	hippoOutputDir := params.TempDir.Append("hippo_output")
 	err := wfutils.CreateFolder(ctx, hippoOutputDir)

--- a/workflows/watch_folder_transcode.go
+++ b/workflows/watch_folder_transcode.go
@@ -18,8 +18,9 @@ type WatchFolderTranscodeInput struct {
 
 func WatchFolderTranscode(ctx workflow.Context, params WatchFolderTranscodeInput) error {
 	logger := workflow.GetLogger(ctx)
-
 	logger.Info("Starting WatchFolderTranscode")
+
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
 	path, err := paths.Parse(params.Path)
 	if err != nil {


### PR DESCRIPTION
Found a lot of duplicate definitions on activity options when I wanted to fix the retry policy for transcode/audio queues, so I removed it and changed to per queue defaults. 
Transcode should fail faster, and worker things are usually only failing due to restarts.