### PR TITLE
Change AAC encoder to provide CBR

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -80,6 +81,23 @@ func main() {
 		panic(err)
 	}
 
+	if environment.GetQueue() == environment.QueueAudio {
+		// Test if the libfdk_aac encoder is available
+		cmd := exec.Command("ffmpeg", "-xerror",
+			"-f", "lavfi", "-xerror",
+			"-i", "sine=frequency=1000:duration=0.1",
+			"-c:a", "libfdk_aac",
+			"-f", "null", "-")
+
+		err := cmd.Run()
+		if err != nil {
+			panic(err)
+		}
+
+		if cmd.ProcessState.ExitCode() != 0 {
+			panic("audio worker must support ffmpeg with libfdk_aac")
+		}
+	}
 	workerOptions := worker.Options{
 		DeadlockDetectionTimeout:           time.Hour * 3,
 		DisableRegistrationAliasing:        true, // Recommended according to readme, default false for backwards compatibility

--- a/services/transcode/audio.go
+++ b/services/transcode/audio.go
@@ -108,7 +108,7 @@ func AudioAac(input common.AudioInput, cb ffmpeg.ProgressCallback) (*common.Audi
 		"-progress", "pipe:1",
 		"-hide_banner",
 		"-i", input.Path.Local(),
-		"-c:a", "aac",
+		"-c:a", "libfdk_aac",
 		"-b:a", input.Bitrate,
 	}
 
@@ -292,7 +292,6 @@ func AudioMP3(input common.AudioInput, cb ffmpeg.ProgressCallback) (*common.Audi
 	} else {
 		params = append(params, "-q:a", fmt.Sprint(getQfactorFromBitrate(input.Bitrate)))
 	}
-
 
 	outputFilePath := filepath.Join(input.DestinationPath.Local(), input.Path.Base())
 	outputFilePath = fmt.Sprintf("%s-%s.mp3", outputFilePath[:len(outputFilePath)-len(filepath.Ext(outputFilePath))], input.Bitrate)


### PR DESCRIPTION
According to https://trac.ffmpeg.org/wiki/Encode/AAC#fdk_cbr we must use the fdk encoder. This is available in our docker image but on the bare metal installations. Thus I added a check for that.

Because we do not want the system to crash late if the encoder is not available we do a check at the startup of the worker if it is an audio worker.