### PR TITLE
fix(notify): send error notifications to the chat the caller asked for

### DIFF
--- a/utils/workflows/files.go
+++ b/utils/workflows/files.go
@@ -254,7 +254,7 @@ func RcloneWaitForFileGone(ctx workflow.Context, file paths.Path, notificationCh
 
 		template.Message = fmt.Sprintf("⚠️ File ```%s``` still exists, retrying in one minute (%d/%d)", file.Rclone(), i+1, retries)
 		msg.UpdateWithTemplate(template)
-		msg = SendTelegramMessage(ctx, notificationChannel, msg)
+		msg = SendTelegramMessage(ctx, msg)
 
 		workflow.Sleep(ctx, time.Minute)
 	}

--- a/utils/workflows/notify.go
+++ b/utils/workflows/notify.go
@@ -10,8 +10,16 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-func SendTelegramErorr(ctx workflow.Context, channel telegram.Chat, vxid string, err error) {
-	SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟥 Export of `%s` failed:\n```\n%s\n```", vxid, err.Error()))
+// SendTelegramError reports a failure to the given chat.
+//
+// vxid is optional; omit it for failures that happen before an asset exists.
+func SendTelegramError(ctx workflow.Context, channel telegram.Chat, vxid string, err error) {
+	subject := workflow.GetInfo(ctx).WorkflowType.Name
+	if vxid != "" {
+		subject += fmt.Sprintf(" of `%s`", vxid)
+	}
+
+	SendTelegramText(ctx, channel, fmt.Sprintf("🟥 %s failed:\n```\n%s\n```", subject, err.Error()))
 }
 
 func SendTelegramText(ctx workflow.Context, channel telegram.Chat, message string) {
@@ -28,7 +36,10 @@ func SendTelegramText(ctx workflow.Context, channel telegram.Chat, message strin
 	}
 }
 
-func SendTelegramMessage(ctx workflow.Context, channel telegram.Chat, msg *telegram.Message) *telegram.Message {
+// SendTelegramMessage sends an already-built message. The destination chat is
+// carried on msg itself, set when it was created with telegram.NewMessage, so no
+// channel argument is taken — an earlier signature had one and silently ignored it.
+func SendTelegramMessage(ctx workflow.Context, msg *telegram.Message) *telegram.Message {
 	msg, err := Execute(ctx, activities.Util.SendTelegramMessage, msg).Result(ctx)
 
 	if err != nil {

--- a/utils/workflows/notify_test.go
+++ b/utils/workflows/notify_test.go
@@ -1,0 +1,120 @@
+package wfutils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/activities"
+	"github.com/bcc-code/bcc-media-flows/services/telegram"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+type NotifyTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+}
+
+// The telegram package resolves ChatVOD/ChatBMM/... from TELEGRAM_CHAT_ID_* at
+// package init, so without those set every one of them is Chat{Value: 0} and they
+// are indistinguishable. Tests therefore use explicit distinct values, so an
+// assertion about routing cannot pass vacuously.
+var (
+	testChatBMM   = telegram.Chat{Value: 111}
+	testChatOther = telegram.Chat{Value: 222}
+)
+
+type sendErrorInput struct {
+	Chat telegram.Chat
+	VXID string
+	Err  string
+}
+
+func sendTelegramErrorWorkflow(ctx workflow.Context, in sendErrorInput) error {
+	ctx = workflow.WithActivityOptions(ctx, GetDefaultActivityOptions())
+	SendTelegramError(ctx, in.Chat, in.VXID, errors.New(in.Err))
+	return nil
+}
+
+// captureMessage mocks the send activity and returns a pointer to what it received.
+func (s *NotifyTestSuite) captureMessage(env *testsuite.TestWorkflowEnvironment) **telegram.Message {
+	captured := new(*telegram.Message)
+	env.OnActivity(activities.Util.SendTelegramMessage, mock.Anything, mock.MatchedBy(
+		func(msg *telegram.Message) bool {
+			*captured = msg
+			return true
+		},
+	)).Return(&telegram.Message{}, nil)
+	return captured
+}
+
+// The regression: the channel argument was ignored and telegram.ChatOther
+// hardcoded, so every BMM ingest failure was reported to the wrong chat.
+func (s *NotifyTestSuite) Test_SendTelegramError_UsesTheGivenChannel() {
+	env := s.NewTestWorkflowEnvironment()
+	captured := s.captureMessage(env)
+
+	env.ExecuteWorkflow(sendTelegramErrorWorkflow, sendErrorInput{
+		Chat: testChatBMM,
+		VXID: "VX-1",
+		Err:  "ingest blew up",
+	})
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+
+	s.Require().NotNil(*captured, "no telegram message was sent")
+	s.Equal(testChatBMM, (*captured).Chat, "must report to the chat the caller asked for")
+	s.NotEqual(testChatOther, (*captured).Chat)
+	s.Contains((*captured).Markdown, "ingest blew up")
+	s.Contains((*captured).Markdown, "VX-1")
+}
+
+// A different channel must route differently, so the first test cannot be passing
+// by coincidence.
+func (s *NotifyTestSuite) Test_SendTelegramError_RoutesPerChannel() {
+	env := s.NewTestWorkflowEnvironment()
+	captured := s.captureMessage(env)
+
+	env.ExecuteWorkflow(sendTelegramErrorWorkflow, sendErrorInput{
+		Chat: testChatOther,
+		VXID: "VX-2",
+		Err:  "export blew up",
+	})
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+
+	s.Require().NotNil(*captured)
+	s.Equal(testChatOther, (*captured).Chat)
+	s.NotEqual(testChatBMM, (*captured).Chat)
+}
+
+// Many callers have no asset yet and pass "". The message should not then contain
+// an empty quoted identifier.
+func (s *NotifyTestSuite) Test_SendTelegramError_OmitsEmptyVXID() {
+	env := s.NewTestWorkflowEnvironment()
+	captured := s.captureMessage(env)
+
+	env.ExecuteWorkflow(sendTelegramErrorWorkflow, sendErrorInput{
+		Chat: testChatBMM,
+		VXID: "",
+		Err:  "failed before the asset existed",
+	})
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+
+	s.Require().NotNil(*captured)
+	// The old message read "Export of `` failed" when vxid was empty.
+	s.NotContains((*captured).Markdown, "of `", "empty vxid should be left out entirely")
+	s.Contains((*captured).Markdown, "failed before the asset existed")
+	// The workflow type still identifies what failed.
+	s.Contains((*captured).Markdown, "sendTelegramErrorWorkflow")
+}
+
+func TestNotifyTestSuite(t *testing.T) {
+	suite.Run(t, new(NotifyTestSuite))
+}

--- a/utils/workflows/notify_test.go
+++ b/utils/workflows/notify_test.go
@@ -50,8 +50,8 @@ func (s *NotifyTestSuite) captureMessage(env *testsuite.TestWorkflowEnvironment)
 	return captured
 }
 
-// The regression: the channel argument was ignored and telegram.ChatOther
-// hardcoded, so every BMM ingest failure was reported to the wrong chat.
+// The channel argument has to reach the message: hardcoding telegram.ChatOther
+// sends every BMM ingest failure to the wrong chat.
 func (s *NotifyTestSuite) Test_SendTelegramError_UsesTheGivenChannel() {
 	env := s.NewTestWorkflowEnvironment()
 	captured := s.captureMessage(env)

--- a/workflows/export/isilon_export.go
+++ b/workflows/export/isilon_export.go
@@ -120,7 +120,7 @@ func IsilonExport(ctx workflow.Context, params IsilonExportParams) error {
 	if mergeResult.VideoFile == nil {
 		err = temporal.NewNonRetryableApplicationError(
 			"Isilon export needs a video file, but this item is audio-only", "NO_VIDEO_FILE", nil)
-		wfutils.SendTelegramErorr(ctx, telegram.ChatOther, params.VXID, err)
+		wfutils.SendTelegramError(ctx, telegram.ChatOther, params.VXID, err)
 		return err
 	}
 

--- a/workflows/export/isilon_export.go
+++ b/workflows/export/isilon_export.go
@@ -99,14 +99,14 @@ func IsilonExport(ctx workflow.Context, params IsilonExportParams) error {
 	}).Get(ctx, &mergeResult)
 
 	if err != nil {
-		wfutils.SendTelegramErorr(ctx, telegram.ChatOther, params.VXID, err)
+		wfutils.SendTelegramError(ctx, telegram.ChatOther, params.VXID, err)
 		return err
 	}
 
 	audioPaths := []paths.Path{}
 	audioKeys, err := wfutils.GetMapKeysSafely(ctx, mergeResult.AudioFiles)
 	if err != nil {
-		wfutils.SendTelegramErorr(ctx, telegram.ChatOther, params.VXID, err)
+		wfutils.SendTelegramError(ctx, telegram.ChatOther, params.VXID, err)
 		return err
 	}
 

--- a/workflows/ingest/bmm_simple_upload.go
+++ b/workflows/ingest/bmm_simple_upload.go
@@ -49,49 +49,49 @@ func BmmIngestUpload(ctx workflow.Context, params BmmSimpleUploadParams) (*BmmSi
 
 	err = wfutils.MoveFile(ctx, path, newPath, rclone.PriorityNormal)
 	if err != nil {
-		wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, "", err)
+		wfutils.SendTelegramError(ctx, telegram.ChatBMM, "", err)
 		return nil, err
 	}
 
 	res, err := ImportFileAsTag(ctx, "original", newPath, "BMM-"+strconv.Itoa(params.TrackID)+" "+params.Language+" - "+params.Title)
 	if err != nil {
-		wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, "", err)
+		wfutils.SendTelegramError(ctx, telegram.ChatBMM, "", err)
 		return nil, err
 	}
 
 	err = SetUploadedBy(ctx, res.AssetID, params.UploadedBy)
 	if err != nil {
-		wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, res.AssetID, err)
+		wfutils.SendTelegramError(ctx, telegram.ChatBMM, res.AssetID, err)
 		return nil, err
 	}
 
 	err = SetUploadJobID(ctx, res.AssetID, workflow.GetInfo(ctx).OriginalRunID)
 	if err != nil {
-		wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, res.AssetID, err)
+		wfutils.SendTelegramError(ctx, telegram.ChatBMM, res.AssetID, err)
 		return nil, err
 	}
 
 	err = wfutils.SetVidispineMeta(ctx, res.AssetID, vscommon.FieldLanguagesRecorded.Value, params.Language)
 	if err != nil {
-		wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, res.AssetID, err)
+		wfutils.SendTelegramError(ctx, telegram.ChatBMM, res.AssetID, err)
 		return nil, err
 	}
 
 	err = wfutils.SetVidispineMetaInGroup(ctx, res.AssetID, vscommon.FieldBmmTrackID.Value, strconv.Itoa(params.TrackID), "BMM Metadata")
 	if err != nil {
-		wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, res.AssetID, err)
+		wfutils.SendTelegramError(ctx, telegram.ChatBMM, res.AssetID, err)
 		return nil, err
 	}
 
 	err = wfutils.SetVidispineMetaInGroup(ctx, res.AssetID, vscommon.FieldBmmTitle.Value, params.Title, "BMM Metadata")
 	if err != nil {
-		wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, res.AssetID, err)
+		wfutils.SendTelegramError(ctx, telegram.ChatBMM, res.AssetID, err)
 		return nil, err
 	}
 
 	err = WaitForImportTag(ctx, res)
 	if err != nil {
-		wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, res.AssetID, err)
+		wfutils.SendTelegramError(ctx, telegram.ChatBMM, res.AssetID, err)
 		return nil, err
 	}
 
