### PR TITLE
fix(ingest): stop IngestSyncFix hanging, and report its failures

### DIFF
--- a/utils/workflows/future_group.go
+++ b/utils/workflows/future_group.go
@@ -1,0 +1,52 @@
+package wfutils
+
+import (
+	"go.temporal.io/sdk/workflow"
+)
+
+// FutureGroup tracks the futures registered on a workflow.Selector so they can be
+// drained exactly, instead of draining a count derived from whatever inputs
+// produced them.
+//
+// Deriving that count is the trap this type exists to remove. Callbacks routinely
+// register follow-up futures of their own and return early when something fails,
+// so a count computed up front overshoots the moment anything goes wrong, and
+// Select then blocks forever waiting on a future that was never registered. Two
+// separate workflows shipped that bug (VXExportToVOD and IngestSyncFix), in both
+// cases surfacing as an export that hung until its activity timeout and then
+// reported a meaningless deadline error rather than the real failure.
+//
+// For workflow code only: it relies on workflow coroutines being cooperatively
+// scheduled on a single goroutine, so it needs no locking.
+type FutureGroup struct {
+	selector workflow.Selector
+	pending  int
+}
+
+func NewFutureGroup(ctx workflow.Context) *FutureGroup {
+	return &FutureGroup{selector: workflow.NewSelector(ctx)}
+}
+
+// Add registers a future along with the callback that handles it once it
+// resolves. Callbacks may call Add themselves; those futures get drained by the
+// same Wait.
+func (g *FutureGroup) Add(future workflow.Future, callback func(f workflow.Future)) {
+	g.pending++
+	g.selector.AddFuture(future, callback)
+}
+
+// Wait blocks until every registered future has resolved, including any that
+// callbacks register while draining. Returns immediately if nothing is pending.
+func (g *FutureGroup) Wait(ctx workflow.Context) {
+	for g.pending > 0 {
+		// Select runs exactly one ready callback, which may Add more futures and
+		// so push pending back up before we decrement it.
+		g.selector.Select(ctx)
+		g.pending--
+	}
+}
+
+// Pending reports how many registered futures have not been handled yet.
+func (g *FutureGroup) Pending() int {
+	return g.pending
+}

--- a/utils/workflows/future_group_test.go
+++ b/utils/workflows/future_group_test.go
@@ -1,0 +1,110 @@
+package wfutils_test
+
+import (
+	"testing"
+	"time"
+
+	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+type FutureGroupTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+}
+
+// groupProbeParams describes a fan-out shape to push through a FutureGroup.
+type groupProbeParams struct {
+	// Tasks holds one entry per top-level future. true means its callback
+	// registers follow-up work; false means the callback returns early without
+	// registering anything, the way real callbacks do when the work they were
+	// waiting on failed.
+	Tasks []bool
+
+	// FollowUps is how many futures a succeeding callback registers.
+	FollowUps int
+}
+
+type groupProbeResult struct {
+	Callbacks int
+	Pending   int
+}
+
+// groupProbeWorkflow reproduces the scheduling shape that broke VXExportToVOD and
+// IngestSyncFix: the top level registers a future per unit of work, and each
+// callback either registers follow-up futures or bails out early.
+//
+// The property under test is that Wait terminates for every shape. Draining a
+// count derived from the inputs instead overshoots as soon as one callback bails,
+// and Select then blocks forever on a future that was never registered.
+func groupProbeWorkflow(ctx workflow.Context, params groupProbeParams) (groupProbeResult, error) {
+	group := wfutils.NewFutureGroup(ctx)
+	callbacks := 0
+
+	for _, taskSucceeds := range params.Tasks {
+		succeeds := taskSucceeds
+		group.Add(workflow.NewTimer(ctx, time.Second), func(workflow.Future) {
+			callbacks++
+			if !succeeds {
+				return
+			}
+			for i := 0; i < params.FollowUps; i++ {
+				group.Add(workflow.NewTimer(ctx, time.Second), func(workflow.Future) {
+					callbacks++
+				})
+			}
+		})
+	}
+
+	group.Wait(ctx)
+
+	return groupProbeResult{Callbacks: callbacks, Pending: group.Pending()}, nil
+}
+
+func (s *FutureGroupTestSuite) run(params groupProbeParams) groupProbeResult {
+	env := s.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(groupProbeWorkflow, params)
+
+	s.True(env.IsWorkflowCompleted(), "workflow did not complete — Wait deadlocked")
+	s.NoError(env.GetWorkflowError())
+
+	var result groupProbeResult
+	s.NoError(env.GetWorkflowResult(&result))
+	s.Zero(result.Pending, "group should be fully drained")
+	return result
+}
+
+func (s *FutureGroupTestSuite) Test_AllTasksRegisterFollowUps() {
+	result := s.run(groupProbeParams{Tasks: []bool{true, true, true}, FollowUps: 2})
+	// 3 top-level callbacks + 3×2 follow-ups.
+	s.Equal(9, result.Callbacks)
+}
+
+// The regression: one callback bails out without registering its follow-ups.
+func (s *FutureGroupTestSuite) Test_OneCallbackBailsOut() {
+	result := s.run(groupProbeParams{Tasks: []bool{true, false, true}, FollowUps: 2})
+	// 3 top-level callbacks + 2×2 follow-ups from the two that continued.
+	s.Equal(7, result.Callbacks)
+}
+
+func (s *FutureGroupTestSuite) Test_EveryCallbackBailsOut() {
+	result := s.run(groupProbeParams{Tasks: []bool{false, false, false}, FollowUps: 2})
+	s.Equal(3, result.Callbacks)
+}
+
+func (s *FutureGroupTestSuite) Test_NoFollowUpWork() {
+	result := s.run(groupProbeParams{Tasks: []bool{true}, FollowUps: 0})
+	s.Equal(1, result.Callbacks)
+}
+
+// Nothing registered at all must return immediately rather than block.
+func (s *FutureGroupTestSuite) Test_NothingRegistered() {
+	result := s.run(groupProbeParams{FollowUps: 2})
+	s.Equal(0, result.Callbacks)
+}
+
+func TestFutureGroupTestSuite(t *testing.T) {
+	suite.Run(t, new(FutureGroupTestSuite))
+}

