### PR TITLE
Skip blank email recipients

### DIFF
--- a/activities/email.go
+++ b/activities/email.go
@@ -2,25 +2,30 @@ package activities
 
 import (
 	"context"
-	"fmt"
+	"errors"
+	"strings"
+
 	"github.com/bcc-code/bcc-media-flows/services/emails"
 )
 
 func (ua UtilActivities) SendEmail(_ context.Context, msg emails.Message) (any, error) {
-	var errors []error
+	var errs []error
 	for _, email := range msg.To {
-		err := emails.Send(email, msg.Subject, msg.PlainText, msg.HTML)
-		if err != nil {
-			errors = append(errors, err)
+		// Skip blank recipients. Recipient lists are built by splitting a
+		// comma-separated field, so trailing commas or an empty sender field
+		// yield empty entries that SendGrid rejects outright.
+		email = strings.TrimSpace(email)
+		if email == "" {
+			continue
+		}
+
+		if err := emails.Send(email, msg.Subject, msg.PlainText, msg.HTML); err != nil {
+			errs = append(errs, err)
 		}
 	}
 
-	if len(errors) > 0 {
-		errMsg := ""
-		for _, err := range errors {
-			errMsg += err.Error() + "\n"
-		}
-		return nil, fmt.Errorf("failed to send email: %s", errMsg)
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
 	}
 
 	return nil, nil

--- a/services/emails/send.go
+++ b/services/emails/send.go
@@ -3,6 +3,7 @@ package emails
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/bcc-code/bcc-media-flows/services/notifications"
 	"github.com/sendgrid/sendgrid-go"
@@ -10,6 +11,10 @@ import (
 )
 
 func Send(email string, subject string, messagePlainText string, messageHTML string) error {
+	if strings.TrimSpace(email) == "" {
+		return fmt.Errorf("recipient email is empty")
+	}
+
 	client := sendgrid.NewSendClient(os.Getenv("SENDGRID_API_KEY"))
 	from := mail.NewEmail("Workflows", "workflows@em5370.brunstad.tv")
 	to := mail.NewEmail(email, email)

--- a/workflows/ingest/asset_ingest_json.go
+++ b/workflows/ingest/asset_ingest_json.go
@@ -52,9 +52,13 @@ func AssetJSON(ctx workflow.Context, params AssetJSONParams) (*AssetResult, erro
 	// The media file sits next to the JSON sidecar.
 	mediaPath := jsonPath.Dir().Append(form.Filename)
 
-	targets := lo.Map(strings.Split(metadata.JobProperty.SenderEmail, ","), func(s string, _ int) string {
-		return strings.TrimSpace(s)
+	targets := lo.FilterMap(strings.Split(metadata.JobProperty.SenderEmail, ","), func(s string, _ int) (string, bool) {
+		s = strings.TrimSpace(s)
+		return s, s != ""
 	})
+	if len(targets) == 0 {
+		logger.Warn("No recipient email for JSON ingest; skipping notification", "orderForm", metadata.JobProperty.OrderForm)
+	}
 
 	if notification, ok := importTriggeredNotification(*form, metadata.JobProperty); ok {
 		wfutils.SendEmailTemplate(ctx, targets, notification)


### PR DESCRIPTION
A comma-separated sender field with a trailing comma or an empty sender yields empty recipient entries, which SendGrid rejects with "The to email parameter is required". Skip blank addresses in the SendEmail activity, guard Send against empty addresses, and filter empties when building the JSON ingest recipient list (logging a warning when none remain).