@@ -102,7 +102,7 @@ func BmmIngestUpload(ctx workflow.Context, params BmmSimpleUploadParams) (*BmmSi
 		Language: params.Language,
 	}).Get(ctx, nil)
 	if err != nil {
-		wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, res.AssetID, err)
+		wfutils.SendTelegramError(ctx, telegram.ChatBMM, res.AssetID, err)
 		// Continue. Just because we failed transcription we should not stop the workflow
 	}
 
@@ -122,14 +122,14 @@ func BmmIngestUpload(ctx workflow.Context, params BmmSimpleUploadParams) (*BmmSi
 
 	err = future.Get(ctx, nil)
 	if err != nil {
-		wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, res.AssetID, err)
+		wfutils.SendTelegramError(ctx, telegram.ChatBMM, res.AssetID, err)
 		return nil, err
 	}
 
 	if params.IsPodcast {
 		err = deliverToSSF(ctx, res.AssetID, newPath, params)
 		if err != nil {
-			wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, res.AssetID, err)
+			wfutils.SendTelegramError(ctx, telegram.ChatBMM, res.AssetID, err)
 			return nil, err
 		}
 	}

--- a/workflows/ingest/bmm_track_metadata.go
+++ b/workflows/ingest/bmm_track_metadata.go
@@ -122,20 +122,20 @@ func BmmTrackMetadata(ctx workflow.Context, params BmmTrackMetadataParams) (*Bmm
 			Destination: newPath,
 		}).Result(ctx)
 		if err != nil {
-			wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, "", err)
+			wfutils.SendTelegramError(ctx, telegram.ChatBMM, "", err)
 			return nil, fmt.Errorf("failed to download file: %w", err)
 		}
 
 		title := fmt.Sprintf("BMM-%d %s - %s", params.BmmTrackID, params.Language, params.Title)
 		res, err := ImportFileAsTag(ctx, "original", newPath, title)
 		if err != nil {
-			wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, "", err)
+			wfutils.SendTelegramError(ctx, telegram.ChatBMM, "", err)
 			return nil, err
 		}
 
 		err = WaitForImportTag(ctx, res)
 		if err != nil {
-			wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, res.AssetID, err)
+			wfutils.SendTelegramError(ctx, telegram.ChatBMM, res.AssetID, err)
 			return nil, err
 		}
 
