### PR TITLE
fix(transcode): repair the GrowingPreview subprocess lifecycle

### DIFF
--- a/activities/preview.go
+++ b/activities/preview.go
@@ -75,6 +75,15 @@ type TranscodeGrowingPreviewParams struct {
 
 func (va VideoActivities) TranscodeGrowingPreview(ctx context.Context, input TranscodeGrowingPreviewParams) (any, error) {
 	activity.RecordHeartbeat(ctx, "Transcode Preview", input)
+
+	// Heartbeat on a background ticker as well as from the callback below. The callback
+	// only fires once every 60s and the loop then runs a full remux of the accumulated
+	// HLS playlist synchronously, which grows with the playlist over a multi-hour
+	// ingest. One slow remux was enough to blow the 10 minute HeartbeatTimeout and have
+	// Temporal retry the whole preview from byte 0.
+	stop := simpleHeartBeater(ctx)
+	defer close(stop)
+
 	err := transcode.GrowingPreview(ctx, transcode.GrowingPreviewInput{
 		FilePath:        input.OriginalFilePath.Local(),
 		DestinationFile: input.DestinationFilePath.Local(),

--- a/services/transcode/preview.go
+++ b/services/transcode/preview.go
@@ -388,9 +388,9 @@ func GrowingPreview(ctx context.Context, input GrowingPreviewInput, heartbeater 
 	// Create a pipe between the two commands
 	pipe, err := tailCmd.StdoutPipe()
 	if err != nil {
-		// This used to print and call os.Exit(1), which killed the whole transcode
-		// worker: every other activity on the process died without reporting an error,
-		// only failing later via heartbeat timeout.
+		// Must return rather than exit: this runs inside a Temporal activity, so
+		// terminating the process would kill every other activity on the worker without
+		// reporting an error, leaving them to fail later on a heartbeat timeout.
 		return fmt.Errorf("could not create tail stdout pipe: %w", err)
 	}
 	ffmpegCmd.Stdin = pipe

--- a/services/transcode/preview.go
+++ b/services/transcode/preview.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -60,7 +61,7 @@ func buildVUMeterFilters(audioTracks int, trcPrefix string, scaleFilter string) 
 	lastVid := "[vmain]"
 	for i := 0; i < audioTracks; i++ {
 		y := 10 + i*(meterH+spacing)
-		parts = append(parts, 
+		parts = append(parts,
 			fmt.Sprintf("[0:a:%d]showvolume=w=%d:h=%d:p=%.2f:t=1,format=rgba[vum%d]", i, meterW, meterH, meterAlpha, i),
 			fmt.Sprintf("%s[vum%d]overlay=x=10:y=%d[tmp%d]", lastVid, i, y, i),
 		)
@@ -352,7 +353,21 @@ func GrowingPreview(ctx context.Context, input GrowingPreviewInput, heartbeater 
 
 	tailCmd := exec.CommandContext(ctx, "tail", "-c", "+1", "-f", input.FilePath)
 
-	ffmpegCmd := exec.Command("ffmpeg",
+	// Context-bound so a cancelled or timed-out activity cannot leave ffmpeg running.
+	// This matters on retry: a new attempt restarts tail from byte 0, and an orphan
+	// from the previous attempt would keep writing into the same TempDir, so two
+	// ffmpegs would be producing the same HLS segments.
+	//
+	// Cancel is deliberately a no-op instead of CommandContext's default SIGKILL.
+	// Cancellation kills tail, ffmpeg then sees EOF on stdin and finalises the HLS
+	// playlist cleanly; killing it outright would risk truncating the final segment.
+	// WaitDelay bounds how long Wait may block after cancellation before force-killing,
+	// so a wedged ffmpeg cannot hang the activity indefinitely.
+	//
+	// Note the documented consequence: because Cancel returns nil rather than
+	// os.ErrProcessDone, Wait reports the context error even when ffmpeg exits
+	// successfully. That is why the cancellation path below ignores Wait's result.
+	ffmpegCmd := exec.CommandContext(ctx, "ffmpeg",
 		"-i", "pipe:0", // Input from stdin
 		"-i", watermark,
 		"-c:v", "libx264", // Video codec: H.264
@@ -367,58 +382,109 @@ func GrowingPreview(ctx context.Context, input GrowingPreviewInput, heartbeater 
 		"-hls_segment_filename", filepath.Join(input.TempDir, "segment_%03d.ts"), // Segment file names
 		"-y", filepath.Join(input.TempDir, "playlist.m3u8")) // Output playlist file
 
+	ffmpegCmd.Cancel = func() error { return nil }
+	ffmpegCmd.WaitDelay = 2 * time.Minute
+
 	// Create a pipe between the two commands
 	pipe, err := tailCmd.StdoutPipe()
 	if err != nil {
-		fmt.Printf("Error creating pipe: %v\n", err)
-		os.Exit(1)
+		// This used to print and call os.Exit(1), which killed the whole transcode
+		// worker: every other activity on the process died without reporting an error,
+		// only failing later via heartbeat timeout.
+		return fmt.Errorf("could not create tail stdout pipe: %w", err)
 	}
 	ffmpegCmd.Stdin = pipe
 
-	// Set output for ffmpeg
+	// Set output for ffmpeg. Stderr is teed so operators keep seeing it in the worker
+	// log while the tail is also available to quote in an error. Bounded on purpose:
+	// activity errors are stored in the workflow history, and a decode-warning storm on
+	// a multi-hour ingest would otherwise put megabytes there.
 	ffmpegCmd.Stdout = os.Stdout
-	ffmpegCmd.Stderr = os.Stderr
+	stderrTail := &boundedTailWriter{max: maxFFmpegErrorTail}
+	ffmpegCmd.Stderr = io.MultiWriter(os.Stderr, stderrTail)
 
 	fmt.Printf("Executing tail command: %s\n", strings.Join(tailCmd.Args, " "))
 	fmt.Printf("Executing ffmpeg command: %s\n", strings.Join(ffmpegCmd.Args, " "))
 
 	// Start tail command
 	if err := tailCmd.Start(); err != nil {
-		return fmt.Errorf("Error starting tail: %v\n", err)
+		return fmt.Errorf("error starting tail: %w", err)
 	}
+
+	// Reaps tail and closes the pipe's read end. Without this every invocation leaked
+	// one descriptor and left a zombie: StdoutPipe registers the read end in
+	// tailCmd.parentIOPipes, which only Wait closes, and handing it to ffmpegCmd.Stdin
+	// does not transfer ownership because exec returns a caller-supplied *os.File as-is.
+	defer func() { _ = tailCmd.Wait() }()
 
 	// Start ffmpeg command
 	if err := ffmpegCmd.Start(); err != nil {
-		return fmt.Errorf("Error starting ffmpeg: %v\nCommand: %s", err, strings.Join(ffmpegCmd.Args, " "))
+		return fmt.Errorf("error starting ffmpeg: %w\nCommand: %s", err, strings.Join(ffmpegCmd.Args, " "))
 	}
 
-	running := true
+	ffmpegDone := make(chan error, 1)
+	go func() { ffmpegDone <- ffmpegCmd.Wait() }()
+
 	start := time.Now()
-	for running {
+	for {
 		select {
-		case <-time.After(60 * time.Second):
-			break
+		case waitErr := <-ffmpegDone:
+			// ffmpeg stopped while the file is still growing, so no more preview is
+			// coming. Nothing used to watch for this, so the activity carried on
+			// heartbeating and remuxing a stale playlist until its 8 hour timeout.
+			if muxErr := muxFinishedPreview(input.TempDir, input.DestinationFile); muxErr != nil {
+				fmt.Println(muxErr)
+			}
+			return fmt.Errorf("ffmpeg exited before the ingest finished: %w\nffmpeg stderr:\n%s",
+				waitErr, stderrTail.String())
+
 		case <-ctx.Done():
-			running = false
-		}
+			// Expected path: the workflow cancels this activity once the ingest is
+			// complete. Killing tail closes ffmpeg's stdin, which lets it finalise the
+			// playlist. Bounded by WaitDelay.
+			<-ffmpegDone
 
-		heartbeater(ctx, time.Since(start))
+			// Mux once more after ffmpeg has exited so the final HLS segment is included.
+			if muxErr := muxFinishedPreview(input.TempDir, input.DestinationFile); muxErr != nil {
+				fmt.Println(muxErr)
+			}
 
-		err = muxFinishedPreview(input.TempDir, input.DestinationFile)
-		if err != nil {
-			fmt.Println(err)
+			// ffmpeg's exit status here describes the shutdown, not the outcome — the
+			// deliverable is the muxed file. Returning it would make the normal end of
+			// every live ingest look like a failure.
+			return nil
+
+		case <-time.After(60 * time.Second):
+			heartbeater(ctx, time.Since(start))
+
+			if muxErr := muxFinishedPreview(input.TempDir, input.DestinationFile); muxErr != nil {
+				// Expected mid-ingest: this mux can race ffmpeg rewriting the playlist.
+				fmt.Println(muxErr)
+			}
 		}
 	}
+}
 
-	waitErr := ffmpegCmd.Wait()
+// maxFFmpegErrorTail is how much of ffmpeg's stderr is quoted back in an error.
+const maxFFmpegErrorTail = 4096
 
-	// Mux once more after ffmpeg has exited so the final HLS segment is included.
-	err = muxFinishedPreview(input.TempDir, input.DestinationFile)
-	if err != nil {
-		fmt.Println(err)
+// boundedTailWriter keeps only the last max bytes written to it, so a long-running
+// command's stderr can be quoted in an error without it growing without bound.
+type boundedTailWriter struct {
+	buf []byte
+	max int
+}
+
+func (w *boundedTailWriter) Write(p []byte) (int, error) {
+	w.buf = append(w.buf, p...)
+	if len(w.buf) > w.max {
+		w.buf = w.buf[len(w.buf)-w.max:]
 	}
+	return len(p), nil
+}
 
-	return waitErr
+func (w *boundedTailWriter) String() string {
+	return string(w.buf)
 }
 
 func muxFinishedPreview(inputFolder, outputFile string) error {

--- a/services/transcode/preview.go
+++ b/services/transcode/preview.go
@@ -411,8 +411,8 @@ func GrowingPreview(ctx context.Context, input GrowingPreviewInput, heartbeater 
 		return fmt.Errorf("error starting tail: %w", err)
 	}
 
-	// Reaps tail and closes the pipe's read end. Without this every invocation leaked
-	// one descriptor and left a zombie: StdoutPipe registers the read end in
+	// Reaps tail and closes the pipe's read end. Skipping this leaks a descriptor and
+	// leaves a zombie per call: StdoutPipe registers the read end in
 	// tailCmd.parentIOPipes, which only Wait closes, and handing it to ffmpegCmd.Stdin
 	// does not transfer ownership because exec returns a caller-supplied *os.File as-is.
 	defer func() { _ = tailCmd.Wait() }()
@@ -430,8 +430,8 @@ func GrowingPreview(ctx context.Context, input GrowingPreviewInput, heartbeater 
 		select {
 		case waitErr := <-ffmpegDone:
 			// ffmpeg stopped while the file is still growing, so no more preview is
-			// coming. Nothing used to watch for this, so the activity carried on
-			// heartbeating and remuxing a stale playlist until its 8 hour timeout.
+			// coming. Without this case the activity would carry on heartbeating and
+			// remuxing a stale playlist until its 8 hour timeout.
 			if muxErr := muxFinishedPreview(input.TempDir, input.DestinationFile); muxErr != nil {
 				fmt.Println(muxErr)
 			}

--- a/services/transcode/preview_integration_test.go
+++ b/services/transcode/preview_integration_test.go
@@ -50,9 +50,9 @@ func TestGrowingPreview_VUMeters(t *testing.T) {
 
 	select {
 	case err := <-done:
-		// Previously discarded. Cancellation is how every live ingest ends normally, so
-		// it must not be reported as a failure — and asserting it here also guards
-		// against killing ffmpeg outright, which would truncate the final segment.
+		// Cancellation is how every live ingest ends normally, so it must not surface as
+		// a failure. This also guards the graceful shutdown: killing ffmpeg outright
+		// rather than letting its stdin EOF would truncate the final segment.
 		require.NoError(t, err, "cancellation is the normal end of a live ingest")
 	case <-time.After(60 * time.Second):
 		t.Fatal("GrowingPreview did not exit after context cancellation")

--- a/services/transcode/preview_integration_test.go
+++ b/services/transcode/preview_integration_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+// Tests in this file drive real ffmpeg over generated media, so a single case costs
+// tens of seconds and they are excluded from the default test run. The unit tests in
+// preview_test.go cover the pure filter-building logic and stay fast.
+//
+// Run these with: go test -tags=integration ./services/transcode/...
+package transcode
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bcc-code/bcc-media-flows/paths"
+	"github.com/bcc-code/bcc-media-flows/services/ffmpeg"
+	"github.com/bcc-code/bcc-media-flows/utils/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrowingPreview_VUMeters(t *testing.T) {
+	os.MkdirAll("testdata/generated", 0755)
+
+	inputFile := "testdata/generated/testsrc_growing_4streams.mxf"
+	p, err := paths.Parse(inputFile)
+	require.NoError(t, err)
+	testutils.GenerateStreamableMXFTestFile(p, 4, 5.0)
+
+	tempDir := t.TempDir()
+	destFile := filepath.Join(tempDir, "growing_preview.mp4")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- GrowingPreview(ctx, GrowingPreviewInput{
+			FilePath:        inputFile,
+			TempDir:         tempDir,
+			DestinationFile: destFile,
+			WatermarkPath:   "testdata/test_overlay.png",
+		}, func(ctx context.Context, duration time.Duration) {})
+	}()
+
+	// Give ffmpeg time to consume the static file, then stop the tail
+	time.Sleep(10 * time.Second)
+	cancel()
+
+	select {
+	case err := <-done:
+		// Previously discarded. Cancellation is how every live ingest ends normally, so
+		// it must not be reported as a failure — and asserting it here also guards
+		// against killing ffmpeg outright, which would truncate the final segment.
+		require.NoError(t, err, "cancellation is the normal end of a live ingest")
+	case <-time.After(60 * time.Second):
+		t.Fatal("GrowingPreview did not exit after context cancellation")
+	}
+
+	stat, err := os.Stat(destFile)
+	require.NoError(t, err, "destination file should exist")
+	require.True(t, stat.Size() > 1000, "destination file should not be empty")
+
+	info, err := ffmpeg.ProbeFile(destFile)
+	require.NoError(t, err)
+	var videoStreams, audioStreams int
+	for _, stream := range info.Streams {
+		switch stream.CodecType {
+		case "video":
+			videoStreams++
+		case "audio":
+			audioStreams++
+		}
+	}
+	assert.Equal(t, 1, videoStreams)
+	assert.Equal(t, 1, audioStreams)
+}
+
+func TestPreview_VUMeters_MultipleAudioTracks(t *testing.T) {
+	t.Parallel()
+	trackCounts := []int{1, 2, 4, 16}
+	os.MkdirAll("testdata/generated", 0755)
+
+	for _, n := range trackCounts {
+		t.Run(fmt.Sprintf("audio_tracks_%d", n), func(t *testing.T) {
+			inputFile := filepath.Join("testdata/generated", fmt.Sprintf("testsrc_%dtracks.mov", n))
+			outputDir := "testdata/generated"
+			p, err := paths.Parse(inputFile)
+			require.NoError(t, err)
+			testutils.GenerateSoftronTestFile(p, n, 2.0)
+
+			previewInput := PreviewInput{
+				FilePath:      inputFile,
+				OutputDir:     outputDir,
+				WatermarkPath: "testdata/test_overlay.png",
+			}
+
+			result, err := Preview(previewInput, nil)
+			require.NoError(t, err, "Preview should succeed for %d tracks", n)
+			require.NotNil(t, result)
+			stat, err := os.Stat(result.LowResolutionPath)
+			require.NoError(t, err)
+			require.True(t, stat.Size() > 1000, "Preview output should not be empty for %d tracks", n)
+		})
+	}
+}
+
+func TestPreview_VUMeters_SeparateAudioStreams(t *testing.T) {
+	t.Parallel()
+	trackCounts := []int{1, 2, 4, 8}
+	os.MkdirAll("testdata/generated", 0755)
+
+	for _, n := range trackCounts {
+		t.Run(fmt.Sprintf("separate_streams_%d", n), func(t *testing.T) {
+			inputFile := filepath.Join("testdata/generated", fmt.Sprintf("testsrc_separate_%dstreams.mov", n))
+			outputDir := "testdata/generated"
+			p, err := paths.Parse(inputFile)
+			require.NoError(t, err)
+			testutils.GenerateSeparateAudioStreamsTestFile(p, n, 2.0)
+
+			previewInput := PreviewInput{
+				FilePath:      inputFile,
+				OutputDir:     outputDir,
+				WatermarkPath: "testdata/test_overlay.png",
+			}
+
+			result, err := Preview(previewInput, nil)
+			require.NoError(t, err, "Preview should succeed for %d separate streams", n)
+			require.NotNil(t, result)
+			stat, err := os.Stat(result.LowResolutionPath)
+			require.NoError(t, err)
+			require.True(t, stat.Size() > 1000, "Preview output should not be empty for %d separate streams", n)
+		})
+	}
+}

--- a/services/transcode/preview_test.go
+++ b/services/transcode/preview_test.go
@@ -153,9 +153,9 @@ func growingPreviewFailFast(t *testing.T) error {
 }
 
 // ffmpeg exiting on its own means no more preview is coming, so GrowingPreview must
-// return promptly. Nothing used to watch for it: the loop selected only on a 60s timer
-// and ctx.Done(), so the activity kept heartbeating and remuxing a stale playlist until
-// its 8 hour StartToCloseTimeout. Note the context is never cancelled here.
+// return promptly rather than wait for cancellation. The context is deliberately never
+// cancelled here: a drain loop watching only its timer and ctx.Done() would keep the
+// activity alive to its 8 hour StartToCloseTimeout, and this test to its deadline.
 func TestGrowingPreview_FfmpegExitingEarlyIsReported(t *testing.T) {
 	err := growingPreviewFailFast(t)
 
@@ -184,10 +184,10 @@ func countOpenFDs(t *testing.T) int {
 	return 0
 }
 
-// Each invocation used to leak the tail pipe's read end and leave an unreaped tail:
-// StdoutPipe registers the read end in tailCmd.parentIOPipes, which only Wait closes,
-// and Wait was never called. That leak is also the only thing that could ever have made
-// os.Pipe fail, which the old code answered with os.Exit(1).
+// Repeated invocations must not accumulate descriptors. StdoutPipe registers the pipe's
+// read end in tailCmd.parentIOPipes, which only Wait closes, so failing to wait on tail
+// leaks one descriptor and one zombie per call — and descriptor exhaustion is the only
+// thing that can make os.Pipe fail in the first place.
 func TestGrowingPreview_DoesNotLeakDescriptors(t *testing.T) {
 	// Warm up first so one-off allocations are not counted as growth.
 	_ = growingPreviewFailFast(t)

--- a/services/transcode/preview_test.go
+++ b/services/transcode/preview_test.go
@@ -9,10 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"fmt"
-	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/services/ffmpeg"
-	"github.com/bcc-code/bcc-media-flows/utils/testutils"
 	"github.com/bcc-code/mediabank-bridge/log"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -120,111 +117,89 @@ func TestBuildGrowingPreviewFilter(t *testing.T) {
 	assert.Contains(t, many, "[0:a:0][0:a:1]amerge=inputs=2,pan=stereo|c0<c0|c1<c1[AUDIO-.mp4-0]")
 }
 
-func TestGrowingPreview_VUMeters(t *testing.T) {
-	os.MkdirAll("testdata/generated", 0755)
-
-	inputFile := "testdata/generated/testsrc_growing_4streams.mxf"
-	p, err := paths.Parse(inputFile)
-	require.NoError(t, err)
-	testutils.GenerateStreamableMXFTestFile(p, 4, 5.0)
+// growingPreviewFailFast runs GrowingPreview against a file that does not exist, which
+// makes both children exit within about a second: tail fails immediately, its stdout
+// closes, and ffmpeg then has an empty input to probe.
+//
+// This deliberately avoids generated media. Feeding ffmpeg an unprobeable stream does
+// not work as a trigger — `tail -f` never closes the pipe, so ffmpeg blocks waiting for
+// a header rather than failing, which is also why a missing watermark is no use: ffmpeg
+// never gets past probing input 0 to discover input 1 is missing.
+func growingPreviewFailFast(t *testing.T) error {
+	t.Helper()
 
 	tempDir := t.TempDir()
-	destFile := filepath.Join(tempDir, "growing_preview.mp4")
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	done := make(chan error, 1)
 	go func() {
 		done <- GrowingPreview(ctx, GrowingPreviewInput{
-			FilePath:        inputFile,
+			FilePath:        filepath.Join(tempDir, "does-not-exist.mxf"),
 			TempDir:         tempDir,
-			DestinationFile: destFile,
+			DestinationFile: filepath.Join(tempDir, "preview.mp4"),
 			WatermarkPath:   "testdata/test_overlay.png",
 		}, func(ctx context.Context, duration time.Duration) {})
 	}()
 
-	// Give ffmpeg time to consume the static file, then stop the tail
-	time.Sleep(10 * time.Second)
-	cancel()
-
 	select {
-	case <-done:
-	case <-time.After(60 * time.Second):
-		t.Fatal("GrowingPreview did not exit after context cancellation")
+	case err := <-done:
+		return err
+	case <-time.After(30 * time.Second):
+		t.Fatal("GrowingPreview did not notice ffmpeg exiting; it waited for cancellation instead")
+		return nil
 	}
+}
 
-	stat, err := os.Stat(destFile)
-	require.NoError(t, err, "destination file should exist")
-	require.True(t, stat.Size() > 1000, "destination file should not be empty")
+// ffmpeg exiting on its own means no more preview is coming, so GrowingPreview must
+// return promptly. Nothing used to watch for it: the loop selected only on a 60s timer
+// and ctx.Done(), so the activity kept heartbeating and remuxing a stale playlist until
+// its 8 hour StartToCloseTimeout. Note the context is never cancelled here.
+func TestGrowingPreview_FfmpegExitingEarlyIsReported(t *testing.T) {
+	err := growingPreviewFailFast(t)
 
-	info, err := ffmpeg.ProbeFile(destFile)
-	require.NoError(t, err)
-	var videoStreams, audioStreams int
-	for _, stream := range info.Streams {
-		switch stream.CodecType {
-		case "video":
-			videoStreams++
-		case "audio":
-			audioStreams++
+	require.Error(t, err, "a dead ffmpeg must be reported, not waited out")
+	assert.Contains(t, err.Error(), "ffmpeg exited before the ingest finished")
+	// The stderr tail is what makes the failure diagnosable at all.
+	assert.Contains(t, err.Error(), "ffmpeg stderr")
+}
+
+// countOpenFDs reports how many descriptors this process holds.
+//
+// Linux exposes this as /proc/self/fd, which is where the workers run. macOS has
+// /dev/fd but os.ReadDir on it fails with EBADF, so this skips there rather than
+// pretending to measure something.
+func countOpenFDs(t *testing.T) int {
+	t.Helper()
+
+	for _, dir := range []string{"/proc/self/fd", "/dev/fd"} {
+		entries, err := os.ReadDir(dir)
+		if err == nil {
+			return len(entries)
 		}
 	}
-	assert.Equal(t, 1, videoStreams)
-	assert.Equal(t, 1, audioStreams)
+
+	t.Skip("no readable fd directory on this platform (expected on macOS; runs on Linux)")
+	return 0
 }
 
-func TestPreview_VUMeters_MultipleAudioTracks(t *testing.T) {
-	t.Parallel()
-	trackCounts := []int{1, 2, 4, 16}
-	os.MkdirAll("testdata/generated", 0755)
+// Each invocation used to leak the tail pipe's read end and leave an unreaped tail:
+// StdoutPipe registers the read end in tailCmd.parentIOPipes, which only Wait closes,
+// and Wait was never called. That leak is also the only thing that could ever have made
+// os.Pipe fail, which the old code answered with os.Exit(1).
+func TestGrowingPreview_DoesNotLeakDescriptors(t *testing.T) {
+	// Warm up first so one-off allocations are not counted as growth.
+	_ = growingPreviewFailFast(t)
+	before := countOpenFDs(t)
 
-	for _, n := range trackCounts {
-		t.Run("audio_tracks_"+string(rune(n)), func(t *testing.T) {
-			inputFile := filepath.Join("testdata/generated", fmt.Sprintf("testsrc_%dtracks.mov", n))
-			outputDir := "testdata/generated"
-			p, err := paths.Parse(inputFile)
-			require.NoError(t, err)
-			testutils.GenerateSoftronTestFile(p, n, 2.0)
-
-			previewInput := PreviewInput{
-				FilePath:      inputFile,
-				OutputDir:     outputDir,
-				WatermarkPath: "testdata/test_overlay.png",
-			}
-
-			result, err := Preview(previewInput, nil)
-			require.NoError(t, err, "Preview should succeed for %d tracks", n)
-			require.NotNil(t, result)
-			stat, err := os.Stat(result.LowResolutionPath)
-			require.NoError(t, err)
-			require.True(t, stat.Size() > 1000, "Preview output should not be empty for %d tracks", n)
-		})
+	const iterations = 5
+	for i := 0; i < iterations; i++ {
+		_ = growingPreviewFailFast(t)
 	}
-}
 
-func TestPreview_VUMeters_SeparateAudioStreams(t *testing.T) {
-	t.Parallel()
-	trackCounts := []int{1, 2, 4, 8}
-	os.MkdirAll("testdata/generated", 0755)
-
-	for _, n := range trackCounts {
-		t.Run(fmt.Sprintf("separate_streams_%d", n), func(t *testing.T) {
-			inputFile := filepath.Join("testdata/generated", fmt.Sprintf("testsrc_separate_%dstreams.mov", n))
-			outputDir := "testdata/generated"
-			p, err := paths.Parse(inputFile)
-			require.NoError(t, err)
-			testutils.GenerateSeparateAudioStreamsTestFile(p, n, 2.0)
-
-			previewInput := PreviewInput{
-				FilePath:      inputFile,
-				OutputDir:     outputDir,
-				WatermarkPath: "testdata/test_overlay.png",
-			}
-
-			result, err := Preview(previewInput, nil)
-			require.NoError(t, err, "Preview should succeed for %d separate streams", n)
-			require.NotNil(t, result)
-			stat, err := os.Stat(result.LowResolutionPath)
-			require.NoError(t, err)
-			require.True(t, stat.Size() > 1000, "Preview output should not be empty for %d separate streams", n)
-		})
-	}
+	after := countOpenFDs(t)
+	assert.LessOrEqual(t, after, before+1,
+		"descriptors grew from %d to %d over %d runs, so the tail pipe is still leaking",
+		before, after, iterations)
 }


### PR DESCRIPTION
### What

`transcode.GrowingPreview` runs `tail -f` piped into ffmpeg for live-ingest previews. Four lifecycle defects, in the order they actually matter:

1. **A retry storm that leaves two ffmpegs writing the same segments.** The loop ran a full remux of the whole accumulated playlist *between* heartbeats. That remux grows over a multi-hour event while `HeartbeatTimeout` is 10 m — one slow iteration times out the attempt, Temporal retries and restarts `tail` from byte 0, and because ffmpeg was not context-bound the previous attempt's ffmpeg kept writing into the same `TempDir`.
2. **An 8-hour silent failure window.** The loop selected only on a 60 s timer and `ctx.Done()`, so ffmpeg exiting early went unnoticed: the activity kept heartbeating and remuxing a stale playlist, looking healthy, until `StartToCloseTimeout`.
3. **A leaked fd and zombie per invocation** — `StdoutPipe`'s read end is closed only by `Wait()`, which was never called.
4. **`os.Exit(1)`** on `StdoutPipe` failure, the only `os.Exit` in the repo. It kills the worker with no error and no heartbeat flush, taking every concurrent transcode with it. Practically unreachable — it needs fd exhaustion — but it is the response to the leak in (3).

### Fix

Returns an error instead of exiting, `Wait`s on `tail`, and binds ffmpeg to the context with `Cancel = func() error { return nil }` plus `WaitDelay`. The no-op `Cancel` is deliberate: cancellation kills `tail`, ffmpeg sees EOF on stdin and **finalises the HLS playlist gracefully** — SIGKILLing it instead would risk truncating the final segment. Adds `ffmpegDone` as a third `select` case, tees stderr through a bounded tail so the returned error carries ffmpeg's own words, and adds the house `simpleHeartBeater` so heartbeats no longer depend on the remux finishing.

### Verification

The early-exit test hangs to its deadline against the old code. The three tests that need real media move behind `//go:build integration` — they took ~21 s, and unit tests should be well under a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
