### PR TITLE
fix(workflows): use workflow.Now instead of time.Now in workflow code

### DIFF
--- a/utils/workflows/interceptors.go
+++ b/utils/workflows/interceptors.go
@@ -55,13 +55,22 @@ func (c *AnalyticsWorkflowInboundInterceptor) ExecuteWorkflow(
 		parent = info.ParentWorkflowExecution.ID
 	}
 
-	analytics.GetService().WorkflowStarted(info.WorkflowType.Name, info.WorkflowExecution.ID, parent)
+	// Emitting only outside replay keeps one event per workflow: a replayed task
+	// re-runs this interceptor from the top, so an unguarded call would report the
+	// same workflow started again on every cache eviction.
+	if !workflow.IsReplaying(ctx) {
+		//workflowcheck:ignore analytics writes to stdout/rudderstack, but only outside replay
+		analytics.GetService().WorkflowStarted(info.WorkflowType.Name, info.WorkflowExecution.ID, parent)
+	}
 
-	startTime := time.Now()
+	// workflow.Now, not time.Now: the wall clock differs between the original run
+	// and a replay, and it measures time spent in this worker rather than the
+	// workflow's own elapsed time.
+	startTime := workflow.Now(ctx)
 
 	result, err := c.Next.ExecuteWorkflow(ctx, in)
 
-	duration := time.Since(startTime)
+	duration := workflow.Now(ctx).Sub(startTime)
 	executionTime := duration.Milliseconds()
 
 	status := "Success"
@@ -69,7 +78,10 @@ func (c *AnalyticsWorkflowInboundInterceptor) ExecuteWorkflow(
 		status = "Failure"
 	}
 
-	analytics.GetService().WorkflowFinished(info.WorkflowType.Name, info.WorkflowExecution.ID, parent, status, executionTime)
+	if !workflow.IsReplaying(ctx) {
+		//workflowcheck:ignore analytics writes to stdout/rudderstack, but only outside replay
+		analytics.GetService().WorkflowFinished(info.WorkflowType.Name, info.WorkflowExecution.ID, parent, status, executionTime)
+	}
 
 	return result, err
 }

--- a/workflows/export/generate_short.go
+++ b/workflows/export/generate_short.go
@@ -98,7 +98,9 @@ func GenerateShort(ctx workflow.Context, params GenerateShortDataParams) (*Gener
 		return nil, err
 	}
 
-	titleWithShort := badChars.ReplaceAllString(exportData.Title, "_") + "_short_" + time.Now().Format("20060102150405")
+	// workflow.Now is stable across replays; time.Now would name the output file
+	// differently every time the workflow is replayed.
+	titleWithShort := badChars.ReplaceAllString(exportData.Title, "_") + "_short_" + workflow.Now(ctx).Format("20060102150405")
 
 	clip := exportData.Clips[0]
 	clip.InSeconds = params.InSeconds


### PR DESCRIPTION
**1/6 of a stack clearing `workflowcheck`'s ten reports.** Base: `master`.

Two of the ten are the same defect: the wall clock read from inside a workflow.

`GenerateShort` builds the output filename from `time.Now()`, so a replay names the file after the replay's clock rather than the original run's.

The analytics workflow interceptor timed every workflow with `time.Now()`/`time.Since()`. Besides being non-deterministic it measured the wrong thing — the interceptor's goroutine is re-entered from the top on every replay, so the reported duration was time spent in the current worker, not the workflow's elapsed time. `workflow.Now()` differencing gives the real duration and survives replay.

The same re-entry made the analytics events duplicate: **every cache eviction re-emitted `WorkflowStarted`** for a workflow that started hours ago. Both emissions now sit behind `workflow.IsReplaying`, so each workflow reports exactly one start and one finish. Those two calls carry `//workflowcheck:ignore`, since the checker cannot see the replay guard.

Verified: `workflowcheck` no longer reports `interceptors.go:47` or `generate_short.go:43`. Eight sites remain, cleared by the branches on top of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)