### PR TITLE
Only keep one transcribed subtitle

### DIFF
--- a/workflows/misc/transcribe-vx.go
+++ b/workflows/misc/transcribe-vx.go
@@ -80,6 +80,7 @@ func TranscribeVX(
 			AssetID:  params.VXID,
 			FilePath: transcriptionJob.JSONPath,
 			ShapeTag: "transcription_json",
+			Replace:  true,
 		})
 
 	importSRTJob := wfutils.Execute(ctx, activities.Vidispine.ImportFileAsShapeActivity,
@@ -87,6 +88,7 @@ func TranscribeVX(
 			AssetID:  params.VXID,
 			FilePath: transcriptionJob.SRTPath,
 			ShapeTag: "Transcribed_Subtitle_SRT",
+			Replace:  true,
 		})
 
 	var errs []error


### PR DESCRIPTION
I came across this while doing something else and remember we talked before about only keeping the newest transcription so it is not ambiguous what version will be used in exports etc.