### PR TITLE
Make sure prefixing an audio file with silece keeps it in stereo.

### DIFF
--- a/services/transcode/prepend-silence.go
+++ b/services/transcode/prepend-silence.go
@@ -9,14 +9,14 @@ import (
 
 // PrependSilence prepends a given file with a given length of silence.
 // The sample rate of the output file is the same as the input file.
-// TODO: Untested
 func PrependSilence(file paths.Path, outputPath paths.Path, length float64, sampleRate int, cb ffmpeg.ProgressCallback) (*paths.Path, error) {
 	params := []string{
 		"-f", "lavfi",
-		"-i", fmt.Sprintf("aevalsrc=0:d=%f", length),
+		"-i", fmt.Sprintf("aevalsrc=0|0:d=%f", length),
 		"-i", file.Local(),
 		"-filter_complex", fmt.Sprintf("[0:a][1:a]concat=n=2:v=0:a=1"),
 		"-ar", fmt.Sprintf("%d", sampleRate),
+		"-y",
 		outputPath.Local(),
 	}
 

--- a/services/transcode/prepend_silence_test.go
+++ b/services/transcode/prepend_silence_test.go
@@ -2,16 +2,48 @@ package transcode
 
 import (
 	"github.com/bcc-code/bcc-media-flows/paths"
+	"github.com/bcc-code/bcc-media-flows/services/ffmpeg"
 	"github.com/stretchr/testify/assert"
+	"os"
+	"os/exec"
 	"testing"
 )
 
+func GenerateTestFile() paths.Path {
+	outFile := paths.MustParse("./testdata/generated/test_tone_stereo.wav")
+	os.MkdirAll(outFile.Dir().Local(), 0755)
+
+	args := []string{
+		"-f", "lavfi",
+		"-i", "sine=frequency=300:duration=10:sample_rate=48000",
+		"-f", "lavfi",
+		"-i", "sine=frequency=1000:duration=10:sample_rate=48000",
+		"-filter_complex", "[0:a][1:a]amerge=inputs=2[a]",
+		"-map", "[a]",
+		"-c:a", "pcm_s16le",
+		outFile.Local(),
+	}
+
+	cmd := exec.Command("ffmpeg", args...)
+	err := cmd.Run()
+	if err != nil {
+		panic(err)
+	}
+
+	return outFile
+}
+
 func Test_PrependSilence(t *testing.T) {
-	input := paths.MustParse("/tmp/test1.wav")
-	output := paths.MustParse("/tmp/test1_prefixed.wav")
+	input := GenerateTestFile()
+	output := paths.MustParse("./testdata/generated/test_tone_stereo_prefixed.wav")
 
 	cb, _ := printProgress()
-	res, err := PrependSilence(input, output, 1.0, 48000, cb)
+	res, err := PrependSilence(input, output, 0, 48000, cb)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, res)
+
+	info, err := ffmpeg.GetStreamInfo(output.Local())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(info.AudioStreams))
+	assert.Equal(t, 2, info.AudioStreams[0].Channels)
 }

--- a/services/transcode/prepend_silence_test.go
+++ b/services/transcode/prepend_silence_test.go
@@ -38,7 +38,7 @@ func Test_PrependSilence(t *testing.T) {
 	output := paths.MustParse("./testdata/generated/test_tone_stereo_prefixed.wav")
 
 	cb, _ := printProgress()
-	res, err := PrependSilence(input, output, 0, 48000, cb)
+	res, err := PrependSilence(input, output, 1.0, 48000, cb)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, res)
 

--- a/services/transcode/prepend_silence_test.go
+++ b/services/transcode/prepend_silence_test.go
@@ -1,0 +1,17 @@
+package transcode
+
+import (
+	"github.com/bcc-code/bcc-media-flows/paths"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_PrependSilence(t *testing.T) {
+	input := paths.MustParse("/tmp/test1.wav")
+	output := paths.MustParse("/tmp/test1_prefixed.wav")
+
+	cb, _ := printProgress()
+	res, err := PrependSilence(input, output, 1.0, 48000, cb)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, res)
+}

--- a/services/transcode/testdata/.gitignore
+++ b/services/transcode/testdata/.gitignore
@@ -1,1 +1,2 @@
 *
+generated/*


### PR DESCRIPTION
Mono files will be converted to "fake" stereo. I think this is acceptable in this case.