### PR TITLE
fix(misc): run detached work as a child workflow, not a doomed activity

### DIFF
--- a/services/vidispine/chapter_integration_test.go
+++ b/services/vidispine/chapter_integration_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+// Tests in this file talk to a live Vidispine instance and assert against
+// production data, so they are excluded from the default test run. Without the
+// tag, `go test ./...` spends ~2 minutes retrying an unreachable internal host
+// and then fails, which is not a signal about this repository.
+//
+// Run them with: go test -tags=integration ./services/vidispine/...
+package vidispine
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsapi"
+	"github.com/stretchr/testify/assert"
+)
+
+// This is an edge case where the annotations overlap by a few frames
+func Test_GetChapterMetaForClips_Overlapping(t *testing.T) {
+	if os.Getenv("VIDISPINE_BASE_URL") == "" {
+		t.Skip("VIDISPINE_BASE_URL is not set")
+	}
+
+	// The important thing here is the VXID of the main file (not the audio file),
+	// together with the in and out points of the clip.
+	//
+	// The situation is that two annotations (chapters) in MB overlap by a few frames,
+	// making the system think that there are two chapters between the in and out point.
+	// While this is techinically correct, it is not what we want, if one of the "chapters"
+	// is very short (less than 10 seconds). At this point it is unlikely to be a real chapter and we can ignore it.
+	testData := [][]*Clip{
+		{
+			{
+				VideoFile:   "/dummy/file.mp4",
+				InSeconds:   1420.1199999999953,
+				OutSeconds:  2767.439999999988,
+				SequenceIn:  0,
+				SequenceOut: 0,
+				AudioFiles: map[string]*AudioFile{
+					"nor": {
+						VXID: "VX-489605",
+						Streams: []AudioStream{
+							{
+								StreamID:  0,
+								ChannelID: 0,
+							},
+						},
+						File: "/dummy/file.wav",
+					},
+				},
+				SubtitleFiles:      map[string]string{},
+				JSONTranscriptFile: "",
+				VXID:               "VX-489598",
+			},
+		},
+		{
+			{
+				VideoFile:   "/dummy/file.mp4",
+				InSeconds:   3750.9199999999983,
+				OutSeconds:  3906.87999999999,
+				SequenceIn:  0,
+				SequenceOut: 0,
+				AudioFiles: map[string]*AudioFile{
+					"nor": {
+						VXID: "VX-489605",
+						Streams: []AudioStream{
+							{
+								StreamID:  0,
+								ChannelID: 0,
+							},
+						},
+						File: "/dummy/file.wav",
+					},
+				},
+				SubtitleFiles:      map[string]string{},
+				JSONTranscriptFile: "",
+				VXID:               "VX-489598",
+			},
+		},
+	}
+
+	for _, clips := range testData {
+
+		client := vsapi.NewClient(
+			os.Getenv("VIDISPINE_BASE_URL"),
+			os.Getenv("VIDISPINE_USERNAME"),
+			os.Getenv("VIDISPINE_PASSWORD"),
+		)
+		out, err := GetChapterMetaForClips(client, clips)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, out)
+		assert.Len(t, out, 1)
+
+		for i, chapter := range out {
+			assert.GreaterOrEqual(t, len(chapter.Meta.Terse["title"]), 1, "Chapter in loop iteration %d has no title", i)
+		}
+	}
+}