--- a/utils/workflows/future_group_test.go
+++ b/utils/workflows/future_group_test.go
@@ -82,7 +82,8 @@ func (s *FutureGroupTestSuite) Test_AllTasksRegisterFollowUps() {
 	s.Equal(9, result.Callbacks)
 }
 
-// The regression: one callback bails out without registering its follow-ups.
+// The case a count derived from the inputs gets wrong: one callback bails out
+// without registering its follow-ups.
 func (s *FutureGroupTestSuite) Test_OneCallbackBailsOut() {
 	result := s.run(groupProbeParams{Tasks: []bool{true, false, true}, FollowUps: 2})
 	// 3 top-level callbacks + 2×2 follow-ups from the two that continued.

--- a/workflows/export/vx_export_vod.go
+++ b/workflows/export/vx_export_vod.go
@@ -134,7 +134,7 @@ func VXExportToVOD(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	service := &vxExportVodService{
 		ingestFolder:           params.ExportData.SafeTitle + "_" + params.RunID,
 		params:                 params,
-		filesSelector:          workflow.NewSelector(ctx),
+		fileFutures:            wfutils.NewFutureGroup(ctx),
 		qualitiesWithLanguages: assignLanguagesToResolutions(audioKeys, params.ParentParams.Resolutions),
 		smilVideos:             make(map[resolutionString]smil.Video),
 	}
@@ -161,7 +161,7 @@ func VXExportToVOD(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 		onFileCreated := func(f workflow.Future) {
 			service.handleStreamWorkflowFuture(ctx, resolutionWithLanguages, f)
 		}
-		service.addFuture(future, onFileCreated)
+		service.fileFutures.Add(future, onFileCreated)
 		if resolution.IsFile {
 			for _, key := range audioKeys {
 				lang := key
@@ -171,20 +171,20 @@ func VXExportToVOD(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 				onFileCreated := func(f workflow.Future) {
 					service.handleFileWorkflowFuture(ctx, lang, resolution, f)
 				}
-				service.addFuture(future, onFileCreated)
+				service.fileFutures.Add(future, onFileCreated)
 			}
 		}
 	}
 
 	videosByQuality := getVideosByQuality(baseVideo, params.TempDir, wm, params.ParentParams.Resolutions)
-	err = doVideoTasks(ctx, service.addFuture, videosByQuality, onVideoCreated)
+	err = doVideoTasks(ctx, service.fileFutures.Add, videosByQuality, onVideoCreated)
 	if err != nil {
 		return nil, err
 	}
 
 	// Drains the video futures and, as their callbacks schedule them, the stream
 	// and translated-file futures too (fills slices, etc.).
-	service.waitForFiles(ctx)
+	service.fileFutures.Wait(ctx)
 
 	for _, task := range service.tasks {
 		err = task.Get(ctx, nil)
@@ -273,35 +273,15 @@ type vxExportVodService struct {
 	params                 VXExportChildWorkflowParams
 	ingestFolder           string
 	qualitiesWithLanguages []ResolutionWithLanguages
-	filesSelector          workflow.Selector
-	pendingFiles           int
-	smilVideos             map[resolutionString]smil.Video
-	files                  []asset.IngestFileMeta
-	tasks                  []workflow.Future
-	errs                   []error
-}
-
-// addFuture registers a future on filesSelector and counts it, so that
-// waitForFiles drains exactly the futures that were actually scheduled.
-//
-// Counting is the whole point: the number of futures cannot be derived from the
-// resolution and language lists. onVideoCreated schedules the stream and
-// translated-file futures itself and returns early when a transcode fails, so a
-// count taken from the inputs overshoots on any failure and Select then blocks
-// forever on a future that was never scheduled.
-func (v *vxExportVodService) addFuture(future workflow.Future, callback func(f workflow.Future)) {
-	v.pendingFiles++
-	v.filesSelector.AddFuture(future, callback)
-}
-
-// waitForFiles blocks until every registered future has resolved. Callbacks run
-// during Select and may register further futures; addFuture accounts for those,
-// so the loop keeps going until the whole tree of work is drained.
-func (v *vxExportVodService) waitForFiles(ctx workflow.Context) {
-	for v.pendingFiles > 0 {
-		v.filesSelector.Select(ctx)
-		v.pendingFiles--
-	}
+	// fileFutures tracks the stream and translated-file futures. onVideoCreated
+	// registers them itself and returns early when a transcode fails, so the count
+	// cannot be derived from the resolution and language lists — see
+	// wfutils.FutureGroup.
+	fileFutures *wfutils.FutureGroup
+	smilVideos  map[resolutionString]smil.Video
+	files       []asset.IngestFileMeta
+	tasks       []workflow.Future
+	errs        []error
 }
 
 func (v *vxExportVodService) setMetadataAndPublishToVOD(

--- a/workflows/export/vx_export_vod_test.go
+++ b/workflows/export/vx_export_vod_test.go
@@ -3,7 +3,6 @@ package export
 import (
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/bcc-code/bcc-media-flows/activities"
 	"github.com/bcc-code/bcc-media-flows/common"
@@ -14,116 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/testsuite"
-	"go.temporal.io/sdk/workflow"
 )
-
-type VODDrainTestSuite struct {
-	suite.Suite
-	testsuite.WorkflowTestSuite
-}
-
-// drainProbeParams describes a fan-out shape to push through
-// vxExportVodService.addFuture and waitForFiles.
-type drainProbeParams struct {
-	// Videos holds one entry per simulated video transcode. true means the
-	// callback schedules follow-up work; false means it returns early without
-	// scheduling anything, the way onVideoCreated does when a transcode fails or
-	// when no language is found for the resolution.
-	Videos []bool
-
-	// FollowUps is how many futures a succeeding callback schedules, standing in
-	// for the stream file plus one translated file per audio language.
-	FollowUps int
-}
-
-type drainProbeResult struct {
-	Callbacks int
-	Pending   int
-}
-
-// drainProbeWorkflow reproduces the scheduling shape of VXExportToVOD: the top
-// level registers one future per video, and each video callback either registers
-// follow-up futures or bails out early.
-//
-// The point of the test is that waitForFiles must terminate for every shape. A drain
-// count derived from the input lists (qualitiesWithLanguages, and Resolutions ×
-// audioKeys) overshoots as soon as any callback returns early, and Select then blocks
-// forever on a future nothing ever scheduled.
-func drainProbeWorkflow(ctx workflow.Context, params drainProbeParams) (drainProbeResult, error) {
-	service := &vxExportVodService{filesSelector: workflow.NewSelector(ctx)}
-	callbacks := 0
-
-	for _, videoSucceeds := range params.Videos {
-		succeeds := videoSucceeds
-		service.addFuture(workflow.NewTimer(ctx, time.Second), func(workflow.Future) {
-			callbacks++
-			if !succeeds {
-				return
-			}
-			for i := 0; i < params.FollowUps; i++ {
-				service.addFuture(workflow.NewTimer(ctx, time.Second), func(workflow.Future) {
-					callbacks++
-				})
-			}
-		})
-	}
-
-	service.waitForFiles(ctx)
-
-	return drainProbeResult{Callbacks: callbacks, Pending: service.pendingFiles}, nil
-}
-
-func (s *VODDrainTestSuite) run(params drainProbeParams) drainProbeResult {
-	env := s.NewTestWorkflowEnvironment()
-	env.ExecuteWorkflow(drainProbeWorkflow, params)
-
-	// The assertion that matters: the drain terminates for every shape.
-	s.True(env.IsWorkflowCompleted(), "workflow did not complete — waitForFiles deadlocked")
-	s.NoError(env.GetWorkflowError())
-
-	var result drainProbeResult
-	s.NoError(env.GetWorkflowResult(&result))
-	s.Zero(result.Pending, "pending count should be fully drained")
-	return result
-}
-
-// Every video succeeds: the baseline, where the drain count and the number of
-// scheduled futures happen to agree.
-func (s *VODDrainTestSuite) Test_AllVideosSucceed() {
-	result := s.run(drainProbeParams{Videos: []bool{true, true, true}, FollowUps: 2})
-	// 3 video callbacks + 3×2 follow-ups.
-	s.Equal(9, result.Callbacks)
-}
-
-// One failed transcode schedules no follow-ups, so a count taken from the input
-// lists overshoots by FollowUps and Select blocks forever.
-func (s *VODDrainTestSuite) Test_OneVideoFails_DoesNotDeadlock() {
-	result := s.run(drainProbeParams{Videos: []bool{true, false, true}, FollowUps: 2})
-	// 3 video callbacks + 2×2 follow-ups from the two that succeeded.
-	s.Equal(7, result.Callbacks)
-}
-
-func (s *VODDrainTestSuite) Test_AllVideosFail_DoesNotDeadlock() {
-	result := s.run(drainProbeParams{Videos: []bool{false, false, false}, FollowUps: 2})
-	s.Equal(3, result.Callbacks)
-}
-
-// A single video with no follow-up work, i.e. no IsFile resolutions and no
-// languages assigned.
-func (s *VODDrainTestSuite) Test_NoFollowUpWork() {
-	result := s.run(drainProbeParams{Videos: []bool{true}, FollowUps: 0})
-	s.Equal(1, result.Callbacks)
-}
-
-// Nothing scheduled at all must not block either.
-func (s *VODDrainTestSuite) Test_NoVideos() {
-	result := s.run(drainProbeParams{FollowUps: 2})
-	s.Equal(0, result.Callbacks)
-}
-
-func TestVODDrainTestSuite(t *testing.T) {
-	suite.Run(t, new(VODDrainTestSuite))
-}
 
 // VODExportTestSuite drives the real VXExportToVOD workflow against mocked
 // activities, so the drain fix is covered end to end and not only on the helper.

--- a/workflows/ingest/sync_fix.go
+++ b/workflows/ingest/sync_fix.go
@@ -1,7 +1,9 @@
 package ingestworkflows
 
 import (
+	"errors"
 	"fmt"
+
 	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
 	"github.com/bcc-code/bcc-media-flows/common"
 	"github.com/bcc-code/bcc-media-flows/paths"
@@ -102,7 +104,11 @@ func IngestSyncFix(ctx workflow.Context, params IngestSyncFixParams) error {
 	wfutils.SendTelegramText(ctx, telegram.ChatVOD, fmt.Sprintf("🟦 `%s`\n\nApplying adjustments to audio files.\n%dms", params.VXID, params.Adjustment))
 
 	var errs []error
-	selector := workflow.NewSelector(ctx)
+	// A FutureGroup rather than a bare selector: the copy below can fail before a
+	// future is ever registered, and the callback registers its follow-up future
+	// only once the copy is confirmed. Draining a count derived from `languages`
+	// overshot in both cases and blocked forever.
+	group := wfutils.NewFutureGroup(ctx)
 	for _, lang := range languages {
 		path := audioPaths[lang]
 		dest := outputFolder.Append(path.Base())
@@ -117,7 +123,7 @@ func IngestSyncFix(ctx workflow.Context, params IngestSyncFixParams) error {
 		}
 
 		f := wfutils.Execute(ctx, activities.Util.RcloneWaitForJob, activities.RcloneWaitForJobInput{JobID: jobID}).Future
-		selector.AddFuture(f, func(future workflow.Future) {
+		group.Add(f, func(future workflow.Future) {
 			var copied bool
 			err := future.Get(ctx, &copied)
 			if err != nil {
@@ -144,7 +150,7 @@ func IngestSyncFix(ctx workflow.Context, params IngestSyncFixParams) error {
 					Start:  float64(-samples) / float64(48000),
 				}).Future
 			}
-			selector.AddFuture(f, func(future workflow.Future) {
+			group.Add(f, func(future workflow.Future) {
 				err := future.Get(ctx, nil)
 				if err != nil {
 					errs = append(errs, err)
@@ -153,9 +159,15 @@ func IngestSyncFix(ctx workflow.Context, params IngestSyncFixParams) error {
 		})
 	}
 
-	for range languages {
-		selector.Select(ctx)
-		selector.Select(ctx)
+	group.Wait(ctx)
+
+	// Every failure above was collected into errs and then discarded by a bare
+	// `return nil`, so a run in which nothing worked still reported success and
+	// still posted the green notification.
+	if len(errs) > 0 {
+		err := errors.Join(errs...)
+		wfutils.SendTelegramText(ctx, telegram.ChatVOD, fmt.Sprintf("🟥 `%s`\n\nFailed to apply adjustments to audio files:\n```\n%s\n```", params.VXID, err.Error()))
+		return err
 	}
 
 	wfutils.SendTelegramText(ctx, telegram.ChatVOD, fmt.Sprintf("🟩 `%s`\n\nAdjustments applied to audio files.", params.VXID))

--- a/workflows/ingest/sync_fix_test.go
+++ b/workflows/ingest/sync_fix_test.go
@@ -1,0 +1,134 @@
+package ingestworkflows
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/activities"
+	"github.com/bcc-code/bcc-media-flows/paths"
+	"github.com/bcc-code/bcc-media-flows/services/telegram"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/testsuite"
+)
+
+type SyncFixTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+}
+
+func syncFixAudioPaths() map[string]paths.Path {
+	return map[string]paths.Path{
+		"nor": paths.New(paths.TempDrive, "nor.wav"),
+		"eng": paths.New(paths.TempDrive, "eng.wav"),
+	}
+}
+
+// mockCommon covers everything up to the copy loop. Adjustment is non-zero in
+// every test so the workflow skips the automatic-adjustment branch, which is a
+// separate concern from the drain.
+func (s *SyncFixTestSuite) mockCommon(env *testsuite.TestWorkflowEnvironment) {
+	env.OnActivity(activities.Vidispine.GetRelatedAudioFiles, mock.Anything, mock.Anything).Return(
+		syncFixAudioPaths(), nil).Maybe()
+
+	env.OnActivity(activities.Util.CreateFolder, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+
+	env.OnActivity(activities.Util.SendTelegramMessage, mock.Anything, mock.Anything).Return(
+		&telegram.Message{}, nil).Maybe()
+
+	// Adjustment is positive in these tests, so PrependSilence is the branch taken.
+	env.OnActivity(activities.Audio.PrependSilence, mock.Anything, mock.Anything).Return(
+		&activities.PrependSilenceOutput{}, nil).Maybe()
+	env.OnActivity(activities.Audio.TrimFile, mock.Anything, mock.Anything).Return(
+		&activities.TrimResult{}, nil).Maybe()
+}
+
+func (s *SyncFixTestSuite) execute(env *testsuite.TestWorkflowEnvironment) error {
+	env.ExecuteWorkflow(IngestSyncFix, IngestSyncFixParams{VXID: "VX-1", Adjustment: 100})
+	s.True(env.IsWorkflowCompleted(), "workflow hung instead of completing")
+	return env.GetWorkflowError()
+}
+
+// The happy path: every copy is confirmed and every adjustment applied.
+func (s *SyncFixTestSuite) Test_AllLanguagesSucceed() {
+	env := s.NewTestWorkflowEnvironment()
+	s.mockCommon(env)
+
+	env.OnActivity(activities.Util.RcloneCopyFile, mock.Anything, mock.Anything).Return(1, nil)
+	env.OnActivity(activities.Util.RcloneWaitForJob, mock.Anything, mock.Anything).Return(true, nil)
+
+	s.NoError(s.execute(env))
+}
+
+// RcloneCopyFile failing means no future is ever registered for that language, so
+// the old `2 * len(languages)` drain overshot by two and blocked forever.
+func (s *SyncFixTestSuite) Test_CopyFileFails_ReportsErrorInsteadOfHanging() {
+	env := s.NewTestWorkflowEnvironment()
+	s.mockCommon(env)
+
+	env.OnActivity(activities.Util.RcloneCopyFile, mock.Anything, mock.Anything).Return(
+		0, errors.New("rclone refused the copy"))
+
+	err := s.execute(env)
+	s.Error(err, "a failed copy must not be reported as success")
+	s.Contains(err.Error(), "rclone refused the copy")
+}
+
+// The job resolving as "not copied" is the subtler overshoot: the wait future was
+// registered, but the callback returns before registering its follow-up, so the
+// drain overshot by one.
+func (s *SyncFixTestSuite) Test_CopyNotConfirmed_ReportsErrorInsteadOfHanging() {
+	env := s.NewTestWorkflowEnvironment()
+	s.mockCommon(env)
+
+	env.OnActivity(activities.Util.RcloneCopyFile, mock.Anything, mock.Anything).Return(1, nil)
+	env.OnActivity(activities.Util.RcloneWaitForJob, mock.Anything, mock.Anything).Return(false, nil)
+
+	err := s.execute(env)
+	s.Error(err)
+	s.Contains(err.Error(), "failed to copy file")
+}
+
+// A failure in the adjustment itself was also collected and then dropped.
+func (s *SyncFixTestSuite) Test_AdjustmentFails_ReportsError() {
+	env := s.NewTestWorkflowEnvironment()
+
+	env.OnActivity(activities.Vidispine.GetRelatedAudioFiles, mock.Anything, mock.Anything).Return(
+		syncFixAudioPaths(), nil).Maybe()
+	env.OnActivity(activities.Util.CreateFolder, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	env.OnActivity(activities.Util.SendTelegramMessage, mock.Anything, mock.Anything).Return(
+		&telegram.Message{}, nil).Maybe()
+	env.OnActivity(activities.Util.RcloneCopyFile, mock.Anything, mock.Anything).Return(1, nil)
+	env.OnActivity(activities.Util.RcloneWaitForJob, mock.Anything, mock.Anything).Return(true, nil)
+	env.OnActivity(activities.Audio.PrependSilence, mock.Anything, mock.Anything).Return(
+		nil, errors.New("ffmpeg could not prepend silence"))
+
+	err := s.execute(env)
+	s.Error(err)
+	s.Contains(err.Error(), "ffmpeg could not prepend silence")
+}
+
+// Both languages failing must still report both causes, not just the first, and
+// must not hang despite the drain overshooting by four.
+func (s *SyncFixTestSuite) Test_AllLanguagesFail_ReportsEveryCause() {
+	env := s.NewTestWorkflowEnvironment()
+	s.mockCommon(env)
+
+	env.OnActivity(activities.Util.RcloneCopyFile, mock.Anything, mock.MatchedBy(
+		func(input activities.RcloneFileInput) bool { return input.Source.Base() == "nor.wav" },
+	)).Return(0, errors.New("nor copy failed"))
+
+	env.OnActivity(activities.Util.RcloneCopyFile, mock.Anything, mock.MatchedBy(
+		func(input activities.RcloneFileInput) bool { return input.Source.Base() != "nor.wav" },
+	)).Return(0, errors.New("eng copy failed"))
+
+	err := s.execute(env)
+	s.Error(err)
+	// errors.Join, not just the first failure.
+	s.Contains(err.Error(), "nor copy failed")
+	s.Contains(err.Error(), "eng copy failed")
+}
+
+func TestSyncFixTestSuite(t *testing.T) {
+	suite.Run(t, new(SyncFixTestSuite))
+}


### PR DESCRIPTION
### What

`IngestSyncFix` always performed `2×len(languages)` `Select` calls regardless of how many futures were actually added — the same deadlock as the VOD export — and then discarded the accumulated `errs` with a bare `return nil`, so **every** failure was reported as success.

### Fix

Extracts the counted-drain pattern from the PR below into `wfutils.FutureGroup` (`Add`, `Wait`, `Pending`) with its own tests, moves both `VXExportToVOD` and `IngestSyncFix` onto it, and returns `errors.Join(errs...)` with a red notification instead of `nil`.

### Verification

The three deadlock cases fail against the old code with `deadline exceeded`; the adjustment-failure case fails with *"An error is expected but got nil"* — that is the false-success path, where the count happened to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