@@ -173,7 +173,7 @@ func BmmTrackMetadata(ctx workflow.Context, params BmmTrackMetadataParams) (*Bmm
 		}).Get(ctx, nil)
 		if err != nil {
 			logger.Warn("TranscribeVX failed; continuing", "error", err)
-			wfutils.SendTelegramErorr(ctx, telegram.ChatBMM, assetID, err)
+			wfutils.SendTelegramError(ctx, telegram.ChatBMM, assetID, err)
 		}
 
 		_ = CreatePreviews(ctx, []string{assetID})


### PR DESCRIPTION
### What

`SendTelegramErorr` took a `channel` argument and ignored it, hardcoding `telegram.ChatOther`, so BMM ingest failures were reported to the wrong chat and callers that had carefully picked a channel had no way to tell.

### Fix

Uses the given channel. Fixes the typo in the exported name (`SendTelegramErorr` → `SendTelegramError`) and drops a now-redundant channel parameter from `SendTelegramMessage`, which reads the chat from `msg.Chat`.

### Verification

New `utils/workflows` notify tests capture the sent message and assert the chat. They fail against the old code with the wrong chat ID.

### Note

The second commit renames one call site introduced by the nil-deref PR below. Both changes merge cleanly in isolation and the combination does not compile — worth knowing if these are ever landed out of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