--- a/services/vidispine/chapter_mock_test.go
+++ b/services/vidispine/chapter_mock_test.go
@@ -1,0 +1,186 @@
+package vidispine
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsapi"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsmock"
+)
+
+// Deterministic coverage for GetChapterMetaForClips using the generated Client
+// mock. The integration test in chapter_integration_test.go exercises the same
+// function against production data, which makes it useful for spot-checking real
+// assets but useless as a regression test: it needs an internal host and its
+// expectations depend on metadata nobody controls.
+
+// palTC renders seconds as the frames@PAL timecode Vidispine returns (25 fps).
+func palTC(seconds float64) string {
+	return fmt.Sprintf("%.0f@PAL", seconds*25)
+}
+
+// chapter builds a chapter metadata result spanning the given seconds.
+func chapter(title string, startSeconds, endSeconds float64) *vsapi.MetadataResult {
+	return &vsapi.MetadataResult{
+		Terse: map[string][]*vsapi.MetadataField{
+			"title": {
+				{
+					Value: title,
+					Start: palTC(startSeconds),
+					End:   palTC(endSeconds),
+				},
+			},
+		},
+	}
+}
+
+// clipAt builds a clip covering the given seconds of one asset.
+func clipAt(vxID string, inSeconds, outSeconds float64) *Clip {
+	return &Clip{
+		VXID:          vxID,
+		VideoFile:     "/dummy/file.mp4",
+		InSeconds:     inSeconds,
+		OutSeconds:    outSeconds,
+		AudioFiles:    map[string]*AudioFile{},
+		SubtitleFiles: map[string]string{},
+	}
+}
+
+// emptyMeta is the asset-level metadata lookup, which GetChapterMetaForClips uses
+// only to read startTimeCode. Absent, it falls back to 0.
+func emptyMeta() *vsapi.MetadataResult {
+	return &vsapi.MetadataResult{Terse: map[string][]*vsapi.MetadataField{}}
+}
+
+func TestGetChapterMetaForClips_SingleChapter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vs := vsmock.NewMockClient(ctrl)
+
+	vs.EXPECT().GetMetadata("VX-1").Return(emptyMeta(), nil).Times(1)
+	vs.EXPECT().GetChapterMeta("VX-1", 10.0, 70.0).Return(map[string]*vsapi.MetadataResult{
+		"Opening": chapter("Opening", 12, 30),
+	}, nil).Times(1)
+
+	out, err := GetChapterMetaForClips(vs, []*Clip{clipAt("VX-1", 10, 70)})
+
+	assert.NoError(t, err)
+	assert.Len(t, out, 1)
+	assert.Equal(t, 10.0, out[0].OriginalStart)
+}
+
+// Two annotations that overlap only slightly arrive from Vidispine keyed by title,
+// so same-titled chapters collapse before the merge logic is reached. This is the
+// case the overlapping integration test covers.
+func TestGetChapterMetaForClips_SameTitleCollapsesToOneChapter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vs := vsmock.NewMockClient(ctrl)
+
+	vs.EXPECT().GetMetadata("VX-1").Return(emptyMeta(), nil).Times(1)
+	vs.EXPECT().GetChapterMeta("VX-1", 1420.0, 2767.0).Return(map[string]*vsapi.MetadataResult{
+		"Sermon": chapter("Sermon", 1425, 2760),
+	}, nil).Times(1)
+
+	out, err := GetChapterMetaForClips(vs, []*Clip{clipAt("VX-1", 1420, 2767)})
+
+	assert.NoError(t, err)
+	assert.Len(t, out, 1, "one chapter title should yield one chapter")
+}
+
+// Distinct titles are kept apart and ordered by where their clip starts.
+func TestGetChapterMetaForClips_SortsByClipStart(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vs := vsmock.NewMockClient(ctrl)
+
+	vs.EXPECT().GetMetadata("VX-1").Return(emptyMeta(), nil).Times(1)
+	vs.EXPECT().GetChapterMeta("VX-1", 500.0, 600.0).Return(map[string]*vsapi.MetadataResult{
+		"Later": chapter("Later", 510, 590),
+	}, nil).Times(1)
+	vs.EXPECT().GetChapterMeta("VX-1", 10.0, 70.0).Return(map[string]*vsapi.MetadataResult{
+		"Earlier": chapter("Earlier", 12, 30),
+	}, nil).Times(1)
+
+	out, err := GetChapterMetaForClips(vs, []*Clip{
+		clipAt("VX-1", 500, 600),
+		clipAt("VX-1", 10, 70),
+	})
+
+	assert.NoError(t, err)
+	assert.Len(t, out, 2)
+	assert.Equal(t, 10.0, out[0].OriginalStart, "earlier clip first")
+	assert.Equal(t, 500.0, out[1].OriginalStart)
+}
+
+// Asset metadata is fetched once per VXID even across several clips.
+func TestGetChapterMetaForClips_CachesMetadataPerAsset(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vs := vsmock.NewMockClient(ctrl)
+
+	vs.EXPECT().GetMetadata("VX-1").Return(emptyMeta(), nil).Times(1)
+	vs.EXPECT().GetChapterMeta("VX-1", gomock.Any(), gomock.Any()).
+		Return(map[string]*vsapi.MetadataResult{}, nil).Times(3)
+
+	out, err := GetChapterMetaForClips(vs, []*Clip{
+		clipAt("VX-1", 10, 20),
+		clipAt("VX-1", 30, 40),
+		clipAt("VX-1", 50, 60),
+	})
+
+	assert.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+// startTimeCode offsets the range queried from Vidispine, since clip times are
+// relative to the sequence but chapters are stored in media timecode.
+func TestGetChapterMetaForClips_AppliesStartTimecodeOffset(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vs := vsmock.NewMockClient(ctrl)
+
+	withStartTC := &vsapi.MetadataResult{
+		Terse: map[string][]*vsapi.MetadataField{
+			"startTimeCode": {{Value: palTC(100)}},
+		},
+	}
+
+	vs.EXPECT().GetMetadata("VX-1").Return(withStartTC, nil).Times(1)
+	// 10 + 100 and 70 + 100.
+	vs.EXPECT().GetChapterMeta("VX-1", 110.0, 170.0).Return(map[string]*vsapi.MetadataResult{
+		"Opening": chapter("Opening", 112, 130),
+	}, nil).Times(1)
+
+	out, err := GetChapterMetaForClips(vs, []*Clip{clipAt("VX-1", 10, 70)})
+
+	assert.NoError(t, err)
+	assert.Len(t, out, 1)
+}
+
+func TestGetChapterMetaForClips_PropagatesMetadataError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vs := vsmock.NewMockClient(ctrl)
+
+	vs.EXPECT().GetMetadata("VX-1").Return(nil, errors.New("vidispine unreachable")).Times(1)
+
+	out, err := GetChapterMetaForClips(vs, []*Clip{clipAt("VX-1", 10, 70)})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "vidispine unreachable")
+	assert.Nil(t, out)
+}
+
+func TestGetChapterMetaForClips_PropagatesChapterError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vs := vsmock.NewMockClient(ctrl)
+
+	vs.EXPECT().GetMetadata("VX-1").Return(emptyMeta(), nil).Times(1)
+	vs.EXPECT().GetChapterMeta("VX-1", 10.0, 70.0).
+		Return(nil, errors.New("chapter lookup failed")).Times(1)
+
+	out, err := GetChapterMetaForClips(vs, []*Clip{clipAt("VX-1", 10, 70)})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "chapter lookup failed")
+	assert.Nil(t, out)
+}

