### PR TITLE
Wait for Mediabanken to see file before triggering import

### DIFF
--- a/activities/vidispine/files.go
+++ b/activities/vidispine/files.go
@@ -3,6 +3,7 @@ package vsactivity
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsapi"
@@ -188,4 +189,42 @@ func (a Activities) CloseFile(ctx context.Context, params CloseFileParams) (any,
 	vsClient := GetClient()
 
 	return nil, vsClient.UpdateFileState(params.FileID, vsapi.FileStateClosed)
+}
+
+type WaitForFileVisibleInStorageParams struct {
+	FilePath  paths.Path
+	StorageID string
+}
+
+// WaitForFileVisibleInStorageActivity polls Vidispine until it can see a file
+// at params.FilePath on the given storage. This gates the import job on
+// Mediabanken having stat'd the file from its own NFS mount, since the
+// bccm-flows worker's view of the storage can be ahead of Mediabanken's.
+//
+// The caller bounds the wait via the activity's StartToCloseTimeout.
+func (a Activities) WaitForFileVisibleInStorageActivity(ctx context.Context, params WaitForFileVisibleInStorageParams) (any, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Info("Starting WaitForFileVisibleInStorageActivity")
+
+	storageID := params.StorageID
+	if storageID == "" {
+		storageID = vsapi.DefaultStorageID
+	}
+
+	vsClient := GetClient()
+	for {
+		exists, err := vsClient.FileExistsInStorage(storageID, params.FilePath.Local())
+		if err != nil {
+			return nil, err
+		}
+		if exists {
+			return nil, nil
+		}
+		activity.RecordHeartbeat(ctx, nil)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(15 * time.Second):
+		}
+	}
 }

