### PR TITLE
fix(utils): stop ExecuteAnalysisCmd deadlocking on chatty stderr

### DIFF
--- a/utils/execute_command.go
+++ b/utils/execute_command.go
@@ -85,12 +85,11 @@ func ExecuteAnalysisCmd(cmd *exec.Cmd, outputCallback func(string)) (string, err
 	// Buffered rather than piped, which is what keeps this from deadlocking.
 	//
 	// Stdout is drained to EOF below, and stdout only reaches EOF once the child
-	// exits. Reading stderr afterwards — as this function used to — means a chatty
-	// child fills the 64 KiB stderr pipe, blocks in write(), therefore never exits,
-	// and therefore never closes stdout, so the drain never finishes either. That is
-	// reachable in practice: ffmpeg stays quiet on a clean file thanks to
-	// -hide_banner and -nostats, but damaged input produces per-frame decode
-	// warnings that run to megabytes.
+	// exits. Stderr therefore cannot be a pipe read after that drain: a chatty child
+	// would fill the 64 KiB stderr pipe, block in write(), never exit, never close
+	// stdout, and the drain would never finish either. That is reachable in practice:
+	// ffmpeg stays quiet on a clean file thanks to -hide_banner and -nostats, but
+	// damaged input produces per-frame decode warnings that run to megabytes.
 	//
 	// Assigning an io.Writer instead makes os/exec copy stderr on its own goroutine,
 	// so it can never fill up. cmd.Wait is what guarantees that copy has finished,

--- a/utils/execute_command.go
+++ b/utils/execute_command.go
@@ -4,37 +4,57 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 )
 
+// maxScanLine is the largest single output line we accept. bufio.Scanner defaults
+// to 64 KiB, which ffmpeg can exceed when it dumps metadata-heavy stream info.
+const maxScanLine = 1024 * 1024
+
+// maxErrorTail is how much of a failed command's stderr we quote back. Errors from
+// activities end up in the Temporal workflow history, so this must stay bounded —
+// a decode-warning storm can run to megabytes.
+const maxErrorTail = 4096
+
+// newLineScanner returns a line scanner with a raised line limit.
+func newLineScanner(r io.Reader) *bufio.Scanner {
+	scanner := bufio.NewScanner(r)
+	scanner.Split(bufio.ScanLines)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxScanLine)
+	return scanner
+}
+
+// tailForError trims s to its last maxErrorTail bytes, keeping the end because that
+// is where a failing command reports why.
+func tailForError(s string) string {
+	if len(s) <= maxErrorTail {
+		return s
+	}
+	return "...(truncated)...\n" + s[len(s)-maxErrorTail:]
+}
+
 // ExecuteCmd executes the cmd and returns through outputCallback line-by-line before returning the whole stdout at the end.
 func ExecuteCmd(cmd *exec.Cmd, outputCallback func(string)) (string, error) {
-	stdout, _ := cmd.StdoutPipe()
-	//stderr, _ := cmd.StderrPipe()
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("could not open stdout pipe: %w", err)
+	}
 
 	errorBytes := bytes.Buffer{}
 	cmd.Stderr = &errorBytes
 
 	println("FFMPEG Command:", cmd.String())
 
-	err := cmd.Start()
+	err = cmd.Start()
 	if err != nil {
 		return "", fmt.Errorf("start failed %s", err.Error())
 	}
 
-	//go func() {
-	//	scanner := bufio.NewScanner(stderr)
-	//	scanner.Split(bufio.ScanLines)
-	//	for scanner.Scan() {
-	//		errorString += scanner.Text() + "\n"
-	//	}
-	//}()
-
 	var result string
 
-	scanner := bufio.NewScanner(stdout)
-	scanner.Split(bufio.ScanLines)
+	scanner := newLineScanner(stdout)
 	for scanner.Scan() {
 		line := scanner.Text()
 		result += line + "\n"
@@ -42,54 +62,66 @@ func ExecuteCmd(cmd *exec.Cmd, outputCallback func(string)) (string, error) {
 			outputCallback(line)
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("reading stdout failed: %w", err)
+	}
 
 	err = cmd.Wait()
 	if err != nil {
-		return "", fmt.Errorf("execution failed error: %s,\nmessage: %s", err.Error(), errorBytes.String())
+		return "", fmt.Errorf("execution failed error: %s,\nmessage: %s", err.Error(), tailForError(errorBytes.String()))
 	}
 
 	return result, err
 }
 