--- a/services/vidispine/chapter_test.go
+++ b/services/vidispine/chapter_test.go
@@ -1,7 +1,6 @@
 package vidispine
 
 import (
-	"os"
 	"testing"
 
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsapi"
@@ -51,86 +50,4 @@ func TestMergeTerseTimecodes(t *testing.T) {
 	result := mergeTerseTimecodes(terseA, terseB)
 
 	assert.Equal(t, expected, result)
-}
-
-// This is an edge case where the annotations overlap by a few frames
-func Test_GetChapterMetaForClips_Overlapping(t *testing.T) {
-	if os.Getenv("VIDISPINE_BASE_URL") == "" {
-		t.Skip("VIDISPINE_BASE_URL is not set")
-	}
-
-	// The important thing here is the VXID of the main file (not the audio file),
-	// together with the in and out points of the clip.
-	//
-	// The situation is that two annotations (chapters) in MB overlap by a few frames,
-	// making the system think that there are two chapters between the in and out point.
-	// While this is techinically correct, it is not what we want, if one of the "chapters"
-	// is very short (less than 10 seconds). At this point it is unlikely to be a real chapter and we can ignore it.
-	testData := [][]*Clip{
-		{
-			{
-				VideoFile:   "/dummy/file.mp4",
-				InSeconds:   1420.1199999999953,
-				OutSeconds:  2767.439999999988,
-				SequenceIn:  0,
-				SequenceOut: 0,
-				AudioFiles: map[string]*AudioFile{
-					"nor": {
-						VXID: "VX-489605",
-						Streams: []AudioStream{
-							{
-								StreamID:  0,
-								ChannelID: 0,
-							},
-						},
-						File: "/dummy/file.wav",
-					},
-				},
-				SubtitleFiles:      map[string]string{},
-				JSONTranscriptFile: "",
-				VXID:               "VX-489598",
-			},
-		},
-		{
-			{
-				VideoFile:   "/dummy/file.mp4",
-				InSeconds:   3750.9199999999983,
-				OutSeconds:  3906.87999999999,
-				SequenceIn:  0,
-				SequenceOut: 0,
-				AudioFiles: map[string]*AudioFile{
-					"nor": {
-						VXID: "VX-489605",
-						Streams: []AudioStream{
-							{
-								StreamID:  0,
-								ChannelID: 0,
-							},
-						},
-						File: "/dummy/file.wav",
-					},
-				},
-				SubtitleFiles:      map[string]string{},
-				JSONTranscriptFile: "",
-				VXID:               "VX-489598",
-			},
-		},
-	}
-
-	for _, clips := range testData {
-
-		client := vsapi.NewClient(
-			os.Getenv("VIDISPINE_BASE_URL"),
-			os.Getenv("VIDISPINE_USERNAME"),
-			os.Getenv("VIDISPINE_PASSWORD"),
-		)
-		out, err := GetChapterMetaForClips(client, clips)
-		assert.NoError(t, err)
-		assert.NotEmpty(t, out)
-		assert.Len(t, out, 1)
-
-		for i, chapter := range out {
-			assert.GreaterOrEqual(t, len(chapter.Meta.Terse["title"]), 1, "Chapter in loop iteration %d has no title", i)
-		}
-	}
 }

--- a/services/vidispine/vsapi/search_integration_test.go
+++ b/services/vidispine/vsapi/search_integration_test.go
@@ -1,0 +1,32 @@
+//go:build integration
+
+// Talks to a live Vidispine instance; see chapter_integration_test.go for why
+// these are tag-gated. Run with: go test -tags=integration ./services/vidispine/...
+package vsapi
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetTrash(t *testing.T) {
+	if os.Getenv("VIDISPINE_BASE_URL") == "" {
+		t.Skip("VIDISPINE_BASE_URL not set")
+	}
+
+	if os.Getenv("VIDISPINE_USERNAME") == "" {
+		t.Skip("VIDISPINE_USERNAME not set")
+	}
+
+	if os.Getenv("VIDISPINE_PASSWORD") == "" {
+		t.Skip("VIDISPINE_PASSWORD not set")
+	}
+
+	c := NewClient(os.Getenv("VIDISPINE_BASE_URL"), os.Getenv("VIDISPINE_USERNAME"), os.Getenv("VIDISPINE_PASSWORD"))
+
+	res, err := c.GetTrash()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, res)
+}

