### PR TITLE
fix: sort qualities in smil with 540 first, then ascending

### DIFF
--- a/workflows/export/mux_files_test.go
+++ b/workflows/export/mux_files_test.go
@@ -1,14 +1,15 @@
 package export
 
 import (
-	"github.com/bcc-code/bcc-media-flows/utils"
 	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/utils"
 
 	"github.com/davecgh/go-spew/spew"
 )
 
 func Test_getQualitiesWithLanguages(t *testing.T) {
-	l := getQualitiesWithLanguages([]string{"en", "no"}, []utils.Resolution{
+	l := assignLanguagesToResolutions([]string{"en", "no"}, []utils.Resolution{
 		{
 			Width:  1920,
 			Height: 1080,

--- a/workflows/export/vx_export_vod.go
+++ b/workflows/export/vx_export_vod.go
@@ -73,6 +73,7 @@ func VXExportToVOD(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 		params:                 params,
 		filesSelector:          workflow.NewSelector(ctx),
 		qualitiesWithLanguages: assignLanguagesToResolutions(audioKeys, params.ParentParams.Resolutions),
+		smilVideos:             make(map[resolutionString]smil.Video),
 	}
 
 	onVideoCreated := func(f workflow.Future, resolution utils.Resolution) {


### PR DESCRIPTION
This should fix #311

Switched to using a slice instead of a map and sort it how we want before assigning the languages.
This should fix any race conditions or whatever was causing this.

I also want to sort with 540p at the top so thats why we have to handle the sorting at the "assignLanguages" stage. See code.

NOT TESTED at all!! I dont have a local setup. you can consider this a draft you can build upon or whatever.
I just had some extra time