### PR TITLE
fix(paths): make Files.Less a valid ordering

### DIFF
--- a/paths/files_test.go
+++ b/paths/files_test.go
@@ -1,0 +1,161 @@
+package paths
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// permutations returns every ordering of the given files.
+func permutations(files Files) []Files {
+	if len(files) <= 1 {
+		return []Files{files}
+	}
+
+	var out []Files
+	for i := range files {
+		rest := make(Files, 0, len(files)-1)
+		rest = append(rest, files[:i]...)
+		rest = append(rest, files[i+1:]...)
+
+		for _, p := range permutations(rest) {
+			perm := append(Files{files[i]}, p...)
+			out = append(out, perm)
+		}
+	}
+	return out
+}
+
+// The exact pair the old comparison got wrong: swapping drive and path order made
+// both directions report "less than", which is what left sort.Sort free to return
+// anything.
+func TestFilesLess_IsAntisymmetric_OnTheBrokenPair(t *testing.T) {
+	f := Files{
+		{Drive: Drive{Value: "b"}, Path: "a"},
+		{Drive: Drive{Value: "a"}, Path: "b"},
+	}
+
+	assert.False(t, f.Less(0, 1) && f.Less(1, 0),
+		"Less must not report both directions as less-than")
+}
+
+func TestFilesLess_IsAntisymmetric_OverAllPairs(t *testing.T) {
+	f := Files{
+		{Drive: IsilonDrive, Path: "b/1.wav"},
+		{Drive: IsilonDrive, Path: "a/2.wav"},
+		{Drive: TempDrive, Path: "a/1.wav"},
+		{Drive: TempDrive, Path: "b/2.wav"},
+		{Drive: BrunstadDrive, Path: "a/1.wav"},
+		{Drive: IsilonDrive, Path: "a/1.wav"},
+	}
+
+	for i := range f {
+		for j := range f {
+			if i == j {
+				assert.False(t, f.Less(i, j), "an element cannot be less than itself")
+				continue
+			}
+			assert.False(t, f.Less(i, j) && f.Less(j, i),
+				"pair (%d,%d) reports less-than in both directions", i, j)
+		}
+	}
+}
+
+func TestFilesLess_OrdersByDriveThenPath(t *testing.T) {
+	f := Files{
+		{Drive: TempDrive, Path: "b.wav"},
+		{Drive: IsilonDrive, Path: "b.wav"},
+		{Drive: TempDrive, Path: "a.wav"},
+		{Drive: IsilonDrive, Path: "a.wav"},
+	}
+
+	sort.Sort(f)
+
+	assert.Equal(t, Files{
+		{Drive: IsilonDrive, Path: "a.wav"},
+		{Drive: IsilonDrive, Path: "b.wav"},
+		{Drive: TempDrive, Path: "a.wav"},
+		{Drive: TempDrive, Path: "b.wav"},
+	}, f)
+}
+
+// The property that actually matters for Temporal replay: the sorted sequence is a
+// function of the set, not of the order the elements happened to arrive in.
+//
+// The data deliberately puts drive order and path order in conflict — drives sort
+// brunstad < isilon < temp, while the paths run the other way — because that is
+// what makes the old comparison report both directions as less-than and leaves the
+// output dependent on the input order.
+func TestFilesSort_IsOrderIndependent(t *testing.T) {
+	files := Files{
+		{Drive: TempDrive, Path: "a.wav"},
+		{Drive: IsilonDrive, Path: "b.wav"},
+		{Drive: BrunstadDrive, Path: "c.wav"},
+		{Drive: TempDrive, Path: "b.wav"},
+		{Drive: IsilonDrive, Path: "c.wav"},
+		{Drive: BrunstadDrive, Path: "d.wav"},
+	}
+
+	perms := permutations(files)
+	require.Len(t, perms, 720, "6 elements should give 6! orderings")
+
+	var want Files
+	for i, perm := range perms {
+		got := make(Files, len(perm))
+		copy(got, perm)
+		sort.Sort(got)
+
+		if i == 0 {
+			want = got
+			continue
+		}
+		assert.Equal(t, want, got,
+			"permutation %d sorted differently; the ordering is not well defined", i)
+	}
+}
+
+// The only place Files is sorted today is multitrack channel ordering, and there
+// every element shares a drive: workflows/ingest/multitrack.go sorts one
+// directory's listing, then the per-channel outputs that SplitAudioChannels all
+// writes into tempDir. With one drive the broken clause was always false and the
+// old expression collapsed to a plain path comparison, which is valid — which is
+// why this defect stayed latent rather than corrupting channel order. This test
+// pins the realistic single-drive case; the cross-drive cases above cover the
+// comparison itself.
+func TestFilesSort_MultitrackChannelOrderIsStable(t *testing.T) {
+	channels := Files{
+		{Drive: TempDrive, Path: "track2_ch2.wav"},
+		{Drive: TempDrive, Path: "track1_ch1.wav"},
+		{Drive: TempDrive, Path: "track2_ch1.wav"},
+		{Drive: TempDrive, Path: "track1_ch2.wav"},
+	}
+
+	first := make(Files, len(channels))
+	copy(first, channels)
+	sort.Sort(first)
+
+	assert.Equal(t, Files{
+		{Drive: TempDrive, Path: "track1_ch1.wav"},
+		{Drive: TempDrive, Path: "track1_ch2.wav"},
+		{Drive: TempDrive, Path: "track2_ch1.wav"},
+		{Drive: TempDrive, Path: "track2_ch2.wav"},
+	}, first)
+
+	// Sorting an already-sorted slice must not move anything.
+	second := make(Files, len(first))
+	copy(second, first)
+	sort.Sort(second)
+	assert.Equal(t, first, second, "sorting is not idempotent")
+}
+
+func TestFilesSort_HandlesEmptyAndSingle(t *testing.T) {
+	var empty Files
+	sort.Sort(empty)
+	assert.Empty(t, empty)
+
+	single := Files{{Drive: IsilonDrive, Path: "only.wav"}}
+	sort.Sort(single)
+	assert.Equal(t, Files{{Drive: IsilonDrive, Path: "only.wav"}}, single)
+}

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -273,8 +273,20 @@ func (f Files) Len() int {
 	return len(f)
 }
 