-// ExecuteAnalysisCmd executes the cmd and returns through outputCallback line-by-line and retrutning only
-// the part that is a valid JSON string
+// ExecuteAnalysisCmd executes the cmd and returns the JSON object the command
+// printed to stderr, which is how ffmpeg's loudnorm filter reports its analysis.
 func ExecuteAnalysisCmd(cmd *exec.Cmd, outputCallback func(string)) (string, error) {
-	stdout, _ := cmd.StdoutPipe()
-	stderr, _ := cmd.StderrPipe()
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("could not open stdout pipe: %w", err)
+	}
 
-	err := cmd.Start()
+	// Buffered rather than piped, which is what keeps this from deadlocking.
+	//
+	// Stdout is drained to EOF below, and stdout only reaches EOF once the child
+	// exits. Reading stderr afterwards — as this function used to — means a chatty
+	// child fills the 64 KiB stderr pipe, blocks in write(), therefore never exits,
+	// and therefore never closes stdout, so the drain never finishes either. That is
+	// reachable in practice: ffmpeg stays quiet on a clean file thanks to
+	// -hide_banner and -nostats, but damaged input produces per-frame decode
+	// warnings that run to megabytes.
+	//
+	// Assigning an io.Writer instead makes os/exec copy stderr on its own goroutine,
+	// so it can never fill up. cmd.Wait is what guarantees that copy has finished,
+	// so errorBytes must not be read until after it returns.
+	errorBytes := bytes.Buffer{}
+	cmd.Stderr = &errorBytes
+
+	err = cmd.Start()
 	if err != nil {
 		return "", fmt.Errorf("start failed %s", err.Error())
 	}
 
-	jsonActive := false
-
-	scannerOut := bufio.NewScanner(stdout)
-	scannerOut.Split(bufio.ScanLines)
+	scannerOut := newLineScanner(stdout)
 	for scannerOut.Scan() {
 		line := scannerOut.Text()
 		if outputCallback != nil {
 			outputCallback(line)
 		}
 	}
+	if err := scannerOut.Err(); err != nil {
+		return "", fmt.Errorf("reading stdout failed: %w", err)
+	}
 