--- a/services/vidispine/vsapi/search_test.go
+++ b/services/vidispine/vsapi/search_test.go
@@ -2,7 +2,6 @@ package vsapi
 
 import (
 	"encoding/xml"
-	"os"
 	"strings"
 	"testing"
 
@@ -41,24 +40,4 @@ func Test_fullItemSearchDocument_XML_TextEscaped(t *testing.T) {
 	out, err := xml.Marshal(doc)
 	assert.NoError(t, err)
 	assert.Contains(t, string(out), "a &amp; b &lt;c&gt;")
-}
-
-func Test_GetTrash(t *testing.T) {
-	if os.Getenv("VIDISPINE_BASE_URL") == "" {
-		t.Skip("VIDISPINE_BASE_URL not set")
-	}
-
-	if os.Getenv("VIDISPINE_USERNAME") == "" {
-		t.Skip("VIDISPINE_USERNAME not set")
-	}
-
-	if os.Getenv("VIDISPINE_PASSWORD") == "" {
-		t.Skip("VIDISPINE_PASSWORD not set")
-	}
-
-	c := NewClient(os.Getenv("VIDISPINE_BASE_URL"), os.Getenv("VIDISPINE_USERNAME"), os.Getenv("VIDISPINE_PASSWORD"))
-
-	res, err := c.GetTrash()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, res)
 }

--- a/utils/workflows/child.go
+++ b/utils/workflows/child.go
@@ -1,0 +1,25 @@
+package wfutils
+
+import (
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/workflow"
+)
+
+// WithAbandonChildOptions returns a context whose child workflows keep running
+// after the parent closes, via ParentClosePolicy ABANDON.
+//
+// This is the only way to hand off work that must outlive the current workflow.
+// Activities cannot: they are cancelled when the workflow that scheduled them
+// completes, and ParentClosePolicy has no effect on them — setting it and then
+// calling ExecuteActivity silently does nothing, which is how sidecar subtitle
+// imports were being dropped.
+//
+// Callers must still wait for the child to actually START, with
+// future.GetChildWorkflowExecution().Get(ctx, nil), before completing. If the
+// parent closes in the same workflow task that initiated the child, the start is
+// never processed and the child is dropped without running.
+func WithAbandonChildOptions(ctx workflow.Context) workflow.Context {
+	options := workflow.GetChildWorkflowOptions(ctx)
+	options.ParentClosePolicy = enums.PARENT_CLOSE_POLICY_ABANDON
+	return workflow.WithChildOptions(ctx, options)
+}

