### PR TITLE
Be a bit more lenient to interruptions in growing files.

### DIFF
--- a/activities/files_test.go
+++ b/activities/files_test.go
@@ -1,0 +1,45 @@
+package activities
+
+import (
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/paths"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/testsuite"
+)
+
+type UnitTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+
+	env *testsuite.TestActivityEnvironment
+}
+
+func (s *UnitTestSuite) SetupTest() {
+	s.env = s.NewTestActivityEnvironment()
+}
+
+func (s *UnitTestSuite) TestStandardizeFileName() {
+	p, err := paths.Parse("/mnt/filecatalyst/a  b /c/d e g.txt")
+	t := s.T()
+
+	ua := UtilActivities{}
+	assert.NoError(t, err)
+
+	s.env.RegisterActivity(ua.StandardizeFileName)
+	res, err := s.env.ExecuteActivity(ua.StandardizeFileName, FileInput{Path: p})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+
+	p2 := &paths.Path{}
+	res.Get(p2)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "/a/b/c/d_e_g.txt", p2.Path)
+}
+
+func TestUnitTestSuite(t *testing.T) {
+	suite.Run(t, new(UnitTestSuite))
+}

--- a/services/rsync/incremental.go
+++ b/services/rsync/incremental.go
@@ -64,6 +64,8 @@ func IncrementalCopy(in, out paths.Path, statCallback func(FileInfo)) error {
 			if doneCount == 5 {
 				return nil
 			}
+		} else {
+			doneCount = 0
 		}
 
 		time.Sleep(time.Second * 15)

--- a/services/rsync/incremental.go
+++ b/services/rsync/incremental.go
@@ -51,14 +51,21 @@ func IncrementalCopy(in, out paths.Path, statCallback func(FileInfo)) error {
 		return false, nil
 	}
 
+	doneCount := 0
 	for {
+
 		done, err := doCopy()
 		if err != nil {
 			return err
 		}
+
 		if done {
-			return nil
+			doneCount++
+			if doneCount == 5 {
+				return nil
+			}
 		}
+
 		time.Sleep(time.Second * 15)
 	}
 }


### PR DESCRIPTION
Basically wait 1.5 minutes to make sure the file is really complete and that there was not just a small interruption in transmission. The interval should be > 1 minute due to the FileCatalyst HotFolder having a 1 minute interval on starting jobs.

Fixes: https://github.com/bcc-code/bcc-live/issues/92

(Also added a test I wrote but forgot to commit)