### PR TITLE
Modernize and fix workflow notification emails

### DIFF
--- a/activities/email.go
+++ b/activities/email.go
@@ -9,7 +9,7 @@ import (
 func (ua UtilActivities) SendEmail(_ context.Context, msg emails.Message) (any, error) {
 	var errors []error
 	for _, email := range msg.To {
-		err := emails.Send(email, msg.Subject, msg.HTML)
+		err := emails.Send(email, msg.Subject, msg.PlainText, msg.HTML)
 		if err != nil {
 			errors = append(errors, err)
 		}

--- a/services/emails/send.go
+++ b/services/emails/send.go
@@ -9,12 +9,26 @@ import (
 	"github.com/sendgrid/sendgrid-go/helpers/mail"
 )
 
-func Send(email string, subject string, messageHTML string) error {
+func Send(email string, subject string, messagePlainText string, messageHTML string) error {
 	client := sendgrid.NewSendClient(os.Getenv("SENDGRID_API_KEY"))
 	from := mail.NewEmail("Workflows", "workflows@em5370.brunstad.tv")
 	to := mail.NewEmail(email, email)
 
-	m := mail.NewV3MailInit(from, subject, to, mail.NewContent("text/html", messageHTML))
+	m := mail.NewV3Mail()
+	m.SetFrom(from)
+	m.Subject = subject
+
+	p := mail.NewPersonalization()
+	p.AddTos(to)
+	m.AddPersonalizations(p)
+
+	// Order matters: per RFC 2046 the plain text alternative must come before
+	// the HTML one so clients pick the richest part they support.
+	if messagePlainText != "" {
+		m.AddContent(mail.NewContent("text/plain", messagePlainText))
+	}
+	m.AddContent(mail.NewContent("text/html", messageHTML))
+
 	res, err := client.Send(m)
 	if err != nil {
 		return err

--- a/services/notifications/import_completed.go
+++ b/services/notifications/import_completed.go
@@ -3,13 +3,12 @@ package notifications
 import (
 	_ "embed"
 	"fmt"
-	"html/template"
 )
 
 var (
 	//go:embed templates/import_completed.gohtml
 	importCompletedTemplateString string
-	importCompletedTemplate       = template.Must(template.New("import_completed").Parse(importCompletedTemplateString))
+	importCompletedTemplate       = mustEmailTemplate("import_completed", importCompletedTemplateString)
 )
 
 type ImportCompleted struct {

--- a/services/notifications/import_failed.go
+++ b/services/notifications/import_failed.go
@@ -3,13 +3,12 @@ package notifications
 import (
 	_ "embed"
 	"fmt"
-	"html/template"
 )
 
 var (
 	//go:embed templates/import_failed.gohtml
 	importFailedTemplateString string
-	importFailedTemplate       = template.Must(template.New("import_failed").Parse(importFailedTemplateString))
+	importFailedTemplate       = mustEmailTemplate("import_failed", importFailedTemplateString)
 )
 
 type ImportFailed struct {

--- a/services/notifications/import_triggered.go
+++ b/services/notifications/import_triggered.go
@@ -1,0 +1,67 @@
+package notifications
+
+import (
+	_ "embed"
+	"fmt"
+	"strings"
+)
+
+var (
+	//go:embed templates/import_triggered.gohtml
+	importTriggeredTemplateString string
+	importTriggeredTemplate       = mustEmailTemplate("import_triggered", importTriggeredTemplateString)
+)
+
+// DetailRow is a single label/value pair shown in the import-triggered email.
+type DetailRow struct {
+	Label string
+	Value string
+}
+
+// ImportTriggered notifies the uploader that an import has started. It renders
+// the order form metadata as a readable table (HTML) and list (plain text)
+// instead of dumping the raw order form name.
+type ImportTriggered struct {
+	OrderForm  string
+	Filename   string
+	UploadedBy string
+	UploadedAt string
+	Details    []DetailRow
+}
+
+func (t ImportTriggered) RenderHTML() (string, error) {
+	return renderHtmlTemplate(importTriggeredTemplate, t)
+}
+
+func (t ImportTriggered) RenderMarkdown() (string, error) {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "Import started: %s\n\n", t.OrderForm)
+	b.WriteString("Your upload has been received and an import has been started.\n\n")
+
+	if t.Filename != "" {
+		fmt.Fprintf(&b, "File: %s\n", t.Filename)
+	}
+	if t.UploadedBy != "" {
+		fmt.Fprintf(&b, "Uploaded by: %s\n", t.UploadedBy)
+	}
+	if t.UploadedAt != "" {
+		fmt.Fprintf(&b, "Uploaded at: %s\n", t.UploadedAt)
+	}
+
+	if len(t.Details) > 0 {
+		b.WriteString("\nDetails:\n")
+		for _, d := range t.Details {
+			if d.Value == "" {
+				continue
+			}
+			fmt.Fprintf(&b, "- %s: %s\n", d.Label, d.Value)
+		}
+	}
+
+	return b.String(), nil
+}
+
+func (t ImportTriggered) Subject() string {
+	return fmt.Sprintf("Import started: %s", t.OrderForm)
+}

--- a/services/notifications/import_triggered_test.go
+++ b/services/notifications/import_triggered_test.go
@@ -1,0 +1,86 @@
+package notifications
+
+import (
+	"strings"
+	"testing"
+)
+
+func sampleOslofjord() ImportTriggered {
+	return ImportTriggered{
+		OrderForm:  "LED-Material",
+		Filename:   "wallhaven-3lok9v.png",
+		UploadedBy: "uploader@example.com",
+		UploadedAt: "2026-06-19T10:30:00Z",
+		Details: []DetailRow{
+			{Label: "Name", Value: "Sommerstevne 2026"},
+			{Label: "Event", Value: "TC01"},
+			{Label: "Sub-event", Value: "E01"},
+			{Label: "Post", Value: "123"},
+			{Label: "Type", Value: "LED"},
+		},
+	}
+}
+
+func TestImportTriggered_Subject(t *testing.T) {
+	if got, want := sampleOslofjord().Subject(), "Import started: LED-Material"; got != want {
+		t.Errorf("Subject() = %q, want %q", got, want)
+	}
+}
+
+func TestImportTriggered_RenderMarkdown(t *testing.T) {
+	got, err := sampleOslofjord().RenderMarkdown()
+	if err != nil {
+		t.Fatalf("RenderMarkdown() error: %v", err)
+	}
+
+	for _, want := range []string{
+		"Import started: LED-Material",
+		"File: wallhaven-3lok9v.png",
+		"Uploaded by: uploader@example.com",
+		"- Name: Sommerstevne 2026",
+		"- Event: TC01",
+		"- Type: LED",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("plain text missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
+func TestImportTriggered_RenderMarkdownSkipsEmptyDetails(t *testing.T) {
+	n := ImportTriggered{
+		OrderForm: "LED-Material",
+		Details: []DetailRow{
+			{Label: "Name", Value: "Present"},
+			{Label: "Post", Value: ""},
+		},
+	}
+	got, err := n.RenderMarkdown()
+	if err != nil {
+		t.Fatalf("RenderMarkdown() error: %v", err)
+	}
+	if strings.Contains(got, "Post") {
+		t.Errorf("empty detail row should be omitted, got:\n%s", got)
+	}
+}
+
+func TestImportTriggered_RenderHTML(t *testing.T) {
+	got, err := sampleOslofjord().RenderHTML()
+	if err != nil {
+		t.Fatalf("RenderHTML() error: %v", err)
+	}
+
+	for _, want := range []string{
+		"<!DOCTYPE html>",
+		"Import started",
+		"LED-Material",
+		"wallhaven-3lok9v.png",
+		"Sommerstevne 2026",
+		"Sub-event",
+		"uploader@example.com",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("HTML missing %q", want)
+		}
+	}
+}

--- a/services/notifications/simple.go
+++ b/services/notifications/simple.go
@@ -2,13 +2,12 @@ package notifications
 
 import (
 	_ "embed"
-	"html/template"
 )
 
 var (
 	//go:embed templates/simple_notification.gohtml
 	simpleNotificationTemplateFS string
-	simpleNotificationTemplate   = template.Must(template.New("simple_notification").Parse(simpleNotificationTemplateFS))
+	simpleNotificationTemplate   = mustEmailTemplate("simple_notification", simpleNotificationTemplateFS)
 )
 
 type Simple struct {
@@ -27,7 +26,7 @@ func (t Simple) Subject() string {
 func (t Simple) RenderMarkdown() (string, error) {
 	var markdown string
 	if t.Title != "" {
-		markdown += "#" + t.Title + "\n\n"
+		markdown += "# " + t.Title + "\n\n"
 	}
 	if t.Message != "" {
 		markdown += t.Message

--- a/services/notifications/template.go
+++ b/services/notifications/template.go
@@ -1,7 +1,23 @@
 package notifications
 
+import (
+	_ "embed"
+	"html/template"
+)
+
 type Template interface {
 	RenderHTML() (string, error)
 	RenderMarkdown() (string, error)
 	Subject() string
+}
+
+//go:embed templates/partials.gohtml
+var emailPartials string
+
+// mustEmailTemplate parses a notification body together with the shared
+// "header"/"footer" partials so every email shares one branded, email-client
+// safe layout. The body is the loose content of template `name`; it invokes
+// the partials via {{template "header" .}} / {{template "footer" .}}.
+func mustEmailTemplate(name, body string) *template.Template {
+	return template.Must(template.New(name).Parse(emailPartials + body))
 }

--- a/services/notifications/templates/import_completed.gohtml
+++ b/services/notifications/templates/import_completed.gohtml
@@ -1,38 +1,35 @@
-<!DOCTYPE html>
-<html lang="en">
-{{- /*gotype: github.com/bcc-code/bcc-media-flows/services/notifications.ImportCompleted */}}
+{{- /*gotype: github.com/bcc-code/bcc-media-flows/services/notifications.ImportCompleted */ -}}
+{{template "header" .}}
+                            <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 20px;">
+                                <tr>
+                                    <td style="background-color:#e3f6ec; color:#0b6b3a; font-size:13px; font-weight:600; padding:6px 14px; border-radius:14px;">&#10003; Completed</td>
+                                </tr>
+                            </table>
 
-<head>
-    <title>Home</title>
-</head>
+                            <p style="margin:0 0 16px; font-size:15px; line-height:1.5;">
+                                The import has completed successfully.
+                            </p>
 
-<body>
-    <div>
-        <h2>{{.Title}}</h2>
-        <p>{{.JobID}}</p>
-        <div>
-            <table>
-                <thead>
-                    <tr>
-                        <th>VX-ID</th>
-                        <th>Name</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {{ range $file := .Files }}
-                    <tr>
-                        <td>
-                            {{$file.VXID}}
-                        </td>
-                        <td>
-                            {{$file.Name}}
-                        </td>
-                    </tr>
-                    {{ end }}
-                </tbody>
-            </table>
-        </div>
-    </div>
-</body>
+                            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+                                <tr>
+                                    <td style="padding:10px 0; border-bottom:1px solid #edf0f3; font-size:13px; color:#7b8794; width:40%;">Job ID</td>
+                                    <td style="padding:10px 0; border-bottom:1px solid #edf0f3; font-size:14px; color:#1f2933;">{{.JobID}}</td>
+                                </tr>
+                            </table>
 
-</html>
+                            {{if .Files}}
+                            <p style="margin:24px 0 8px; font-size:13px; color:#7b8794; text-transform:uppercase; letter-spacing:0.06em;">Imported files</p>
+                            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+                                <tr>
+                                    <th align="left" style="padding:8px 0; border-bottom:2px solid #edf0f3; font-size:12px; color:#7b8794; text-transform:uppercase; letter-spacing:0.06em;">VX-ID</th>
+                                    <th align="left" style="padding:8px 0; border-bottom:2px solid #edf0f3; font-size:12px; color:#7b8794; text-transform:uppercase; letter-spacing:0.06em;">Name</th>
+                                </tr>
+                                {{range .Files}}
+                                <tr>
+                                    <td style="padding:10px 0; border-bottom:1px solid #edf0f3; font-size:14px; color:#1f2933;">{{.VXID}}</td>
+                                    <td style="padding:10px 0; border-bottom:1px solid #edf0f3; font-size:14px; color:#1f2933;">{{.Name}}</td>
+                                </tr>
+                                {{end}}
+                            </table>
+                            {{end}}
+{{template "footer" .}}

--- a/services/notifications/templates/import_failed.gohtml
+++ b/services/notifications/templates/import_failed.gohtml
@@ -1,40 +1,33 @@
-<!DOCTYPE html>
-<html lang="en">
-{{- /*gotype: github.com/bcc-code/bcc-media-flows/services/notifications.ImportFailed */}}
+{{- /*gotype: github.com/bcc-code/bcc-media-flows/services/notifications.ImportFailed */ -}}
+{{template "header" .}}
+                            <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 20px;">
+                                <tr>
+                                    <td style="background-color:#fdecec; color:#b3261e; font-size:13px; font-weight:600; padding:6px 14px; border-radius:14px;">&#10007; Failed</td>
+                                </tr>
+                            </table>
 
-<head>
-    <title>Home</title>
-</head>
+                            <p style="margin:0 0 16px; font-size:15px; line-height:1.5;">
+                                The import did not complete. Details are below.
+                            </p>
 
-<body>
-    <div>
-        <h2>{{.Title}}</h2>
-        <p>{{.JobID}}</p>
-        <h2 color="red">Error</h2>
-        <p>{{.Error}}</p>
-        <div>
-            <table>
-                <thead>
-                    <tr>
-                        <th>VX-ID</th>
-                        <th>Name</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {{ range $file := .Files }}
-                    <tr>
-                        <td>
-                            {{$file.VXID}}
-                        </td>
-                        <td>
-                            {{$file.Name}}
-                        </td>
-                    </tr>
-                    {{ end }}
-                </tbody>
-            </table>
-        </div>
-    </div>
-</body>
+                            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+                                <tr>
+                                    <td style="padding:10px 0; border-bottom:1px solid #edf0f3; font-size:13px; color:#7b8794; width:40%;">Job ID</td>
+                                    <td style="padding:10px 0; border-bottom:1px solid #edf0f3; font-size:14px; color:#1f2933;">{{.JobID}}</td>
+                                </tr>
+                            </table>
 
-</html>
+                            <p style="margin:24px 0 8px; font-size:13px; color:#7b8794; text-transform:uppercase; letter-spacing:0.06em;">Error</p>
+                            <div style="background-color:#fdecec; border:1px solid #f5c2c0; border-radius:6px; padding:14px 16px; font-family:'SFMono-Regular',Consolas,'Liberation Mono',Menlo,monospace; font-size:13px; color:#b3261e; white-space:pre-wrap; word-break:break-word;">{{.Error}}</div>
+
+                            {{if .Files}}
+                            <p style="margin:24px 0 8px; font-size:13px; color:#7b8794; text-transform:uppercase; letter-spacing:0.06em;">Files</p>
+                            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+                                {{range .Files}}
+                                <tr>
+                                    <td style="padding:10px 0; border-bottom:1px solid #edf0f3; font-size:14px; color:#1f2933;">{{.Name}}</td>
+                                </tr>
+                                {{end}}
+                            </table>
+                            {{end}}
+{{template "footer" .}}

--- a/services/notifications/templates/import_triggered.gohtml
+++ b/services/notifications/templates/import_triggered.gohtml
@@ -1,0 +1,40 @@
+{{- /*gotype: github.com/bcc-code/bcc-media-flows/services/notifications.ImportTriggered */ -}}
+{{template "header" .}}
+                            <p style="margin:0 0 16px; font-size:15px; line-height:1.5;">
+                                Your upload has been received and an import has been started for order form
+                                <strong>{{.OrderForm}}</strong>.
+                            </p>
+
+                            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse; margin-top:8px;">
+                                {{if .Filename}}
+                                <tr>
+                                    <td style="padding:10px 0; border-bottom:1px solid #edf0f3; font-size:13px; color:#7b8794; width:40%;">File</td>
+                                    <td style="padding:10px 0; border-bottom:1px solid #edf0f3; font-size:14px; color:#1f2933;">{{.Filename}}</td>
+                                </tr>
+                                {{end}}
+                                {{range .Details}}
+                                {{if .Value}}
+                                <tr>
+                                    <td style="padding:10px 0; border-bottom:1px solid #edf0f3; font-size:13px; color:#7b8794; width:40%;">{{.Label}}</td>
+                                    <td style="padding:10px 0; border-bottom:1px solid #edf0f3; font-size:14px; color:#1f2933;">{{.Value}}</td>
+                                </tr>
+                                {{end}}
+                                {{end}}
+                                {{if .UploadedBy}}
+                                <tr>
+                                    <td style="padding:10px 0; border-bottom:1px solid #edf0f3; font-size:13px; color:#7b8794; width:40%;">Uploaded by</td>
+                                    <td style="padding:10px 0; border-bottom:1px solid #edf0f3; font-size:14px; color:#1f2933;">{{.UploadedBy}}</td>
+                                </tr>
+                                {{end}}
+                                {{if .UploadedAt}}
+                                <tr>
+                                    <td style="padding:10px 0; font-size:13px; color:#7b8794; width:40%;">Uploaded at</td>
+                                    <td style="padding:10px 0; font-size:14px; color:#1f2933;">{{.UploadedAt}}</td>
+                                </tr>
+                                {{end}}
+                            </table>
+
+                            <p style="margin:24px 0 0; font-size:13px; line-height:1.5; color:#7b8794;">
+                                You will receive another email once the import has completed.
+                            </p>
+{{template "footer" .}}

--- a/services/notifications/templates/partials.gohtml
+++ b/services/notifications/templates/partials.gohtml
@@ -1,0 +1,37 @@
+{{define "header"}}<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>{{.Subject}}</title>
+</head>
+
+<body style="margin:0; padding:0; background-color:#f4f5f7; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; color:#1f2933;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f5f7; padding:24px 0;">
+        <tr>
+            <td align="center">
+                <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px; width:100%; background-color:#ffffff; border-radius:8px; overflow:hidden; box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+                    <tr>
+                        <td style="background-color:#1f3a5f; padding:24px 32px;">
+                            <div style="color:#ffffff; font-size:13px; letter-spacing:0.08em; text-transform:uppercase; opacity:0.75;">Mediabanken</div>
+                            <div style="color:#ffffff; font-size:22px; font-weight:600; margin-top:4px;">{{.Subject}}</div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding:32px;">{{end}}
+{{define "footer"}}</td>
+                    </tr>
+                    <tr>
+                        <td style="padding:16px 32px; background-color:#f4f5f7; font-size:12px; color:#9aa5b1;">
+                            This is an automated message from BCC Media Workflows.
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>{{end}}

--- a/services/notifications/templates/simple_notification.gohtml
+++ b/services/notifications/templates/simple_notification.gohtml
@@ -1,14 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-{{- /*gotype: github.com/bcc-code/bcc-media-flows/services/notifications.SimpleNotification */}}
-
-<head>
-    <meta charset="UTF-8">
-    <title>{{.Title}}</title>
-</head>
-
-<body>
-    <p>{{.Message}}</p>
-</body>
-
-</html>
+{{- /*gotype: github.com/bcc-code/bcc-media-flows/services/notifications.Simple */ -}}
+{{template "header" .}}
+                            <div style="margin:0; font-size:15px; line-height:1.6; white-space:pre-line;">{{.Message}}</div>
+{{template "footer" .}}

--- a/utils/workflows/notify.go
+++ b/utils/workflows/notify.go
@@ -39,10 +39,16 @@ func SendTelegramMessage(ctx workflow.Context, channel telegram.Chat, msg *teleg
 }
 
 func SendEmails(ctx workflow.Context, targets []string, subject, message string) {
-	msg, err := emails.NewMessage(notifications.Simple{
+	SendEmailTemplate(ctx, targets, notifications.Simple{
 		Title:   subject,
 		Message: message,
-	}, targets, nil, nil)
+	})
+}
+
+// SendEmailTemplate sends a rendered notification template (HTML + plain text)
+// to the given recipients.
+func SendEmailTemplate(ctx workflow.Context, targets []string, content notifications.Template) {
+	msg, err := emails.NewMessage(content, targets, nil, nil)
 
 	if err != nil {
 		workflow.GetLogger(ctx).Error("Failed to create email message", "error", err)

--- a/workflows/ingest/asset_ingest_json.go
+++ b/workflows/ingest/asset_ingest_json.go
@@ -56,7 +56,11 @@ func AssetJSON(ctx workflow.Context, params AssetJSONParams) (*AssetResult, erro
 		return strings.TrimSpace(s)
 	})
 
-	wfutils.SendEmails(ctx, targets, "Import triggered", "Order form: "+metadata.JobProperty.OrderForm)
+	if notification, ok := importTriggeredNotification(*form, metadata.JobProperty); ok {
+		wfutils.SendEmailTemplate(ctx, targets, notification)
+	} else {
+		wfutils.SendEmails(ctx, targets, "Import triggered", "Order form: "+metadata.JobProperty.OrderForm)
+	}
 
 	switch orderForm {
 	case OrderFormVBMaster, OrderFormLEDMaterial:

--- a/workflows/ingest/json_form_mapping.go
+++ b/workflows/ingest/json_form_mapping.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/bcc-code/bcc-media-flows/services/ingest"
+	"github.com/bcc-code/bcc-media-flows/services/notifications"
 )
 
 // jsonFormSpec describes how a single JSON form (identified by formKey) maps
@@ -13,6 +14,9 @@ type jsonFormSpec struct {
 	// fields maps a JSON `fields` key to a pointer to the JobProperty field it
 	// populates. Keys absent from the payload are simply left empty.
 	fields func(jp *ingest.JobProperty) map[string]*string
+	// details returns the human-readable label/value rows shown in the
+	// "import started" email for this form, in display order.
+	details func(jp ingest.JobProperty) []notifications.DetailRow
 }
 
 // jsonFormSpecs is the static registry of supported JSON form keys. Add new
@@ -28,6 +32,14 @@ var jsonFormSpecs = map[string]jsonFormSpec{
 				"title":   &jp.EpisodeTitle,
 			}
 		},
+		details: func(jp ingest.JobProperty) []notifications.DetailRow {
+			return []notifications.DetailRow{
+				{Label: "Title", Value: jp.EpisodeTitle},
+				{Label: "Project", Value: jp.ProgramID},
+				{Label: "Season", Value: jp.Season},
+				{Label: "Episode", Value: jp.Episode},
+			}
+		},
 	},
 	"oslofjord_delivery": {
 		orderForm: OrderFormLEDMaterial,
@@ -38,6 +50,15 @@ var jsonFormSpecs = map[string]jsonFormSpec{
 				"type":        &jp.AssetType,
 				"subEvent":    &jp.Episode,
 				"navn":        &jp.EpisodeTitle,
+			}
+		},
+		details: func(jp ingest.JobProperty) []notifications.DetailRow {
+			return []notifications.DetailRow{
+				{Label: "Name", Value: jp.EpisodeTitle},
+				{Label: "Event", Value: jp.ProgramID},
+				{Label: "Sub-event", Value: jp.Episode},
+				{Label: "Post", Value: jp.ProgramPost},
+				{Label: "Type", Value: jp.AssetType},
 			}
 		},
 	},
@@ -66,4 +87,26 @@ func translateJSONForm(form ingest.JSONForm) (*ingest.Metadata, OrderForm, error
 	}
 
 	return &ingest.Metadata{JobProperty: jp}, spec.orderForm, nil
+}
+
+// importTriggeredNotification builds the "import started" email content for a
+// parsed JSON form. It returns false if the form key is unknown.
+func importTriggeredNotification(form ingest.JSONForm, jp ingest.JobProperty) (notifications.ImportTriggered, bool) {
+	spec, ok := jsonFormSpecs[form.FormKey]
+	if !ok {
+		return notifications.ImportTriggered{}, false
+	}
+
+	var details []notifications.DetailRow
+	if spec.details != nil {
+		details = spec.details(jp)
+	}
+
+	return notifications.ImportTriggered{
+		OrderForm:  spec.orderForm.Value,
+		Filename:   form.OriginalFilename,
+		UploadedBy: form.UploaderEmail,
+		UploadedAt: form.UploadedAt,
+		Details:    details,
+	}, true
 }


### PR DESCRIPTION
Replace the bare "Order form: LED-Material" import-triggered email with a rich, data-driven notification, and unify all emails on one shared, email-client-safe layout.

- Send true multipart emails (text/plain + text/html). Previously the plain-text part was computed via RenderMarkdown but never sent; only HTML went out.
- Add ImportTriggered notification rendering order-form metadata as labeled rows; wire it into the JSON ingest path with per-form labels co-located with the existing field mapping. Falls back to the simple email for unknown forms.
- Extract shared header/footer partials (mustEmailTemplate) so every email shares one branded layout with proper charset/viewport meta and inline styles.
- Fix import_failed invalid <h2 color="red"> -> styled error box; drop leftover <title>Home</title> in completed/failed templates.
- Fix Simple HTML collapsing newlines (white-space:pre-line) and RenderMarkdown emitting "#Title" without a space.