### PR TITLE
fix: guard the nil dereferences that panic workflow tasks

### DIFF
--- a/services/transcode/subtitles.go
+++ b/services/transcode/subtitles.go
@@ -14,9 +14,8 @@ import (
 )
 
 func SubtitleBurnIn(videoFile, subtitleFile, subtitleHeader, outputPath paths.Path, progressCallback ffmpeg.ProgressCallback) (*paths.Path, error) {
-	// The error was previously left unchecked while the dead assignment above it made
-	// assFile look initialised. CreateBurninASSFile returns (nil, err) on four paths,
-	// and assFile.Local() below dereferences it.
+	// CreateBurninASSFile returns (nil, err) on four paths, and assFile.Local() below
+	// dereferences the result, so this error must be checked.
 	assFile, err := CreateBurninASSFile(subtitleHeader, subtitleFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not create burn-in ASS file for %s: %w", subtitleFile.Local(), err)

--- a/services/transcode/subtitles.go
+++ b/services/transcode/subtitles.go
@@ -14,8 +14,13 @@ import (
 )
 
 func SubtitleBurnIn(videoFile, subtitleFile, subtitleHeader, outputPath paths.Path, progressCallback ffmpeg.ProgressCallback) (*paths.Path, error) {
-	assFile := &subtitleFile
+	// The error was previously left unchecked while the dead assignment above it made
+	// assFile look initialised. CreateBurninASSFile returns (nil, err) on four paths,
+	// and assFile.Local() below dereferences it.
 	assFile, err := CreateBurninASSFile(subtitleHeader, subtitleFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not create burn-in ASS file for %s: %w", subtitleFile.Local(), err)
+	}
 
 	params := []string{
 		"-i", videoFile.Local(),

--- a/services/transcode/subtitles_test.go
+++ b/services/transcode/subtitles_test.go
@@ -125,3 +125,26 @@ func Test_writeEvent_ThreeLines(t *testing.T) {
 	line := string(content)
 	assert.Contains(t, line, `A\NB\NC`)
 }
+
+// CreateBurninASSFile returns (nil, err) when it cannot read the header, and
+// SubtitleBurnIn used to ignore that error and then call assFile.Local() on the nil
+// pointer. A dead `assFile := &subtitleFile` above it made the variable look
+// initialised. The header read happens before any ffmpeg call, so this needs no
+// media — only a header path that does not exist.
+func Test_SubtitleBurnIn_MissingHeaderReturnsErrorNotPanic(t *testing.T) {
+	// Constructed rather than parsed: paths.MustParse only accepts the configured
+	// drive prefixes, so a t.TempDir() path would panic inside the helper.
+	videoPath := paths.Path{Drive: paths.TempDrive, Path: "burnin-test/video.mp4"}
+	// Must not be .ass, or CreateBurninASSFile returns early without reading a header.
+	subtitlePath := paths.Path{Drive: paths.TempDrive, Path: "burnin-test/subs.srt"}
+	missingHeader := paths.Path{Drive: paths.TempDrive, Path: "burnin-test/does-not-exist.ass"}
+	outputPath := paths.Path{Drive: paths.TempDrive, Path: "burnin-test"}
+
+	assert.NotPanics(t, func() {
+		out, err := SubtitleBurnIn(videoPath, subtitlePath, missingHeader, outputPath, nil)
+
+		assert.Error(t, err, "an unreadable header must be reported")
+		assert.Contains(t, err.Error(), "burn-in ASS file")
+		assert.Nil(t, out)
+	})
+}

--- a/services/transcode/subtitles_test.go
+++ b/services/transcode/subtitles_test.go
@@ -127,10 +127,9 @@ func Test_writeEvent_ThreeLines(t *testing.T) {
 }
 
 // CreateBurninASSFile returns (nil, err) when it cannot read the header, and
-// SubtitleBurnIn used to ignore that error and then call assFile.Local() on the nil
-// pointer. A dead `assFile := &subtitleFile` above it made the variable look
-// initialised. The header read happens before any ffmpeg call, so this needs no
-// media — only a header path that does not exist.
+// SubtitleBurnIn dereferences that result, so an unreadable header must surface as an
+// error rather than a panic. The header read happens before any ffmpeg call, so this
+// needs no media — only a header path that does not exist.
 func Test_SubtitleBurnIn_MissingHeaderReturnsErrorNotPanic(t *testing.T) {
 	// Constructed rather than parsed: paths.MustParse only accepts the configured
 	// drive prefixes, so a t.TempDir() path would panic inside the helper.

--- a/services/vidispine/enrich_audio_test.go
+++ b/services/vidispine/enrich_audio_test.go
@@ -10,9 +10,9 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-// An item with shapes but no "original" among them made GetShape return nil, and
-// the AudioComponent access straight after dereferenced it. Every sibling GetShape
-// call site in this package guards for nil; this one did not.
+// An item with shapes but no "original" among them makes GetShape return nil, and the
+// AudioComponent access straight after would dereference it, so the nil must be caught
+// and reported — as every GetShape call site in this package does.
 func TestEnrichClipWithEmbeddedAudio_NoOriginalShape(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	vs := vsmock.NewMockClient(ctrl)

--- a/services/vidispine/enrich_audio_test.go
+++ b/services/vidispine/enrich_audio_test.go
@@ -1,0 +1,58 @@
+package vidispine
+
+import (
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsapi"
+	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// An item with shapes but no "original" among them made GetShape return nil, and
+// the AudioComponent access straight after dereferenced it. Every sibling GetShape
+// call site in this package guards for nil; this one did not.
+func TestEnrichClipWithEmbeddedAudio_NoOriginalShape(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vs := vsmock.NewMockClient(ctrl)
+
+	// Shapes exist, just not an "original" one.
+	vs.EXPECT().GetShapes("VX-1").Return(&vsapi.ShapeResult{
+		Shape: []vsapi.Shape{
+			{Tag: []string{"lowres"}},
+		},
+	}, nil).Times(1)
+
+	clip := &Clip{
+		VXID:       "VX-1",
+		AudioFiles: map[string]*AudioFile{},
+	}
+
+	require.NotPanics(t, func() {
+		warnings, err := enrichClipWithEmbeddedAudio(vs, clip, []string{"nor"})
+
+		assert.Error(t, err, "a missing original shape must be reported, not dereferenced")
+		assert.Contains(t, err.Error(), "no original shape found")
+		assert.Contains(t, err.Error(), "VX-1", "the error should name the item")
+		assert.Nil(t, warnings)
+	})
+}
+
+// No shapes at all takes the same path.
+func TestEnrichClipWithEmbeddedAudio_NoShapesAtAll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vs := vsmock.NewMockClient(ctrl)
+
+	vs.EXPECT().GetShapes("VX-2").Return(&vsapi.ShapeResult{}, nil).Times(1)
+
+	clip := &Clip{
+		VXID:       "VX-2",
+		AudioFiles: map[string]*AudioFile{},
+	}
+
+	require.NotPanics(t, func() {
+		_, err := enrichClipWithEmbeddedAudio(vs, clip, []string{"nor"})
+		assert.Error(t, err)
+	})
+}

--- a/services/vidispine/export.go
+++ b/services/vidispine/export.go
@@ -232,8 +232,8 @@ func enrichClipWithEmbeddedAudio(client Client, clip *Clip, languagesToExport []
 
 	shape := shapes.GetShape("original")
 	if shape == nil {
-		// Every sibling GetShape call site checks this; this one did not, and the
-		// AudioComponent access below dereferences it.
+		// The AudioComponent access below dereferences the shape, so a missing original
+		// has to be reported rather than followed.
 		return nil, fmt.Errorf("no original shape found for item %s", clip.VXID)
 	}
 

--- a/services/vidispine/export.go
+++ b/services/vidispine/export.go
@@ -231,6 +231,12 @@ func enrichClipWithEmbeddedAudio(client Client, clip *Clip, languagesToExport []
 	}
 
 	shape := shapes.GetShape("original")
+	if shape == nil {
+		// Every sibling GetShape call site checks this; this one did not, and the
+		// AudioComponent access below dereferences it.
+		return nil, fmt.Errorf("no original shape found for item %s", clip.VXID)
+	}
+
 	var warnings []string
 
 	// Handle unexpected audio component counts by falling back to first 2 tracks

--- a/workflows/export/generate_short.go
+++ b/workflows/export/generate_short.go
@@ -122,6 +122,15 @@ func GenerateShort(ctx workflow.Context, params GenerateShortDataParams) (*Gener
 		return nil, err
 	}
 
+	// Everything below assumes a video: the scene-detect call takes VideoFile
+	// directly, and both Linux() and the CropShort input dereference it. paths.Path
+	// has value receivers, so even the method calls panic on a nil pointer, which
+	// fails the workflow task into an endless retry.
+	if clipResult.VideoFile == nil {
+		return nil, temporal.NewNonRetryableApplicationError(
+			"cannot generate a short without a video file", "NO_VIDEO_FILE", nil)
+	}
+
 	sceneResult, err := wfutils.Execute(ctx,
 		activities.Video.FFmpegGetSceneChanges,
 		clipResult.VideoFile,

--- a/workflows/export/isilon_export.go
+++ b/workflows/export/isilon_export.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bcc-code/bcc-media-flows/utils"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"github.com/orsinium-labs/enum"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -111,6 +112,16 @@ func IsilonExport(ctx workflow.Context, params IsilonExportParams) error {
 
 	for _, key := range audioKeys {
 		audioPaths = append(audioPaths, mergeResult.AudioFiles[key])
+	}
+
+	// Audio-only items have no VideoFile (VXExport sets MakeVideo from
+	// fileInfo.HasVideo), and dereferencing it would panic the workflow task into an
+	// endless retry loop.
+	if mergeResult.VideoFile == nil {
+		err = temporal.NewNonRetryableApplicationError(
+			"Isilon export needs a video file, but this item is audio-only", "NO_VIDEO_FILE", nil)
+		wfutils.SendTelegramErorr(ctx, telegram.ChatOther, params.VXID, err)
+		return err
 	}
 
 	switch exportFormat.Value {

--- a/workflows/export/vx_export_playout.go
+++ b/workflows/export/vx_export_playout.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bcc-code/bcc-media-flows/activities"
 	"github.com/bcc-code/bcc-media-flows/common"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -16,6 +17,15 @@ func VXExportToXDCAM(ctx workflow.Context, params VXExportChildWorkflowParams) (
 	logger.Info("Starting ExportToXDCAM")
 
 	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
+
+	// VXExport sets MakeVideo from fileInfo.HasVideo, so MergeResult.VideoFile is
+	// legitimately nil for audio-only items. Dereferencing it panics the workflow
+	// task, which Temporal retries indefinitely; a non-retryable error fails the
+	// export once with a usable message instead.
+	if params.MergeResult.VideoFile == nil {
+		return nil, temporal.NewNonRetryableApplicationError(
+			"XDCAM export needs a video file, but this item is audio-only", "NO_VIDEO_FILE", nil)
+	}
 
 	xdcamOutputDir := params.TempDir.Append("xdcam_output")
 	err := wfutils.CreateFolder(ctx, xdcamOutputDir)

--- a/workflows/export/vx_export_playout_test.go
+++ b/workflows/export/vx_export_playout_test.go
@@ -1,0 +1,76 @@
+package export
+
+import (
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/activities"
+	"github.com/bcc-code/bcc-media-flows/paths"
+	"github.com/bcc-code/bcc-media-flows/services/vidispine"
+	"github.com/bcc-code/bcc-media-flows/utils"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/testsuite"
+)
+
+type PlayoutExportTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+}
+
+func audioOnlyParams() VXExportChildWorkflowParams {
+	return VXExportChildWorkflowParams{
+		RunID:        "test-run",
+		ParentParams: VXExportParams{VXID: "VX-1", Resolutions: []utils.Resolution{{Width: 1920, Height: 1080}}},
+		ExportData:   vidispine.ExportData{Title: "Audio Only", SafeTitle: "audio_only"},
+		MergeResult: MergeExportDataResult{
+			Duration: 60,
+			// VXExport sets MakeVideo from fileInfo.HasVideo, so this is nil for
+			// audio-only items.
+			VideoFile:  nil,
+			AudioFiles: map[string]paths.Path{"nor": paths.New(paths.TempDrive, "nor.wav")},
+		},
+		TempDir:   paths.New(paths.TempDrive, "temp"),
+		OutputDir: paths.New(paths.TempDrive, "output"),
+	}
+}
+
+// Dereferencing a nil VideoFile panicked the workflow task, and Temporal retries a
+// panicking task indefinitely — so the export never failed, it just span. It must
+// fail once, with a message that says why.
+func (s *PlayoutExportTestSuite) Test_AudioOnlyItem_FailsWithoutPanicking() {
+	env := s.NewTestWorkflowEnvironment()
+	// Mocked so that, without the guard, execution reaches the
+	// *params.MergeResult.VideoFile dereference rather than stopping earlier on an
+	// unmocked activity.
+	env.OnActivity(activities.Util.CreateFolder, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+
+	env.ExecuteWorkflow(VXExportToXDCAM, audioOnlyParams())
+
+	s.True(env.IsWorkflowCompleted(), "workflow should have completed, not retried forever")
+
+	err := env.GetWorkflowError()
+	s.Require().Error(err)
+	s.Contains(err.Error(), "audio-only")
+}
+
+// The guard must not be retried: no amount of retrying will produce a video file.
+func (s *PlayoutExportTestSuite) Test_AudioOnlyItem_IsNotRetried() {
+	env := s.NewTestWorkflowEnvironment()
+	// Mocked so that, without the guard, execution reaches the
+	// *params.MergeResult.VideoFile dereference rather than stopping earlier on an
+	// unmocked activity.
+	env.OnActivity(activities.Util.CreateFolder, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+
+	env.ExecuteWorkflow(VXExportToXDCAM, audioOnlyParams())
+
+	s.True(env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	s.Require().Error(err)
+
+	// A non-retryable application error carries its type through to the caller.
+	s.Contains(err.Error(), "NO_VIDEO_FILE")
+}
+
+func TestPlayoutExportTestSuite(t *testing.T) {
+	suite.Run(t, new(PlayoutExportTestSuite))
+}

--- a/workflows/ingest/incremental_ingest.go
+++ b/workflows/ingest/incremental_ingest.go
@@ -143,7 +143,6 @@ func doIncremental(ctx workflow.Context, params IncrementalParams) error {
 	previewPath = previewPath.Append(rawPath.Base()).SetExt("mp4")
 
 	var previewFuture wfutils.Task[any]
-	var lowresImportJob *vsactivity.ImportFileResult
 	previewCtx, stopPreviewFunc := workflow.WithCancel(ctx)
 	previewActivityOpts := wfutils.GetDefaultActivityOptions()
 	previewActivityOpts.StartToCloseTimeout = time.Hour * 8
@@ -158,25 +157,34 @@ func doIncremental(ctx workflow.Context, params IncrementalParams) error {
 		})
 
 		_ = workflow.Sleep(ctx, 2*time.Minute)
-		lowresImportJob, _ = wfutils.Execute(ctx, activities.Vidispine.ImportFileAsShapeActivity, vsactivity.ImportFileAsShapeParams{
+		lowresImportJob, importErr := wfutils.Execute(ctx, activities.Vidispine.ImportFileAsShapeActivity, vsactivity.ImportFileAsShapeParams{
 			AssetID:  videoVXID,
 			FilePath: previewPath,
 			ShapeTag: "lowres_watermarked",
 			Growing:  true,
 			Replace:  false,
 		}).Result(ctx)
-
-		if err != nil {
-			logger.Error("%w", err)
+		if importErr != nil {
+			// Previously this error was discarded and the check below inspected the
+			// enclosing function's err instead, so the failure was invisible.
+			logger.Error("Failed to import growing preview as lowres shape", "error", importErr)
 		}
 
-		err := previewFuture.Wait(ctx)
-		wfutils.Execute(ctx, activities.Vidispine.CloseFile, vsactivity.CloseFileParams{
-			FileID: lowresImportJob.FileID,
-		})
+		if previewErr := previewFuture.Wait(ctx); previewErr != nil {
+			logger.Error("Growing preview transcode failed", "error", previewErr)
+		}
 
-		if err != nil {
-			logger.Error("%w", err)
+		// Only close a file the import actually produced. A failed import leaves
+		// lowresImportJob nil, and dereferencing it panics the workflow task — which
+		// Temporal then retries indefinitely.
+		if lowresImportJob == nil {
+			return
+		}
+
+		if closeErr := wfutils.Execute(ctx, activities.Vidispine.CloseFile, vsactivity.CloseFileParams{
+			FileID: lowresImportJob.FileID,
+		}).Wait(ctx); closeErr != nil {
+			logger.Error("Failed to close growing lowres file", "error", closeErr)
 		}
 	})
 

--- a/workflows/ingest/incremental_ingest.go
+++ b/workflows/ingest/incremental_ingest.go
@@ -165,8 +165,8 @@ func doIncremental(ctx workflow.Context, params IncrementalParams) error {
 			Replace:  false,
 		}).Result(ctx)
 		if importErr != nil {
-			// Previously this error was discarded and the check below inspected the
-			// enclosing function's err instead, so the failure was invisible.
+			// Named separately from the enclosing function's err so the failure cannot
+			// be hidden by a later check reading the wrong variable.
 			logger.Error("Failed to import growing preview as lowres shape", "error", importErr)
 		}
 


### PR DESCRIPTION
### What

Five nil dereferences reachable from workflow code. A panic inside `workflow.Go` fails the workflow task, which then retries forever.

- `incremental_ingest.go` — the import error is discarded with `_`, the `if err != nil` inspects an unrelated captured variable, and then `lowresImportJob.FileID` is dereferenced.
- `vx_export_playout.go`, `isilon_export.go`, `generate_short.go` — `*params.MergeResult.VideoFile`, but `VXExport` legitimately sets `MakeVideo: !bmmOnly && fileInfo.HasVideo`, so `VideoFile` is nil for audio-only items.
- `services/vidispine/export.go` — `shapes.GetShape("original")` used without the nil check every sibling call site has.
- `services/transcode/subtitles.go` — `CreateBurninASSFile`'s error is never checked before `assFile.Local()` is dereferenced, and the function returns `(nil, err)` on four paths.

### Fix

Each site now fails once — the exports with a non-retryable `NO_VIDEO_FILE` — rather than panicking the workflow task into an endless retry.

### Verification

Three of the five have tests that fail against the old code with the panic itself. The isilon, generate_short and incremental_ingest guards are untested, and marked as such in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
