### PR TITLE
Remove support for "subclipToExport" metadata filed

### DIFF
--- a/cmd/trigger_ui/templates/vx-export.gohtml
+++ b/cmd/trigger_ui/templates/vx-export.gohtml
@@ -53,8 +53,7 @@
             </div>
             <div class="flex flex-col">
                 <h3 class="font-bold">Subclips to export</h3>
-                <p class="text-sm mb-2">Leave empty to export the entire asset (or use the field specified on the asset)
-                </p>
+                <p class="text-sm mb-2">Leave empty to export the entire asset</p>
                 <ul class="flex flex-col gap-1">
                     {{range $element := .Subclips}}
                     {{$subclip := $element.Title}}

--- a/services/vidispine/clips.go
+++ b/services/vidispine/clips.go
@@ -132,7 +132,7 @@ func getClipForSubclip(
 
 	subclipMeta, ok := clipsMeta[subclipName]
 	if !ok {
-		return nil, errors.New("Subclip " + subclipName + " does not exist")
+		return nil, errors.New("Subclip \"" + subclipName + "\" does not exist")
 	}
 
 	in, out, err := subclipMeta.GetInOut(meta.Get(vscommon.FieldStartTC, "0@PAL"))

--- a/services/vidispine/export.go
+++ b/services/vidispine/export.go
@@ -319,7 +319,6 @@ func GetSubclipNames(client Client, itemVXID string) ([]string, error) {
 }
 
 // GetDataForExport returns the data needed to export the item with the given VXID
-// If exportSubclip is true, the subclip will be exported, otherwise the whole clip
 func GetDataForExport(client Client, itemVXID string, languagesToExport []string, audioSource *ExportAudioSource, subclip string) (*ExportData, error) {
 	originalMeta, err := client.GetMetadata(itemVXID)
 	if err != nil {
@@ -341,9 +340,6 @@ func GetDataForExport(client Client, itemVXID string, languagesToExport []string
 
 	title := meta.Get(vscommon.FieldTitle, "")
 	subclipTitle := subclip
-	if subclipTitle == "" {
-		subclipTitle = meta.Get(vscommon.FieldSubclipToExport, "")
-	}
 	if subclipTitle != "" {
 		title += " - " + subclipTitle
 	}

--- a/services/vidispine/vscommon/fields.go
+++ b/services/vidispine/vscommon/fields.go
@@ -14,7 +14,6 @@ var (
 	FieldSequenceSize          = FieldType{"__sequence_size"}
 	FieldStartTC               = FieldType{"startTimeCode"}
 	FieldStlText               = FieldType{"stl_text"}
-	FieldSubclipToExport       = FieldType{"portal_mf230973"}
 	FieldSubclipType           = FieldType{"portal_mf594493"}
 	FieldTitle                 = FieldType{"title"}
 	FieldIngested              = FieldType{"portal_ingested"}
@@ -42,7 +41,7 @@ var (
 	FieldAssetAudioCodec       = FieldType{"ASSET_AUDIO_CODEC"}
 	FieldOriginalAudioCodec    = FieldType{"originalAudioCodec"}
 	FieldTypes                 = enum.New(FieldDurationSeconds, FieldDescription, FieldExportAudioSource, FieldLangsToExport,
-		FieldPersonsAppearing, FieldSequenceSize, FieldStartTC, FieldSubclipToExport, FieldSubclipType, FieldTitle,
+		FieldPersonsAppearing, FieldSequenceSize, FieldStartTC, FieldSubclipType, FieldTitle,
 		FieldSource, FieldExportAsChapter, FieldSubtransStoryID, FieldOriginalURI, FieldUploadedBy, FieldUploadJob,
 		FieldLanguagesRecorded, FieldGeneralTags, FieldOriginalFileName, FieldOriginalFileNameField,
 		FieldEpisodeDescription, FieldSeason, FieldProgram, FieldEpisode, FieldStlText, FieldIngested, FieldDialogLoudness,


### PR DESCRIPTION
It is not being used and is causing issues like this:

<img width="1070" alt="image" src="https://github.com/bcc-code/bcc-media-flows/assets/398737/b78856b2-6949-47ad-b2bb-7ace3c6214b4">