-	var result string
-	scannerErr := bufio.NewScanner(stderr)
-	scannerErr.Split(bufio.ScanLines)
-	for scannerErr.Scan() {
-		line := scannerErr.Text()
+	err = cmd.Wait()
+	if err != nil {
+		return "", fmt.Errorf("execution failed error: %s,\nmessage: %s", err.Error(), tailForError(errorBytes.String()))
+	}
 
-		if line == "{" {
-			jsonActive = true
-		}
-
-		if jsonActive {
-			result += line + "\n"
-		}
-
-		if line == "}" {
-			jsonActive = false
-		}
+	result, err := extractJSONObject(&errorBytes)
+	if err != nil {
+		return "", fmt.Errorf("reading stderr failed: %w", err)
 	}
 
 	// replace -Inf with -99 if the audio was silent
@@ -98,10 +130,35 @@ func ExecuteAnalysisCmd(cmd *exec.Cmd, outputCallback func(string)) (string, err
 	// replace inf with 0 target_offset if the audio was silent
 	result = strings.ReplaceAll(result, "\"inf\"", "\"0\"")
 
-	err = cmd.Wait()
-	if err != nil {
-		return "", fmt.Errorf("execution failed error: %s", err.Error())
+	return result, nil
+}
+
+// extractJSONObject returns the lines between a bare "{" and a bare "}", which is
+// how ffmpeg brackets the loudnorm JSON summary among its other stderr output.
+func extractJSONObject(r io.Reader) (string, error) {
+	var out strings.Builder
+	jsonActive := false
+
+	scanner := newLineScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if line == "{" {
+			jsonActive = true
+		}
+
+		if jsonActive {
+			out.WriteString(line)
+			out.WriteString("\n")
+		}
+
+		if line == "}" {
+			jsonActive = false
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
 	}
 
-	return result, err
+	return out.String(), nil
 }

--- a/utils/execute_command_test.go
+++ b/utils/execute_command_test.go
@@ -54,9 +54,9 @@ echo "progress=end"
 	return exec.Command("sh", "-c", script)
 }
 
-// The regression. Reading stdout to EOF and only then reading stderr deadlocks once
-// the child fills the stderr pipe: it blocks in write(), so it never exits, so
-// stdout never reaches EOF.
+// Stderr must not be a pipe that is only read after stdout reaches EOF: once the
+// child fills the stderr pipe it blocks in write(), so it never exits, so stdout
+// never reaches EOF either.
 func TestExecuteAnalysisCmd_ChattyStderrDoesNotDeadlock(t *testing.T) {
 	var result string
 	var err error

--- a/utils/execute_command_test.go
+++ b/utils/execute_command_test.go
@@ -103,8 +103,8 @@ func TestExecuteAnalysisCmd_ForwardsStdoutToCallback(t *testing.T) {
 	assert.Equal(t, []string{"progress=continue", "progress=end"}, lines)
 }
 
-// A failing command must report why. Previously the stderr content was dropped and
-// callers saw a bare "exit status 1".
+// A failing command must report why: the error carries the stderr tail, not just a
+// bare "exit status 1".
 func TestExecuteAnalysisCmd_FailureIncludesStderr(t *testing.T) {
 	cmd := exec.Command("sh", "-c", `echo "No such file or directory" >&2; exit 1`)
 

--- a/utils/execute_command_test.go
+++ b/utils/execute_command_test.go
@@ -1,0 +1,164 @@
+package utils_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bcc-code/bcc-media-flows/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runWithDeadline runs fn and fails the test if it has not returned in time, rather
+// than letting a deadlock stall the whole package until the go test timeout.
+func runWithDeadline(t *testing.T, what string, fn func()) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatalf("%s did not return within 30s — it deadlocked", what)
+	}
+}
+
+// chattyStderrCmd builds a command that writes more than a pipe buffer's worth of
+// stderr before writing anything to stdout and exiting, then prints a JSON object on
+// stderr the way ffmpeg's loudnorm filter does.
+//
+// 2000 lines of ~64 bytes is ~128 KiB, comfortably past the 64 KiB pipe buffer, so
+// the child blocks in write() unless stderr is being drained concurrently.
+func chattyStderrCmd() *exec.Cmd {
+	script := `
+i=0
+while [ $i -lt 2000 ]; do
+  echo "[mpeg4 @ 0x0] warning: concealing errors in frame, dts non-monotonic" >&2
+  i=$((i+1))
+done
+echo "{" >&2
+echo "	\"input_i\" : \"-23.05\"," >&2
+echo "	\"input_tp\" : \"-6.20\"," >&2
+echo "	\"input_lra\" : \"5.30\"" >&2
+echo "}" >&2
+echo "progress=end"
+`
+	return exec.Command("sh", "-c", script)
+}
+
+// The regression. Reading stdout to EOF and only then reading stderr deadlocks once
+// the child fills the stderr pipe: it blocks in write(), so it never exits, so
+// stdout never reaches EOF.
+func TestExecuteAnalysisCmd_ChattyStderrDoesNotDeadlock(t *testing.T) {
+	var result string
+	var err error
+
+	runWithDeadline(t, "ExecuteAnalysisCmd with 128 KiB of stderr", func() {
+		result, err = utils.ExecuteAnalysisCmd(chattyStderrCmd(), nil)
+	})
+
+	require.NoError(t, err)
+
+	// The JSON has to survive being buried in all that noise.
+	var parsed map[string]string
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed),
+		"expected a parseable JSON object, got:\n%s", result)
+	assert.Equal(t, "-23.05", parsed["input_i"])
+	assert.Equal(t, "-6.20", parsed["input_tp"])
+	assert.Equal(t, "5.30", parsed["input_lra"])
+}
+
+// The quiet case, which is what a clean media file looks like.
+func TestExecuteAnalysisCmd_ExtractsJSONFromQuietStderr(t *testing.T) {
+	cmd := exec.Command("sh", "-c",
+		`echo "Input #0, mov,mp4" >&2; echo "{" >&2; echo "	\"input_i\" : \"-18.00\"" >&2; echo "}" >&2; echo "progress=end"`)
+
+	result, err := utils.ExecuteAnalysisCmd(cmd, nil)
+	require.NoError(t, err)
+
+	var parsed map[string]string
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+	assert.Equal(t, "-18.00", parsed["input_i"])
+}
+
+// Progress lines on stdout still reach the callback.
+func TestExecuteAnalysisCmd_ForwardsStdoutToCallback(t *testing.T) {
+	cmd := exec.Command("sh", "-c",
+		`echo "progress=continue"; echo "progress=end"; echo "{" >&2; echo "}" >&2`)
+
+	var lines []string
+	_, err := utils.ExecuteAnalysisCmd(cmd, func(line string) {
+		lines = append(lines, line)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"progress=continue", "progress=end"}, lines)
+}
+
+// A failing command must report why. Previously the stderr content was dropped and
+// callers saw a bare "exit status 1".
+func TestExecuteAnalysisCmd_FailureIncludesStderr(t *testing.T) {
+	cmd := exec.Command("sh", "-c", `echo "No such file or directory" >&2; exit 1`)
+
+	_, err := utils.ExecuteAnalysisCmd(cmd, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "No such file or directory")
+}
+
+// Stderr from a failure is bounded, because activity errors are stored in the
+// Temporal workflow history.
+func TestExecuteAnalysisCmd_FailureStderrIsTruncated(t *testing.T) {
+	cmd := exec.Command("sh", "-c",
+		`i=0; while [ $i -lt 5000 ]; do echo "an extremely repetitive decode warning" >&2; i=$((i+1)); done; exit 1`)
+
+	// Also past the pipe buffer, so this needs the deadline guard too.
+	var err error
+	runWithDeadline(t, "ExecuteAnalysisCmd with a failing chatty command", func() {
+		_, err = utils.ExecuteAnalysisCmd(cmd, nil)
+	})
+
+	require.Error(t, err)
+	assert.Less(t, len(err.Error()), 8192, "error message should be bounded, not the whole stderr stream")
+	assert.Contains(t, err.Error(), "truncated")
+}
+
+// ExecuteCmd buffers stderr already, so it never had the deadlock. Cover it so the
+// two stay consistent.
+func TestExecuteCmd_ChattyStderrDoesNotDeadlock(t *testing.T) {
+	script := fmt.Sprintf(`
+i=0
+while [ $i -lt 2000 ]; do
+  echo "%s" >&2
+  i=$((i+1))
+done
+echo "done"
+`, strings.Repeat("x", 60))
+
+	var result string
+	var err error
+
+	runWithDeadline(t, "ExecuteCmd with 128 KiB of stderr", func() {
+		result, err = utils.ExecuteCmd(exec.Command("sh", "-c", script), nil)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "done\n", result)
+}
+
+func TestExecuteCmd_FailureIncludesStderr(t *testing.T) {
+	cmd := exec.Command("sh", "-c", `echo "boom" >&2; exit 2`)
+
+	_, err := utils.ExecuteCmd(cmd, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}


### PR DESCRIPTION
### What

`ExecuteAnalysisCmd` piped stderr, drained stdout to EOF, and only then read stderr. Stdout only reaches EOF once the child exits — so a child that fills the 64 KiB stderr pipe blocks in `write()`, never exits, never closes stdout, and the drain never finishes.

**Reachable, not theoretical:** `-hide_banner -nostats` keeps a clean file well under a pipe's worth of stderr, so the trigger is damaged input, whose per-frame decode warnings run to megabytes. It hung on exactly the files whose analysis you most needed.

### Fix

Assigns stderr an `io.Writer` so `os/exec` drains it on its own goroutine — which is what `ExecuteCmd` five lines above already did. Also in the same path: discarded pipe errors that made `bufio.NewScanner(nil)` panic, an unchecked `scanner.Err()`, and a `cmd.Wait` error that dropped stderr so failures read as a bare `exit status 1`.

### Verification

The deadlock test (128 KiB of stderr) hits its 30 s deadline against the old code with "it deadlocked".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
