### PR TITLE
Exclude README files from cleanup

### DIFF
--- a/utils/files.go
+++ b/utils/files.go
@@ -68,7 +68,11 @@ func GetOldFiles(rootDir string, olderThan time.Time) ([]string, error) {
 			if err != nil {
 				return err
 			}
-			if info.ModTime().Before(olderThan) {
+			if info.ModTime().Before(olderThan) &&
+				filepath.Base(path)[0] != '.' &&
+				!strings.HasPrefix(filepath.Base(path), "README") {
+				// Is old, not hidden, and not a README file
+
 				older = append(older, path)
 			}
 		}


### PR DESCRIPTION
The logic is that we can put README files in key folder we want to keep This files can then act both as a "delete stop" for the empty folder process, as well as info for the users.