--- a/services/vidispine/service.go
+++ b/services/vidispine/service.go
@@ -37,6 +37,7 @@ type Client interface {
 	GetTrash() ([]string, error)
 
 	RegisterFile(filePath string, state vsapi.FileState) (string, error)
+	FileExistsInStorage(storageID, absoluteFilePath string) (bool, error)
 
 	SearchByMetadataField(name, value string) ([]string, error)
 	SetItemMetadataField(params vsapi.ItemMetadataFieldParams) error

--- a/services/vidispine/vsapi/files_paths.go
+++ b/services/vidispine/vsapi/files_paths.go
@@ -115,6 +115,41 @@ func (c *Client) ListFilesForStorage(
 	return result.Result().(*FileSearchResult), nil
 }
 
+// FileExistsInStorage returns true if Vidispine knows about a file at
+// absoluteFilePath on the given storage. It is used to gate operations on the
+// fact that Mediabanken has stat'd the file from its own mount of the storage,
+// since NFS metadata caching can lag the worker host's view by minutes.
+func (c *Client) FileExistsInStorage(storageID, absoluteFilePath string) (bool, error) {
+	storagePath, err := c.GetAbsoluteStoragePath(storageID)
+	if err != nil {
+		return false, err
+	}
+	relPath := strings.TrimPrefix(absoluteFilePath, storagePath)
+
+	requestURL, _ := url.Parse(c.baseURL)
+	requestURL.Path += "/storage/" + url.PathEscape(storageID) + "/file"
+	q := requestURL.Query()
+	q.Set("path", relPath)
+	q.Set("recursive", "false")
+	q.Set("number", "10")
+	requestURL.RawQuery = q.Encode()
+
+	result, err := c.restyClient.R().
+		SetResult(&FileSearchResult{}).
+		Get(requestURL.String())
+	if err != nil {
+		return false, err
+	}
+
+	res := result.Result().(*FileSearchResult)
+	for _, f := range res.Files {
+		if f.Path == relPath {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (c *Client) MoveFile(fileID string, newStorageID string, newName string) (*JobDocument, error) {
 	fileID = url.PathEscape(fileID)
 	newStorageID = url.PathEscape(newStorageID)

--- a/services/vidispine/vsmock/mock_Client.go
+++ b/services/vidispine/vsmock/mock_Client.go
@@ -158,6 +158,21 @@ func (mr *MockClientMockRecorder) DeleteShape(assetID, shapeID any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteShape", reflect.TypeOf((*MockClient)(nil).DeleteShape), assetID, shapeID)
 }
 
+// FileExistsInStorage mocks base method.
+func (m *MockClient) FileExistsInStorage(storageID, absoluteFilePath string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FileExistsInStorage", storageID, absoluteFilePath)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FileExistsInStorage indicates an expected call of FileExistsInStorage.
+func (mr *MockClientMockRecorder) FileExistsInStorage(storageID, absoluteFilePath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileExistsInStorage", reflect.TypeOf((*MockClient)(nil).FileExistsInStorage), storageID, absoluteFilePath)
+}
+
 // FindJob mocks base method.
 func (m *MockClient) FindJob(itemID, jobType string) (*vsapi.JobDocument, error) {
 	m.ctrl.T.Helper()

--- a/utils/workflows/vidispine.go
+++ b/utils/workflows/vidispine.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bcc-code/bcc-media-flows/activities"
 	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
+	"github.com/bcc-code/bcc-media-flows/paths"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -21,6 +22,20 @@ func WaitForVidispineJob(ctx workflow.Context, jobID string) error {
 	ctx = workflow.WithActivityOptions(ctx, options)
 	return Execute(ctx, activities.Vidispine.JobCompleteOrErr, vsactivity.WaitForJobCompletionParams{
 		JobID: jobID,
+	}).Wait(ctx)
+}
+
+// WaitForFileVisibleInVidispineStorage blocks until Vidispine can see the file
+// on its default storage (i.e. Mediabanken has stat'd it through its own NFS
+// mount). Use after writing to Isilon and before kicking off a Vidispine import
+// job, to avoid the worker-host vs. Mediabanken-host visibility race.
+func WaitForFileVisibleInVidispineStorage(ctx workflow.Context, file paths.Path) error {
+	options := GetDefaultActivityOptions()
+	options.StartToCloseTimeout = 10 * time.Minute
+	options.HeartbeatTimeout = 1 * time.Minute
+	ctx = workflow.WithActivityOptions(ctx, options)
+	return Execute(ctx, activities.Vidispine.WaitForFileVisibleInStorageActivity, vsactivity.WaitForFileVisibleInStorageParams{
+		FilePath: file,
 	}).Wait(ctx)
 }
 

--- a/workflows/ingest/asset_ingest_test.go
+++ b/workflows/ingest/asset_ingest_test.go
@@ -159,6 +159,9 @@ func (s *UnitTestSuite) Test_VBBulk_MasterFlow() {
 		Once().
 		Return(&vsactivity.CreatePlaceholderResult{AssetID: "VBBulk2"}, nil)
 
+	s.env.OnActivity(activities.Vidispine.WaitForFileVisibleInStorageActivity, mock.Anything, mock.Anything).
+		Return(nil, nil)
+
 	s.env.OnActivity(activities.Vidispine.ImportFileAsShapeActivity, mock.Anything, vsactivity.ImportFileAsShapeParams{
 		AssetID:  "VBBulk1",
 		FilePath: paths.MustParse("./testdata/generated/VBBulk_output/VBBulk1.mxf"),

--- a/workflows/ingest/common.go
+++ b/workflows/ingest/common.go
@@ -32,6 +32,12 @@ func ImportFileAsTag(ctx workflow.Context, tag string, path paths.Path, title st
 	if err != nil {
 		return nil, err
 	}
+	// Mediabanken mounts the storage separately from the worker host and can
+	// lag behind by minutes due to NFS metadata caching. Wait until Vidispine
+	// can see the file from its own mount before kicking off the import job.
+	if err = wfutils.WaitForFileVisibleInVidispineStorage(ctx, path); err != nil {
+		return nil, err
+	}
 	var job vsactivity.JobResult
 	err = wfutils.Execute(ctx, activities.Vidispine.ImportFileAsShapeActivity, vsactivity.ImportFileAsShapeParams{
 		AssetID:  result.AssetID,


### PR DESCRIPTION
This should not be merged before Monday as I have to validate that it does not have significant adverse effects on the speed of all imports.

Mediabanken mounts the storage independently from the bccm-flows worker. After rclone reports the move complete, the file can still be invisible to Mediabanken for seconds-to-minutes due to NFS metadata caching, which races the Vidispine import job and causes raw imports to fail intermittently.

ImportFileAsTag now polls Vidispine for file visibility on its own storage between placeholder creation and the import shape activity. One insertion covers raw_material, masters, multitrack, bmm_simple_upload, and bmm_track_metadata.