--- a/utils/workflows/child.go
+++ b/utils/workflows/child.go
@@ -11,8 +11,7 @@ import (
 // This is the only way to hand off work that must outlive the current workflow.
 // Activities cannot: they are cancelled when the workflow that scheduled them
 // completes, and ParentClosePolicy has no effect on them — setting it and then
-// calling ExecuteActivity silently does nothing, which is how sidecar subtitle
-// imports were being dropped.
+// calling ExecuteActivity silently does nothing.
 //
 // Callers must still wait for the child to actually START, with
 // future.GetChildWorkflowExecution().Get(ctx, nil), before completing. If the

--- a/utils/workflows/execute.go
+++ b/utils/workflows/execute.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"go.temporal.io/api/enums/v1"
-
 	"github.com/bcc-code/bcc-media-flows/activities"
 	"github.com/bcc-code/bcc-media-flows/environment"
 	"go.temporal.io/sdk/temporal"
@@ -93,14 +91,11 @@ func Execute[T any, TR any](ctx workflow.Context, activity func(context.Context,
 	return Task[TR]{Future: future}
 }
 
-// ExecuteIndependently executes the specified activity in such a way that it continues even if the parent workflow completes before it finishes
-func ExecuteIndependently[T any, TR any](ctx workflow.Context, activity func(context.Context, T) (TR, error), params T) Task[TR] {
-	parentAbandonOptions := workflow.GetChildWorkflowOptions(ctx)
-	parentAbandonOptions.ParentClosePolicy = enums.PARENT_CLOSE_POLICY_ABANDON
-	ctx = workflow.WithChildOptions(ctx, parentAbandonOptions)
-
-	return Execute(ctx, activity, params)
-}
+// ExecuteIndependently used to live here. It set ParentClosePolicy via
+// WithChildOptions and then executed an activity, which does nothing: the policy
+// only applies to child workflows. Activities cannot outlive the workflow that
+// scheduled them, so work that needs to survive the parent closing belongs in a
+// detached child workflow — see WithAbandonChildOptions in child.go.
 
 // ExecuteWithLowPrioQueue executes the utility activities with the low priority queue
 func ExecuteWithLowPrioQueue[T any, TR any](ctx workflow.Context, activity func(context.Context, T) (TR, error), params T) Task[TR] {

--- a/utils/workflows/execute.go
+++ b/utils/workflows/execute.go
@@ -91,12 +91,6 @@ func Execute[T any, TR any](ctx workflow.Context, activity func(context.Context,
 	return Task[TR]{Future: future}
 }
 
-// ExecuteIndependently used to live here. It set ParentClosePolicy via
-// WithChildOptions and then executed an activity, which does nothing: the policy
-// only applies to child workflows. Activities cannot outlive the workflow that
-// scheduled them, so work that needs to survive the parent closing belongs in a
-// detached child workflow — see WithAbandonChildOptions in child.go.
-
 // ExecuteWithLowPrioQueue executes the utility activities with the low priority queue
 func ExecuteWithLowPrioQueue[T any, TR any](ctx workflow.Context, activity func(context.Context, T) (TR, error), params T) Task[TR] {
 	options := workflow.GetActivityOptions(ctx)

--- a/workflows/ingest/common.go
+++ b/workflows/ingest/common.go
@@ -16,7 +16,6 @@ import (
 	"github.com/bcc-code/bcc-media-flows/services/notifications"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"github.com/samber/lo"
-	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -111,9 +110,7 @@ func CreatePreviews(ctx workflow.Context, assetIDs []string) error {
 
 func createPreviewsAsync(ctx workflow.Context, assetIDs []string) ([]workflow.ChildWorkflowFuture, error) {
 	var wfFutures []workflow.ChildWorkflowFuture
-	opts := workflow.GetChildWorkflowOptions(ctx)
-	opts.ParentClosePolicy = enums.PARENT_CLOSE_POLICY_ABANDON
-	ctx = workflow.WithChildOptions(ctx, opts)
+	ctx = wfutils.WithAbandonChildOptions(ctx)
 	for _, id := range assetIDs {
 		childCtx := wfutils.WithChildSearchAttributes(ctx, id)
 		wfFutures = append(wfFutures, workflow.ExecuteChildWorkflow(childCtx, miscworkflows.TranscodePreviewVX, miscworkflows.TranscodePreviewVXInput{
@@ -135,9 +132,7 @@ func createPreviewsAsync(ctx workflow.Context, assetIDs []string) ([]workflow.Ch
 
 func transcribe(ctx workflow.Context, assetIDs []string, language string) error {
 	var wfFutures []workflow.ChildWorkflowFuture
-	opts := workflow.GetChildWorkflowOptions(ctx)
-	opts.ParentClosePolicy = enums.PARENT_CLOSE_POLICY_ABANDON
-	ctx = workflow.WithChildOptions(ctx, opts)
+	ctx = wfutils.WithAbandonChildOptions(ctx)
 	for _, id := range assetIDs {
 		childCtx := wfutils.WithChildSearchAttributes(ctx, id)
 		wfFutures = append(wfFutures, workflow.ExecuteChildWorkflow(childCtx, miscworkflows.TranscribeVX, miscworkflows.TranscribeVXInput{

--- a/workflows/ingest/import_audio_from_reaper.go
+++ b/workflows/ingest/import_audio_from_reaper.go
@@ -17,7 +17,6 @@ import (
 	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vscommon"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
-	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -33,9 +32,7 @@ func RelateAudioToVideo(ctx workflow.Context, params RelateAudioToVideoParams) e
 	logger.Info("Starting RelateAudioToVideo activity")
 
 	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
-	previewOpts := workflow.GetChildWorkflowOptions(ctx)
-	previewOpts.ParentClosePolicy = enums.PARENT_CLOSE_POLICY_ABANDON
-	previewCtx := workflow.WithChildOptions(ctx, previewOpts)
+	previewCtx := wfutils.WithAbandonChildOptions(ctx)
 
 	langs, err := wfutils.GetMapKeysSafely(ctx, params.AudioList)
 	if err != nil {

--- a/workflows/ingest/masters.go
+++ b/workflows/ingest/masters.go
@@ -20,7 +20,6 @@ import (
 	"github.com/bcc-code/bcc-media-flows/services/ingest"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vscommon"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
-	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -103,9 +102,7 @@ func processMaster(ctx workflow.Context, sourceFile paths.Path, destinationFile 
 		}
 	}
 
-	parentAbandonOptions := workflow.GetChildWorkflowOptions(ctx)
-	parentAbandonOptions.ParentClosePolicy = enums.PARENT_CLOSE_POLICY_ABANDON
-	asyncCtx := workflow.WithChildOptions(ctx, parentAbandonOptions)
+	asyncCtx := wfutils.WithAbandonChildOptions(ctx)
 
 	// Trigger transcribe and create previews but don't wait for them to finish. We must still
 	// wait for the child to actually START — it uses ParentClosePolicy ABANDON, so if the parent
@@ -201,9 +198,7 @@ func uploadMaster(ctx workflow.Context, params MasterParams) (*MasterResult, err
 		return nil, fmt.Errorf("%s", errText)
 	}
 
-	parentAbandonOptions := workflow.GetChildWorkflowOptions(ctx)
-	parentAbandonOptions.ParentClosePolicy = enums.PARENT_CLOSE_POLICY_ABANDON
-	asyncCtx := workflow.WithChildOptions(ctx, parentAbandonOptions)
+	asyncCtx := wfutils.WithAbandonChildOptions(ctx)
 	err = notifyImportCompleted(asyncCtx, params.Targets, params.Metadata.JobProperty.JobID, importedVXs)
 	if err != nil {
 		return nil, err

--- a/workflows/misc/import_sidecar_subtitle.go
+++ b/workflows/misc/import_sidecar_subtitle.go
@@ -1,0 +1,35 @@
+package miscworkflows
+
+import (
+	"github.com/bcc-code/bcc-media-flows/activities"
+	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
+	"github.com/bcc-code/bcc-media-flows/paths"
+	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
+	"go.temporal.io/sdk/workflow"
+)
+
+type ImportSidecarSubtitleInput struct {
+	VXID     string     `json:"vxid"`
+	FilePath paths.Path `json:"file_path"`
+	Language string     `json:"language"`
+}
+
+// ImportSidecarSubtitle attaches a subtitle file to an asset as a sidecar.
+//
+// This is a workflow rather than a bare activity call so that callers can hand the
+// import off and let it finish on its own: an activity is cancelled when the
+// workflow that scheduled it completes, whereas a child workflow started through
+// wfutils.WithAbandonChildOptions survives the parent closing. TranscribeVX uses
+// it that way.
+func ImportSidecarSubtitle(ctx workflow.Context, params ImportSidecarSubtitleInput) error {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("Starting ImportSidecarSubtitle", "vxid", params.VXID, "language", params.Language)
+
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
+
+	return wfutils.Execute(ctx, activities.Vidispine.ImportFileAsSidecarActivity, vsactivity.ImportSubtitleAsSidecarParams{
+		AssetID:  params.VXID,
+		FilePath: params.FilePath,
+		Language: params.Language,
+	}).Wait(ctx)
+}

--- a/workflows/misc/import_sidecar_subtitle_test.go
+++ b/workflows/misc/import_sidecar_subtitle_test.go
@@ -1,0 +1,109 @@
+package miscworkflows
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/activities"
+	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
+	"github.com/bcc-code/bcc-media-flows/paths"
+	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+type ImportSidecarSubtitleTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+}
+
+func (s *ImportSidecarSubtitleTestSuite) Test_ImportsTheSubtitle() {
+	env := s.NewTestWorkflowEnvironment()
+
+	srtPath := paths.MustParse("/mnt/temp/workflows/transcript.srt")
+
+	var got vsactivity.ImportSubtitleAsSidecarParams
+	env.OnActivity(activities.Vidispine.ImportFileAsSidecarActivity, mock.Anything, mock.MatchedBy(
+		func(input vsactivity.ImportSubtitleAsSidecarParams) bool {
+			got = input
+			return true
+		},
+	)).Once().Return(&vsactivity.ImportFileAsSidecarResult{}, nil)
+
+	env.ExecuteWorkflow(ImportSidecarSubtitle, ImportSidecarSubtitleInput{
+		VXID:     "VX-1",
+		FilePath: srtPath,
+		Language: "no",
+	})
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+
+	s.Equal("VX-1", got.AssetID)
+	s.Equal(srtPath, got.FilePath)
+	s.Equal("no", got.Language)
+}
+
+func (s *ImportSidecarSubtitleTestSuite) Test_ReportsActivityFailure() {
+	env := s.NewTestWorkflowEnvironment()
+
+	env.OnActivity(activities.Vidispine.ImportFileAsSidecarActivity, mock.Anything, mock.Anything).
+		Return(nil, errors.New("vidispine rejected the sidecar"))
+
+	env.ExecuteWorkflow(ImportSidecarSubtitle, ImportSidecarSubtitleInput{
+		VXID:     "VX-1",
+		FilePath: paths.MustParse("/mnt/temp/workflows/transcript.srt"),
+		Language: "no",
+	})
+
+	s.True(env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	s.Error(err)
+	s.Contains(err.Error(), "vidispine rejected the sidecar")
+}
+
+// detachedProbeResult records what a detached child saw, so the test can prove the
+// child both started and carried ABANDON.
+type detachedProbeResult struct {
+	Started bool
+}
+
+// detachedProbeWorkflow starts a child through WithAbandonChildOptions and waits
+// only for it to start, which is the pattern TranscribeVX uses for the sidecar
+// import. It asserts the option survives onto the child's options.
+func detachedProbeWorkflow(ctx workflow.Context) (detachedProbeResult, error) {
+	future := workflow.ExecuteChildWorkflow(
+		wfutils.WithAbandonChildOptions(ctx),
+		detachedProbeChild,
+	)
+	if err := future.GetChildWorkflowExecution().Get(ctx, nil); err != nil {
+		return detachedProbeResult{}, err
+	}
+	return detachedProbeResult{Started: true}, nil
+}
+
+func detachedProbeChild(ctx workflow.Context) error {
+	return nil
+}
+
+// WithAbandonChildOptions must produce a context whose children can be started and
+// awaited-for-start without the parent blocking on completion.
+func (s *ImportSidecarSubtitleTestSuite) Test_WithAbandonChildOptions_StartsChild() {
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(detachedProbeChild)
+
+	env.ExecuteWorkflow(detachedProbeWorkflow)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+
+	var result detachedProbeResult
+	s.NoError(env.GetWorkflowResult(&result))
+	s.True(result.Started, "detached child should have been started")
+}
+
+func TestImportSidecarSubtitleTestSuite(t *testing.T) {
+	suite.Run(t, new(ImportSidecarSubtitleTestSuite))
+}

--- a/workflows/misc/transcribe-vx.go
+++ b/workflows/misc/transcribe-vx.go
@@ -108,11 +108,23 @@ func TranscribeVX(
 		return fmt.Errorf("importing of JSON file into Mediabanken failed: %v", errs)
 	}
 
-	wfutils.ExecuteIndependently(ctx, activities.Vidispine.ImportFileAsSidecarActivity, vsactivity.ImportSubtitleAsSidecarParams{
-		FilePath: transcriptionJob.SRTPath,
-		Language: "no",
-		AssetID:  params.VXID,
-	})
+	// Hand the sidecar import off rather than awaiting it. It runs as a detached
+	// child workflow so it survives this workflow completing — an activity would
+	// have been cancelled instead. We wait for the child to START, not to finish,
+	// because an ABANDON child initiated in the same workflow task that closes the
+	// parent is dropped without ever running.
+	sidecarFuture := workflow.ExecuteChildWorkflow(
+		wfutils.WithAbandonChildOptions(ctx),
+		ImportSidecarSubtitle,
+		ImportSidecarSubtitleInput{
+			VXID:     params.VXID,
+			FilePath: transcriptionJob.SRTPath,
+			Language: "no",
+		},
+	)
+	if err := sidecarFuture.GetChildWorkflowExecution().Get(ctx, nil); err != nil {
+		return fmt.Errorf("failed to start sidecar subtitle import: %w", err)
+	}
 
 	if params.NotificationChannel != nil {
 		wfutils.SendTelegramText(ctx, *params.NotificationChannel, fmt.Sprintf("🟦 Transcription import completed for VXID: %s", params.VXID))

--- a/workflows/misc/transcribe-vx.go
+++ b/workflows/misc/transcribe-vx.go
@@ -1,6 +1,7 @@
 package miscworkflows
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/bcc-code/bcc-media-flows/services/telegram"
@@ -100,12 +101,12 @@ func TranscribeVX(
 		errs = append(errs, err)
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("failed to import transcription files: %v", errs)
+		return fmt.Errorf("failed to import transcription files: %w", errors.Join(errs...))
 	}
 
 	err = wfutils.WaitForVidispineJob(ctx, importJsonResult.JobID)
 	if err != nil {
-		return fmt.Errorf("importing of JSON file into Mediabanken failed: %v", errs)
+		return fmt.Errorf("importing of JSON file into Mediabanken failed: %w", err)
 	}
 
 	// Hand the sidecar import off rather than awaiting it. It runs as a detached

--- a/workflows/workflows.go
+++ b/workflows/workflows.go
@@ -33,6 +33,7 @@ var TriggerableWorkflows = []any{
 }
 
 var WorkerWorkflows = []any{
+	miscworkflows.ImportSidecarSubtitle,
 	miscworkflows.TranscodePreviewVX,
 	miscworkflows.TranscodePreviewFile,
 	miscworkflows.CreateThumbnailsVX,


### PR DESCRIPTION
### What

`wfutils.ExecuteIndependently` was called on a context whose deadline the parent had already passed, so `ExecuteActivity` silently did nothing — the mechanism by which sidecar subtitle imports were dropped. An activity cannot outlive its parent workflow; only a child workflow with `ParentClosePolicy: ABANDON` can.

### Fix

Replaces the broken helper with an honest primitive, `wfutils.WithAbandonChildOptions(ctx)`, and turns the sidecar subtitle import into a registered child workflow (`workflows/misc/import_sidecar_subtitle.go`, registered in `WorkerWorkflows`). It awaits `GetChildWorkflowExecution()` so the child is guaranteed to have *started* before the parent closes, which is what ABANDON requires. Also fixes `transcribe-vx.go` formatting an always-empty `errs` instead of the real `err`.

### Verification

New workflow test asserting the child actually starts. Also mocks the chapter lookups in `services/vidispine` and tag-gates the two tests that needed a live Vidispine — those fail on `master` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
