### PR TITLE
fix(cantemo): close the holes in the HTTP status hook

### DIFF
--- a/services/cantemo/client.go
+++ b/services/cantemo/client.go
@@ -18,6 +18,40 @@ type cantemoErrorResponse struct {
 	Detail string `json:"detail"`
 }
 
+// maxErrorBodyLen bounds how much of an error body is quoted back. These errors
+// travel up into the Temporal workflow history, and an HTML error page from a proxy
+// would otherwise put the whole document there.
+const maxErrorBodyLen = 512
+
+func truncateErrorBody(body []byte) string {
+	if len(body) <= maxErrorBodyLen {
+		return string(body)
+	}
+	return string(body[:maxErrorBodyLen]) + "…(truncated)"
+}
+
+// cantemoErrorFromResponse describes a non-2xx response.
+//
+// The status is checked by the caller rather than inferred from resp.Error() being
+// populated. resty only unmarshals an error body for JSON and XML content types, so
+// the previous hook returned nil for an HTML 502 from a proxy or an empty-bodied
+// 404 — leaving callers with a zero-valued result and no error. It also fell back to
+// merry.New("") when the envelope carried no "detail", producing a non-nil error
+// with an empty message.
+func cantemoErrorFromResponse(resp *resty.Response) error {
+	request := resp.Request.Method + " " + resp.Request.URL
+
+	detail := truncateErrorBody(resp.Body())
+	if cantemoError, ok := resp.Error().(*cantemoErrorResponse); ok && cantemoError != nil && cantemoError.Detail != "" {
+		detail = cantemoError.Detail
+	}
+
+	return merry.New(
+		fmt.Sprintf("cantemo %s failed (status %d): %s", request, resp.StatusCode(), detail),
+		merry.WithHTTPCode(resp.StatusCode()),
+	)
+}
+
 func NewClient(baseURL, authToken string) *Client {
 	baseURL = strings.TrimSuffix(baseURL, "/")
 
@@ -27,12 +61,11 @@ func NewClient(baseURL, authToken string) *Client {
 	client.SetHeader("Accept", "application/json")
 	client.SetDisableWarn(true)
 	client.SetError(cantemoErrorResponse{})
-	client.OnAfterResponse(func(c *resty.Client, resp *resty.Response) error {
-		cantemoError, ok := resp.Error().(*cantemoErrorResponse)
-		if ok && cantemoError != nil {
-			return merry.New(cantemoError.Detail, merry.WithHTTPCode(resp.StatusCode()))
+	client.OnAfterResponse(func(_ *resty.Client, resp *resty.Response) error {
+		if !resp.IsError() {
+			return nil
 		}
-		return nil
+		return cantemoErrorFromResponse(resp)
 	})
 
 	return &Client{
@@ -61,8 +94,10 @@ func (c *Client) GetFormats(itemID string) ([]Format, error) {
 }
 
 func (c *Client) GetMetadata(itemID string) (*ItemMetadata, error) {
+	// SetDebug(true) used to be here. resty's debug mode dumps every request header,
+	// including the Auth-Token set in NewClient, plus the full response body — to
+	// stdout, on every metadata fetch.
 	req := c.restyClient.R()
-	req.SetDebug(true)
 	res, err := req.SetResult(&ItemMetadata{}).
 		Get("/API/v2/items/" + itemID + "/")
 
@@ -272,25 +307,25 @@ type ACLInheritanceExtraData struct {
 // ACLInheritance represents the inherited_from field in ACL
 // (extracted to a named type)
 type ACLInheritance struct {
-	ID        string                 `json:"id"`
-	Type      string                 `json:"type"`
+	ID        string                  `json:"id"`
+	Type      string                  `json:"type"`
 	ExtraData ACLInheritanceExtraData `json:"extra_data"`
 }
 
 // ACL represents an access control list entry for a Cantemo item
 type ACL struct {
-	Source               string           `json:"source"`
-	SourceName           string           `json:"source_name"`
-	SourceFullName       *string          `json:"source_full_name"`
-	Permission           string           `json:"permission"`
-	PermissionTranslated string           `json:"permission_translated"`
-	Recursive            bool             `json:"recursive"`
-	Grantor              string           `json:"grantor"`
-	GrantorFullName      *string          `json:"grantor_full_name"`
-	ID                   string           `json:"id"`
-	Priority             string           `json:"priority"`
-	PriorityTranslated   string           `json:"priority_translated"`
-	InheritedFrom        *ACLInheritance  `json:"inherited_from"`
+	Source               string          `json:"source"`
+	SourceName           string          `json:"source_name"`
+	SourceFullName       *string         `json:"source_full_name"`
+	Permission           string          `json:"permission"`
+	PermissionTranslated string          `json:"permission_translated"`
+	Recursive            bool            `json:"recursive"`
+	Grantor              string          `json:"grantor"`
+	GrantorFullName      *string         `json:"grantor_full_name"`
+	ID                   string          `json:"id"`
+	Priority             string          `json:"priority"`
+	PriorityTranslated   string          `json:"priority_translated"`
+	InheritedFrom        *ACLInheritance `json:"inherited_from"`
 }
 
 // ACLResponse remains unchanged

--- a/services/cantemo/client.go
+++ b/services/cantemo/client.go
@@ -32,12 +32,11 @@ func truncateErrorBody(body []byte) string {
 
 // cantemoErrorFromResponse describes a non-2xx response.
 //
-// The status is checked by the caller rather than inferred from resp.Error() being
-// populated. resty only unmarshals an error body for JSON and XML content types, so
-// the previous hook returned nil for an HTML 502 from a proxy or an empty-bodied
-// 404 — leaving callers with a zero-valued result and no error. It also fell back to
-// merry.New("") when the envelope carried no "detail", producing a non-nil error
-// with an empty message.
+// Callers decide on the status directly rather than inferring it from resp.Error()
+// being populated: resty only unmarshals an error body for JSON and XML content
+// types, so an HTML 502 from a proxy or an empty-bodied 404 leaves resp.Error() nil.
+// The message never depends solely on the envelope's "detail" either, since that key
+// is absent from some responses.
 func cantemoErrorFromResponse(resp *resty.Response) error {
 	request := resp.Request.Method + " " + resp.Request.URL
 
@@ -94,9 +93,8 @@ func (c *Client) GetFormats(itemID string) ([]Format, error) {
 }
 
 func (c *Client) GetMetadata(itemID string) (*ItemMetadata, error) {
-	// SetDebug(true) used to be here. resty's debug mode dumps every request header,
-	// including the Auth-Token set in NewClient, plus the full response body — to
-	// stdout, on every metadata fetch.
+	// Debug mode must stay off here: resty dumps every request header, including the
+	// Auth-Token set in NewClient, plus the full response body, to stdout.
 	req := c.restyClient.R()
 	res, err := req.SetResult(&ItemMetadata{}).
 		Get("/API/v2/items/" + itemID + "/")

--- a/services/cantemo/status_test.go
+++ b/services/cantemo/status_test.go
@@ -1,0 +1,133 @@
+package cantemo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cantemoServer serves one fixed response for every request.
+func cantemoServer(t *testing.T, status int, contentType, body string) *Client {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	return NewClient(server.URL, "token")
+}
+
+// Hole 1, the important one. resty only unmarshals an error body for JSON/XML, so the
+// old hook saw a nil resp.Error() for an HTML response and returned nil. Callers then
+// got a zero-valued result with no error — for GetFiles that meant
+// MoveFileByImportDate iterating zero objects and reporting success.
+func TestClient_HTMLErrorBodyIsAnError(t *testing.T) {
+	client := cantemoServer(t, http.StatusBadGateway, "text/html", "<html>502 Bad Gateway</html>")
+
+	result, err := client.GetFiles("/mnt/x", "imported", "storage", 0, "")
+
+	require.Error(t, err, "an HTML 502 must not read as a file listing with no files")
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "502")
+}
+
+// Same hole with an empty body, which is what a bare 404 from a gateway looks like.
+func TestClient_EmptyErrorBodyIsAnError(t *testing.T) {
+	client := cantemoServer(t, http.StatusNotFound, "text/plain", "")
+
+	result, err := client.GetFiles("/mnt/x", "imported", "storage", 0, "")
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "404")
+}
+
+// Hole 2: a JSON error envelope with no "detail" key produced merry.New(""), a non-nil
+// error carrying no message at all, which then surfaced in Temporal as a blank failure.
+func TestClient_JSONErrorWithoutDetailStillDescribesItself(t *testing.T) {
+	client := cantemoServer(t, http.StatusInternalServerError, "application/json", `{"other":"field"}`)
+
+	_, err := client.GetFiles("/mnt/x", "imported", "storage", 0, "")
+
+	require.Error(t, err)
+	assert.NotEmpty(t, strings.TrimSpace(err.Error()), "the error must say something")
+	assert.Contains(t, err.Error(), "500")
+}
+
+// The structured envelope is still preferred when present.
+func TestClient_JSONDetailIsUsed(t *testing.T) {
+	client := cantemoServer(t, http.StatusForbidden, "application/json",
+		`{"detail":"You do not have permission to perform this action."}`)
+
+	_, err := client.GetFiles("/mnt/x", "imported", "storage", 0, "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "You do not have permission")
+	assert.Contains(t, err.Error(), "403")
+}
+
+// AddRelation returns only an error, so there is no result to inspect. A swallowed
+// failure let import_audio_from_reaper write RelatedMBFieldID metadata as though the
+// relation existed.
+func TestClient_AddRelationReportsFailure(t *testing.T) {
+	client := cantemoServer(t, http.StatusBadGateway, "text/html", "<html>nope</html>")
+
+	err := client.AddRelation("VX-1", "VX-2")
+
+	require.Error(t, err, "a failed relation must not look like a created one")
+}
+
+// GetLookupChoices returning an empty map with a nil error made every chapter publish
+// its raw machine key instead of the human label.
+func TestClient_GetLookupChoicesReportsFailure(t *testing.T) {
+	client := cantemoServer(t, http.StatusInternalServerError, "text/html", "<html>boom</html>")
+
+	choices, err := client.GetLookupChoices("group", "field")
+
+	require.Error(t, err, "an empty choice map must not be indistinguishable from a failure")
+	assert.Nil(t, choices)
+}
+
+// A large error body must not be quoted in full: these errors are stored in the
+// Temporal workflow history.
+func TestClient_ErrorBodyIsTruncated(t *testing.T) {
+	client := cantemoServer(t, http.StatusInternalServerError, "text/html",
+		"<html>"+strings.Repeat("x", 50_000)+"</html>")
+
+	_, err := client.GetFiles("/mnt/x", "imported", "storage", 0, "")
+
+	require.Error(t, err)
+	assert.Less(t, len(err.Error()), 2048, "error body should be bounded")
+	assert.Contains(t, err.Error(), "truncated")
+}
+
+// Success must be untouched by the hook, including the timestamp parsing that follows.
+func TestClient_SuccessIsUnaffected(t *testing.T) {
+	client := cantemoServer(t, http.StatusOK, "application/json",
+		`{"objects":[{"name":"a.mxf","timestamp":"2021-04-20T16:44:51.790+0000"}]}`)
+
+	result, err := client.GetFiles("/mnt/x", "imported", "storage", 0, "")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Len(t, result.Objects, 1)
+}
+
+// A genuinely empty listing on a 200 is still an empty listing, not an error — the
+// distinction the hook exists to restore.
+func TestClient_EmptySuccessIsNotAnError(t *testing.T) {
+	client := cantemoServer(t, http.StatusOK, "application/json", `{"objects":[]}`)
+
+	result, err := client.GetFiles("/mnt/x", "imported", "storage", 0, "")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Objects)
+}


### PR DESCRIPTION
### What

`cantemo` already had an `OnAfterResponse` hook — the shape the audit recommends — but it only fired when resty had populated `Error()`, and resty only unmarshals on 2xx. An HTML 502 from a proxy, or any error body that wasn't the expected JSON, passed straight through as success.

### Fix

Keys the hook off `IsError()` and falls back to a 512-byte truncated body when the JSON `detail` isn't there. Also removes `req.SetDebug(true)` from `GetMetadata`, which dumped the `Auth-Token` header and the full response body to stdout on every metadata fetch.

### Verification

New `httptest` tests covering JSON errors, non-JSON error bodies, and success. They fail against the old code by returning a zero-valued result with `err == nil`.

### Not in this PR

`cantemo` still has no HTTP timeout. Recorded in the audit doc, along with the proposal to replace the seven hand-rolled clients with one shared constructor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
