### PR TITLE
Feat/silence detection

### DIFF
--- a/activities/normalize.go
+++ b/activities/normalize.go
@@ -83,12 +83,24 @@ type NormalizeAudioParams struct {
 
 type NormalizeAudioResult struct {
 	FilePath       paths.Path
+	IsSilent       bool
 	InputAnalysis  *common.AnalyzeEBUR128Result
 	OutputAnalysis *common.AnalyzeEBUR128Result
 }
 
 func NormalizeAudioActivity(ctx context.Context, params NormalizeAudioParams) (*NormalizeAudioResult, error) {
 	out := &NormalizeAudioResult{}
+
+	silent, err := transcode.AudioIsSilent(params.FilePath)
+	if err != nil {
+		return nil, err
+	}
+	if silent {
+		return &NormalizeAudioResult{
+			FilePath: params.FilePath,
+			IsSilent: true,
+		}, nil
+	}
 
 	r128Result, err := AnalyzeEBUR128Activity(ctx, AnalyzeEBUR128Params{
 		FilePath:       params.FilePath,

--- a/cmd/trigger_ui/main.go
+++ b/cmd/trigger_ui/main.go
@@ -190,6 +190,7 @@ func (s *TriggerServer) triggerHandlerPOST(c *gin.Context) {
 		VXID:          vxID,
 		WithFiles:     c.PostForm("withFiles") == "on",
 		WithChapters:  c.PostForm("withChapters") == "on",
+		IgnoreSilence: c.PostForm("ignoreSilence") == "on",
 		WatermarkPath: watermarkPath,
 		AudioSource:   audioSource,
 		Destinations:  c.PostFormArray("destinations[]"),

--- a/cmd/trigger_ui/templates/vx-export.gohtml
+++ b/cmd/trigger_ui/templates/vx-export.gohtml
@@ -115,6 +115,11 @@
             <input class="ml-2 h-4 w-4 my-auto" type="checkbox" name="withChapters"
                    id="withChapters">
         </div>
+        <div class="flex">
+            <label for="ignoreSilence" class="my-auto">Ignore silence</label>
+            <input class="ml-2 h-4 w-4 my-auto" type="checkbox" name="ignoreSilence"
+                   id="ignoreSilence">
+        </div>
 
         <input id="submit"
                class="cursor-pointer rounded-md bg-[#6A64F1] py-3 px-8 text-center text-base font-semibold text-white outline-none"

--- a/services/transcode/audio_test.go
+++ b/services/transcode/audio_test.go
@@ -27,3 +27,8 @@ func Test_AudioSplit(t *testing.T) {
 
 	spew.Dump(files)
 }
+
+func Test_AudioSilence(t *testing.T) {
+	_, err := AudioIsSilent(paths.MustParse("/private/temp/workflows/5d2ea767-6b71-44c6-a207-005d7522326c/FKTB_20210415_2000_SEQ-slv.wav"))
+	print(err)
+}

--- a/services/transcode/audio_test.go
+++ b/services/transcode/audio_test.go
@@ -30,5 +30,5 @@ func Test_AudioSplit(t *testing.T) {
 
 func Test_AudioSilence(t *testing.T) {
 	_, err := AudioIsSilent(paths.MustParse("/private/temp/workflows/5d2ea767-6b71-44c6-a207-005d7522326c/FKTB_20210415_2000_SEQ-slv.wav"))
-	print(err)
+	assert.Nil(t, err)
 }

--- a/workflows/export/vx_export.go
+++ b/workflows/export/vx_export.go
@@ -40,6 +40,7 @@ type VXExportParams struct {
 	AudioSource   string
 	Languages     []string
 	Subclip       string
+	IgnoreSilence bool
 }
 
 type VXExportResult struct {


### PR DESCRIPTION
Detects if the file is silent before it tries to normalize.

Also adds an option to ignore silent files on export. This will let the flow go through without that audio language attached to the asset. If false, the entire flow will fail.