### PR TITLE
fix: return the errors that MergeTranscripts and Multitrack were dropping

### DIFF
--- a/activities/transcribe.go
+++ b/activities/transcribe.go
@@ -3,6 +3,7 @@ package activities
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -71,7 +72,10 @@ func (ua UtilActivities) MergeTranscriptJSON(
 	log.Info("Starting MergeTranscriptJSON")
 
 	targetFile := input.DestinationPath.Append("merged_transcription.no.json")
-	mergedTranscription := transcribe.MergeTranscripts(input.MergeInput)
+	mergedTranscription, err := transcribe.MergeTranscripts(input.MergeInput)
+	if err != nil {
+		return nil, fmt.Errorf("merging transcripts failed: %w", err)
+	}
 
 	marshalled, err := json.Marshal(mergedTranscription)
 	if err != nil {

--- a/services/transcribe/merge_test.go
+++ b/services/transcribe/merge_test.go
@@ -1,0 +1,91 @@
+package transcribe
+
+import (
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/common"
+	"github.com/bcc-code/bcc-media-flows/paths"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testdataPath(name string) paths.Path {
+	return paths.Path{Drive: paths.TestDrive, Path: name}
+}
+
+func mergeInput(items ...common.MergeInputItem) common.MergeInput {
+	return common.MergeInput{Title: "test", Items: items}
+}
+
+// The regression: read failures were appended to an errs slice that was never
+// returned, and the signature had no error at all. An unreadable input silently
+// dropped that whole cut from the merged transcript, and the caller wrote the short
+// result to disk as if it were complete.
+func TestMergeTranscripts_UnreadableFileIsReported(t *testing.T) {
+	result, err := MergeTranscripts(mergeInput(
+		common.MergeInputItem{Path: testdataPath("does_not_exist.json"), Start: 0, End: 10},
+	))
+
+	require.Error(t, err, "an unreadable transcript must not be silently skipped")
+	assert.Nil(t, result)
+}
+
+// Malformed JSON takes the same path, since JsonFileToStruct returns the unmarshal
+// error.
+func TestMergeTranscripts_MalformedJSONIsReported(t *testing.T) {
+	result, err := MergeTranscripts(mergeInput(
+		common.MergeInputItem{Path: testdataPath("malformed.json"), Start: 0, End: 10},
+	))
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+// A partial failure is the dangerous case: one good cut and one bad one used to
+// produce a plausible-looking transcript containing only the good half.
+func TestMergeTranscripts_PartialFailureIsReported(t *testing.T) {
+	result, err := MergeTranscripts(mergeInput(
+		common.MergeInputItem{Path: testdataPath("transcript_a.json"), Start: 0, End: 10},
+		common.MergeInputItem{Path: testdataPath("does_not_exist.json"), Start: 0, End: 10},
+	))
+
+	require.Error(t, err, "a merged transcript missing a cut must not be returned as success")
+	assert.Nil(t, result)
+}
+
+// The happy path still merges, so the change is not just failing everything.
+func TestMergeTranscripts_MergesReadableInput(t *testing.T) {
+	result, err := MergeTranscripts(mergeInput(
+		common.MergeInputItem{Path: testdataPath("transcript_a.json"), Start: 0, End: 10},
+	))
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Len(t, result.Segments, 2)
+	assert.Contains(t, result.Text, "hello")
+	assert.Contains(t, result.Text, "world")
+	assert.Equal(t, "no", result.Language)
+}
+
+// Two readable cuts are offset by the duration of the ones before them.
+func TestMergeTranscripts_OffsetsLaterCuts(t *testing.T) {
+	result, err := MergeTranscripts(mergeInput(
+		common.MergeInputItem{Path: testdataPath("transcript_a.json"), Start: 0, End: 4},
+		common.MergeInputItem{Path: testdataPath("transcript_a.json"), Start: 0, End: 4},
+	))
+
+	require.NoError(t, err)
+	require.Len(t, result.Segments, 4)
+
+	// First cut keeps its own timings; the second is pushed out by the first's length.
+	assert.Equal(t, 0.0, result.Segments[0].Start)
+	assert.Equal(t, 4.0, result.Segments[2].Start)
+}
+
+func TestMergeTranscripts_NoItems(t *testing.T) {
+	result, err := MergeTranscripts(mergeInput())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Segments)
+}

--- a/services/transcribe/merge_test.go
+++ b/services/transcribe/merge_test.go
@@ -17,10 +17,9 @@ func mergeInput(items ...common.MergeInputItem) common.MergeInput {
 	return common.MergeInput{Title: "test", Items: items}
 }
 
-// The regression: read failures were appended to an errs slice that was never
-// returned, and the signature had no error at all. An unreadable input silently
-// dropped that whole cut from the merged transcript, and the caller wrote the short
-// result to disk as if it were complete.
+// An unreadable input must be reported rather than skipped. Dropping one cut still
+// produces a plausible-looking transcript, which the caller writes to disk as if it
+// were complete — so the failure has to travel out through the signature.
 func TestMergeTranscripts_UnreadableFileIsReported(t *testing.T) {
 	result, err := MergeTranscripts(mergeInput(
 		common.MergeInputItem{Path: testdataPath("does_not_exist.json"), Start: 0, End: 10},

--- a/services/transcribe/merge_test.go
+++ b/services/transcribe/merge_test.go
@@ -41,8 +41,8 @@ func TestMergeTranscripts_MalformedJSONIsReported(t *testing.T) {
 	assert.Nil(t, result)
 }
 
-// A partial failure is the dangerous case: one good cut and one bad one used to
-// produce a plausible-looking transcript containing only the good half.
+// A partial failure is the dangerous case: one good cut and one bad one must report
+// the error, not return a plausible-looking transcript containing only the good half.
 func TestMergeTranscripts_PartialFailureIsReported(t *testing.T) {
 	result, err := MergeTranscripts(mergeInput(
 		common.MergeInputItem{Path: testdataPath("transcript_a.json"), Start: 0, End: 10},

--- a/services/transcribe/testdata/malformed.json
+++ b/services/transcribe/testdata/malformed.json
@@ -1,0 +1,1 @@
+{ this is not valid json

--- a/services/transcribe/testdata/transcript_a.json
+++ b/services/transcribe/testdata/transcript_a.json
@@ -1,0 +1,8 @@
+{
+  "text": "hello world ",
+  "language": "no",
+  "segments": [
+    {"id": 0, "start": 0.0, "end": 2.0, "text": "hello", "words": [{"text": "hello", "start": 0.0, "end": 1.0}]},
+    {"id": 1, "start": 2.0, "end": 4.0, "text": "world", "words": [{"text": "world", "start": 2.0, "end": 3.0}]}
+  ]
+}

--- a/services/transcribe/transcribe.go
+++ b/services/transcribe/transcribe.go
@@ -2,6 +2,7 @@ package transcribe
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -277,7 +278,7 @@ type Word struct {
 	Confidence float64 `json:"confidence"`
 }
 
-func MergeTranscripts(input common.MergeInput) *Transcription {
+func MergeTranscripts(input common.MergeInput) (*Transcription, error) {
 	mergedTranscription := &Transcription{
 		Language: "no",
 		Text:     "",
@@ -330,5 +331,12 @@ func MergeTranscripts(input common.MergeInput) *Transcription {
 
 		startAt += mi.End - mi.Start
 	}
-	return mergedTranscription
+
+	// These were collected and then dropped, so an unreadable input file silently
+	// produced a merged transcript missing that whole cut.
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	return mergedTranscription, nil
 }

--- a/workflows/ingest/multitrack.go
+++ b/workflows/ingest/multitrack.go
@@ -108,9 +108,8 @@ func Multitrack(ctx workflow.Context, params MasterParams) (*MasterResult, error
 		return nil, err
 	}
 
-	// Previously `return nil, nil`, which discarded the asset that had just been
-	// created and left callers unable to tell a successful run from an empty one.
-	// Matches what Masters returns.
+	// Callers need the created asset to tell a successful run from an empty one.
+	// Shaped like what Masters returns.
 	return &MasterResult{
 		ImportedVXs: importedVXs,
 	}, nil

--- a/workflows/ingest/multitrack.go
+++ b/workflows/ingest/multitrack.go
@@ -99,12 +99,19 @@ func Multitrack(ctx workflow.Context, params MasterParams) (*MasterResult, error
 		return nil, err
 	}
 
-	err = notifyImportCompleted(ctx, params.Targets, params.Metadata.JobProperty.JobID, map[string]paths.Path{
+	importedVXs := map[string]paths.Path{
 		result.AssetID: muxResult.OutputPath,
-	})
+	}
+
+	err = notifyImportCompleted(ctx, params.Targets, params.Metadata.JobProperty.JobID, importedVXs)
 	if err != nil {
 		return nil, err
 	}
 
-	return nil, nil
+	// Previously `return nil, nil`, which discarded the asset that had just been
+	// created and left callers unable to tell a successful run from an empty one.
+	// Matches what Masters returns.
+	return &MasterResult{
+		ImportedVXs: importedVXs,
+	}, nil
 }


### PR DESCRIPTION
### What

Two functions dropped errors on the floor:

- `MergeTranscripts` appended read failures to an `errs` slice that was never returned, and had no error in its signature at all. An unreadable input silently dropped that whole cut from the merged transcript, and `MergeTranscriptJSON` wrote the short result to disk as if it were complete.
- `Multitrack` returned `nil, nil`, so callers could not tell a successful run from an empty one.

### Fix

`MergeTranscripts` returns `(*Transcription, error)` with `errors.Join`; `Multitrack` returns a populated `MasterResult`.

### Verification

First tests for `services/transcribe`, which had none. The partial-failure case — one good cut and one bad — fails against the old code by returning a plausible-looking transcript containing only the good half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
