### PR TITLE
refactor: split up chapter function

### DIFF
--- a/activities/vidispine/export.go
+++ b/activities/vidispine/export.go
@@ -38,18 +38,18 @@ func (a Activities) GetExportDataActivity(ctx context.Context, params GetExportD
 	return data, nil
 }
 
-type GetChapterDataParams struct {
+type GetTimedMetadataChaptersParams struct {
 	ExportData *vidispine.ExportData
 }
 
-func (a Activities) GetChapterDataActivity(ctx context.Context, params GetChapterDataParams) ([]asset.TimedMetadata, error) {
+func (a Activities) GetTimedMetadataChaptersActivity(ctx context.Context, params GetTimedMetadataChaptersParams) ([]asset.TimedMetadata, error) {
 	log := activity.GetLogger(ctx)
-	activity.RecordHeartbeat(ctx, "GetChapterDataActivity")
-	log.Info("Starting GetChapterDataActivity")
+	activity.RecordHeartbeat(ctx, "GetTimedMetadataChaptersActivity")
+	log.Info("Starting GetTimedMetadataChaptersActivity")
 
 	client := GetClient()
 
-	return vidispine.GetChapterData(client, params.ExportData)
+	return vidispine.GetTimedMetadataChapters(client, params.ExportData.Clips)
 }
 
 func (a Activities) GetRelatedAudioFiles(ctx context.Context, vxID string) (map[string]paths.Path, error) {

--- a/activities/vidispine/export.go
+++ b/activities/vidispine/export.go
@@ -39,7 +39,7 @@ func (a Activities) GetExportDataActivity(ctx context.Context, params GetExportD
 }
 
 type GetTimedMetadataChaptersParams struct {
-	ExportData *vidispine.ExportData
+	Clips []*vidispine.Clip
 }
 
 func (a Activities) GetTimedMetadataChaptersActivity(ctx context.Context, params GetTimedMetadataChaptersParams) ([]asset.TimedMetadata, error) {
@@ -49,7 +49,7 @@ func (a Activities) GetTimedMetadataChaptersActivity(ctx context.Context, params
 
 	client := GetClient()
 
-	return vidispine.GetTimedMetadataChapters(client, params.ExportData.Clips)
+	return vidispine.GetTimedMetadataChapters(client, params.Clips)
 }
 
 func (a Activities) GetRelatedAudioFiles(ctx context.Context, vxID string) (map[string]paths.Path, error) {

--- a/cmd/trigger_ui/main.go
+++ b/cmd/trigger_ui/main.go
@@ -157,7 +157,7 @@ func (s *TriggerServer) vxExportGET(ctx *gin.Context) {
 		renderErrorPage(ctx, http.StatusInternalServerError, err)
 		return
 	}
-	chapters, err := vidispine.GetChapterData(s.vidispine, exportData)
+	chapters, err := vidispine.GetTimedMetadataChapters(s.vidispine, exportData.Clips)
 	if err != nil {
 		renderErrorPage(ctx, http.StatusInternalServerError, err)
 		return

--- a/workflows/export/timedmetadata_vod.go
+++ b/workflows/export/timedmetadata_vod.go
@@ -45,7 +45,7 @@ func ExportTimedMetadata(ctx workflow.Context, params ExportTimedMetadataParams)
 	}
 
 	timedMetadata, err := wfutils.Execute(ctx, activities.Vidispine.GetTimedMetadataChaptersActivity, vsactivity.GetTimedMetadataChaptersParams{
-		ExportData: exportData,
+		Clips: exportData.Clips,
 	}).Result(ctx)
 	if err != nil {
 		return nil, err

--- a/workflows/export/timedmetadata_vod.go
+++ b/workflows/export/timedmetadata_vod.go
@@ -44,7 +44,7 @@ func ExportTimedMetadata(ctx workflow.Context, params ExportTimedMetadataParams)
 		return nil, err
 	}
 
-	timedMetadata, err := wfutils.Execute(ctx, activities.Vidispine.GetChapterDataActivity, vsactivity.GetChapterDataParams{
+	timedMetadata, err := wfutils.Execute(ctx, activities.Vidispine.GetTimedMetadataChaptersActivity, vsactivity.GetTimedMetadataChaptersParams{
 		ExportData: exportData,
 	}).Result(ctx)
 	if err != nil {

--- a/workflows/export/vx_export_bmm.go
+++ b/workflows/export/vx_export_bmm.go
@@ -157,7 +157,7 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 
 	var chapters []asset.TimedMetadata
 	err = wfutils.Execute(ctx, activities.Vidispine.GetTimedMetadataChaptersActivity, vsactivity.GetTimedMetadataChaptersParams{
-		ExportData: &params.ExportData,
+		Clips: params.ExportData.Clips,
 	}).Get(ctx, &chapters)
 	if err != nil {
 		return nil, err

--- a/workflows/export/vx_export_bmm.go
+++ b/workflows/export/vx_export_bmm.go
@@ -156,7 +156,7 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	}
 
 	var chapters []asset.TimedMetadata
-	err = wfutils.Execute(ctx, activities.Vidispine.GetChapterDataActivity, vsactivity.GetChapterDataParams{
+	err = wfutils.Execute(ctx, activities.Vidispine.GetTimedMetadataChaptersActivity, vsactivity.GetTimedMetadataChaptersParams{
 		ExportData: &params.ExportData,
 	}).Get(ctx, &chapters)
 	if err != nil {

--- a/workflows/export/vx_export_vod.go
+++ b/workflows/export/vx_export_vod.go
@@ -32,7 +32,7 @@ func VXExportToVOD(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	// We start chapter export and pick the results up later when needed
 	var chapterDataWF workflow.Future
 	if params.ParentParams.WithChapters {
-		chapterDataWF = wfutils.Execute(ctx, activities.Vidispine.GetChapterDataActivity, vsactivity.GetChapterDataParams{
+		chapterDataWF = wfutils.Execute(ctx, activities.Vidispine.GetTimedMetadataChaptersActivity, vsactivity.GetTimedMetadataChaptersParams{
 			ExportData: &params.ExportData,
 		}).Future
 	}

--- a/workflows/export/vx_export_vod.go
+++ b/workflows/export/vx_export_vod.go
@@ -33,7 +33,7 @@ func VXExportToVOD(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	var chapterDataWF workflow.Future
 	if params.ParentParams.WithChapters {
 		chapterDataWF = wfutils.Execute(ctx, activities.Vidispine.GetTimedMetadataChaptersActivity, vsactivity.GetTimedMetadataChaptersParams{
-			ExportData: &params.ExportData,
+			Clips: params.ExportData.Clips,
 		}).Future
 	}
 


### PR DESCRIPTION
i think i need the GetChapterMetaForClips alone in a script
maybe not
either way, i think it makes sense to split this up? seperate the timedmetadata mapping from the vidispine "chapters"