+// Less orders by drive first, then by path within a drive.
+//
+// The comparison has to be antisymmetric for sort.Sort to produce a defined
+// result. The previous `a.Drive < b.Drive || a.Path < b.Path` was not: for
+// {drive: b, path: a} against {drive: a, path: b} it reported Less(i, j) and
+// Less(j, i) both true, leaving the sorted output arbitrary. Files is sorted inside
+// workflow code — it decides multitrack channel order in
+// workflows/ingest/multitrack.go — so an arbitrary result is a replay hazard and
+// not merely a cosmetic one.
 func (f Files) Less(i, j int) bool {
-	return f[i].Drive.Value < f[j].Drive.Value || f[i].Path < f[j].Path
+	if f[i].Drive.Value != f[j].Drive.Value {
+		return f[i].Drive.Value < f[j].Drive.Value
+	}
+	return f[i].Path < f[j].Path
 }
 
 func (f Files) Swap(i, j int) {


### PR DESCRIPTION
### What

`paths.Files.Less` compared `Drive` and `Path` in a way that is not a strict weak ordering, so `sort.Sort` could produce different results for the same set depending on input order.

**Severity correction:** the original audit entry claimed this made multitrack channel order non-deterministic. It does not — both call sites sort single-drive slices, so the broken clause is always false. This is latent, not active.

### Fix

Makes the comparator a valid ordering: drive, then path.

### Verification

Property test over 6 elements whose drive and path orders conflict; it fails against the old comparator. (A first version with 4 elements passed against the buggy code — not enough to discriminate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
