### PR TITLE
Prevent super short chapters from interfering

### DIFF
--- a/services/vidispine/chapter_test.go
+++ b/services/vidispine/chapter_test.go
@@ -95,6 +95,7 @@ func Test_GetChapterMetaForClips_Overlapping(t *testing.T) {
 }
 
 // This is an edge case where the annotations overlap by a few frames
+// This test is identical to Test_GetChapterMetaForClips_Overlapping but with a different subclip that was exibithing the same behaviour
 func Test_GetChapterMetaForClips_Overlapping2(t *testing.T) {
 	clips := []*Clip{
 		{

--- a/services/vidispine/chapter_test.go
+++ b/services/vidispine/chapter_test.go
@@ -59,6 +59,13 @@ func Test_GetChapterMetaForClips_Overlapping(t *testing.T) {
 		t.Skip("VIDISPINE_BASE_URL is not set")
 	}
 
+	// The important thing here is the VXID of the main file (not the audio file),
+	// together with the in and out points of the clip.
+	//
+	// The situation is that two annotations (chapters) in MB overlap by a few frames,
+	// making the system think that there are two chapters between the in and out point.
+	// While this is techinically correct, it is not what we want, if one of the "chapters"
+	// is very short (less than 10 seconds). At this point it is unlikely to be a real chapter and we can ignore it.
 	testData := [][]*Clip{
 		{
 			{

--- a/services/vidispine/chapter_test.go
+++ b/services/vidispine/chapter_test.go
@@ -53,25 +53,30 @@ func TestMergeTerseTimecodes(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
-func Test_GetChapterMetaForClips(t *testing.T) {
+// This is an edge case where the annotations overlap by a few frames
+func Test_GetChapterMetaForClips_Overlapping(t *testing.T) {
 	clips := []*Clip{
 		{
 			VideoFile:   "/dummy/file.mp4",
-			InSeconds:   1907.7599999999948,
-			OutSeconds:  3025.399999999994,
+			InSeconds:   1420.1199999999953,
+			OutSeconds:  2767.439999999988,
 			SequenceIn:  0,
 			SequenceOut: 0,
 			AudioFiles: map[string]*AudioFile{
 				"nor": {
-					VXID:    "VX-486737",
-					Streams: []int{1, 2},
+					VXID:    "VX-489605",
+					Streams: []int{2},
 					File:    "/dummy/file.wav",
 				},
 			},
 			SubtitleFiles:      map[string]string{},
 			JSONTranscriptFile: "",
-			VXID:               "VX-486737",
+			VXID:               "VX-489598",
 		},
+	}
+
+	if os.Getenv("VIDISPINE_BASE_URL") == "" {
+		t.Skip("VIDISPINE_BASE_URL is not set")
 	}
 
 	client := vsapi.NewClient(
@@ -82,9 +87,50 @@ func Test_GetChapterMetaForClips(t *testing.T) {
 	out, err := GetChapterMetaForClips(client, clips)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, out)
+	assert.Len(t, out, 1)
 
 	for i, chapter := range out {
 		assert.GreaterOrEqual(t, len(chapter.Meta.Terse["title"]), 1, "Chapter in loop iteration %d has no title", i)
 	}
+}
 
+// This is an edge case where the annotations overlap by a few frames
+func Test_GetChapterMetaForClips_Overlapping2(t *testing.T) {
+	clips := []*Clip{
+		{
+			VideoFile:   "/dummy/file.mp4",
+			InSeconds:   3750.9199999999983,
+			OutSeconds:  3906.87999999999,
+			SequenceIn:  0,
+			SequenceOut: 0,
+			AudioFiles: map[string]*AudioFile{
+				"nor": {
+					VXID:    "VX-489605",
+					Streams: []int{2},
+					File:    "/dummy/file.wav",
+				},
+			},
+			SubtitleFiles:      map[string]string{},
+			JSONTranscriptFile: "",
+			VXID:               "VX-489598",
+		},
+	}
+
+	if os.Getenv("VIDISPINE_BASE_URL") == "" {
+		t.Skip("VIDISPINE_BASE_URL is not set")
+	}
+
+	client := vsapi.NewClient(
+		os.Getenv("VIDISPINE_BASE_URL"),
+		os.Getenv("VIDISPINE_USERNAME"),
+		os.Getenv("VIDISPINE_PASSWORD"),
+	)
+	out, err := GetChapterMetaForClips(client, clips)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, out)
+	assert.Len(t, out, 1)
+
+	for i, chapter := range out {
+		assert.GreaterOrEqual(t, len(chapter.Meta.Terse["title"]), 1, "Chapter in loop iteration %d has no title", i)
+	}
 }

--- a/services/vidispine/chapter_test.go
+++ b/services/vidispine/chapter_test.go
@@ -55,83 +55,65 @@ func TestMergeTerseTimecodes(t *testing.T) {
 
 // This is an edge case where the annotations overlap by a few frames
 func Test_GetChapterMetaForClips_Overlapping(t *testing.T) {
-	clips := []*Clip{
-		{
-			VideoFile:   "/dummy/file.mp4",
-			InSeconds:   1420.1199999999953,
-			OutSeconds:  2767.439999999988,
-			SequenceIn:  0,
-			SequenceOut: 0,
-			AudioFiles: map[string]*AudioFile{
-				"nor": {
-					VXID:    "VX-489605",
-					Streams: []int{2},
-					File:    "/dummy/file.wav",
-				},
-			},
-			SubtitleFiles:      map[string]string{},
-			JSONTranscriptFile: "",
-			VXID:               "VX-489598",
-		},
-	}
-
 	if os.Getenv("VIDISPINE_BASE_URL") == "" {
 		t.Skip("VIDISPINE_BASE_URL is not set")
 	}
 
-	client := vsapi.NewClient(
-		os.Getenv("VIDISPINE_BASE_URL"),
-		os.Getenv("VIDISPINE_USERNAME"),
-		os.Getenv("VIDISPINE_PASSWORD"),
-	)
-	out, err := GetChapterMetaForClips(client, clips)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, out)
-	assert.Len(t, out, 1)
-
-	for i, chapter := range out {
-		assert.GreaterOrEqual(t, len(chapter.Meta.Terse["title"]), 1, "Chapter in loop iteration %d has no title", i)
-	}
-}
-
-// This is an edge case where the annotations overlap by a few frames
-// This test is identical to Test_GetChapterMetaForClips_Overlapping but with a different subclip that was exibithing the same behaviour
-func Test_GetChapterMetaForClips_Overlapping2(t *testing.T) {
-	clips := []*Clip{
+	testData := [][]*Clip{
 		{
-			VideoFile:   "/dummy/file.mp4",
-			InSeconds:   3750.9199999999983,
-			OutSeconds:  3906.87999999999,
-			SequenceIn:  0,
-			SequenceOut: 0,
-			AudioFiles: map[string]*AudioFile{
-				"nor": {
-					VXID:    "VX-489605",
-					Streams: []int{2},
-					File:    "/dummy/file.wav",
+			{
+				VideoFile:   "/dummy/file.mp4",
+				InSeconds:   1420.1199999999953,
+				OutSeconds:  2767.439999999988,
+				SequenceIn:  0,
+				SequenceOut: 0,
+				AudioFiles: map[string]*AudioFile{
+					"nor": {
+						VXID:    "VX-489605",
+						Streams: []int{2},
+						File:    "/dummy/file.wav",
+					},
 				},
+				SubtitleFiles:      map[string]string{},
+				JSONTranscriptFile: "",
+				VXID:               "VX-489598",
 			},
-			SubtitleFiles:      map[string]string{},
-			JSONTranscriptFile: "",
-			VXID:               "VX-489598",
+		},
+		{
+			{
+				VideoFile:   "/dummy/file.mp4",
+				InSeconds:   3750.9199999999983,
+				OutSeconds:  3906.87999999999,
+				SequenceIn:  0,
+				SequenceOut: 0,
+				AudioFiles: map[string]*AudioFile{
+					"nor": {
+						VXID:    "VX-489605",
+						Streams: []int{2},
+						File:    "/dummy/file.wav",
+					},
+				},
+				SubtitleFiles:      map[string]string{},
+				JSONTranscriptFile: "",
+				VXID:               "VX-489598",
+			},
 		},
 	}
 
-	if os.Getenv("VIDISPINE_BASE_URL") == "" {
-		t.Skip("VIDISPINE_BASE_URL is not set")
-	}
+	for _, clips := range testData {
 
-	client := vsapi.NewClient(
-		os.Getenv("VIDISPINE_BASE_URL"),
-		os.Getenv("VIDISPINE_USERNAME"),
-		os.Getenv("VIDISPINE_PASSWORD"),
-	)
-	out, err := GetChapterMetaForClips(client, clips)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, out)
-	assert.Len(t, out, 1)
+		client := vsapi.NewClient(
+			os.Getenv("VIDISPINE_BASE_URL"),
+			os.Getenv("VIDISPINE_USERNAME"),
+			os.Getenv("VIDISPINE_PASSWORD"),
+		)
+		out, err := GetChapterMetaForClips(client, clips)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, out)
+		assert.Len(t, out, 1)
 
-	for i, chapter := range out {
-		assert.GreaterOrEqual(t, len(chapter.Meta.Terse["title"]), 1, "Chapter in loop iteration %d has no title", i)
+		for i, chapter := range out {
+			assert.GreaterOrEqual(t, len(chapter.Meta.Terse["title"]), 1, "Chapter in loop iteration %d has no title", i)
+		}
 	}
 }


### PR DESCRIPTION
After much back and forth, confusion and chaos I think this works. Tested on 2 real cases.
The solution is to essentially ignore chapters that are less than 10s long, as it makes no sense to have them as chapters in any case.