### PR TITLE
fix(workflows): iterate maps in sorted key order

### DIFF
--- a/utils/workflows/files.go
+++ b/utils/workflows/files.go
@@ -15,7 +15,6 @@ import (
 	"github.com/bcc-code/bcc-media-flows/activities"
 	"github.com/bcc-code/bcc-media-flows/environment"
 	"github.com/bcc-code/bcc-media-flows/paths"
-	"github.com/samber/lo"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -186,15 +185,6 @@ func GetWorkflowTempFolder(ctx workflow.Context) (paths.Path, error) {
 	}
 
 	return path, CreateFolder(ctx, path)
-}
-
-// GetMapKeysSafely makes sure that the order of the keys returned are identical to other workflow executions.
-func GetMapKeysSafely[K comparable, T any](ctx workflow.Context, m map[K]T) ([]K, error) {
-	var keys []K
-	err := workflow.SideEffect(ctx, func(ctx workflow.Context) any {
-		return lo.Keys(m)
-	}).Get(&keys)
-	return keys, err
 }
 
 func IsImage(ctx workflow.Context, file paths.Path) (bool, error) {

--- a/utils/workflows/maps.go
+++ b/utils/workflows/maps.go
@@ -1,0 +1,39 @@
+package wfutils
+
+import (
+	"cmp"
+	"slices"
+
+	"github.com/samber/lo"
+	"go.temporal.io/sdk/workflow"
+)
+
+// SortedKeys returns the keys of m in ascending order.
+//
+// Workflow code must not range over a map: Go randomizes the iteration order,
+// so a replay can visit the entries in a different order than the original run
+// and schedule its activities in a different order. Ranging over SortedKeys
+// instead gives the same order every time.
+//
+// Unlike GetMapKeysSafely this costs no history: the order is derived from the
+// keys rather than recorded, so there is no SideEffect to replay. Prefer it
+// wherever the key type is ordered.
+//
+//workflowcheck:ignore the map iteration below feeds a sort, so the result does not depend on it
+func SortedKeys[K cmp.Ordered, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// GetMapKeysSafely makes sure that the order of the keys returned are identical to other workflow executions.
+func GetMapKeysSafely[K comparable, T any](ctx workflow.Context, m map[K]T) ([]K, error) {
+	var keys []K
+	err := workflow.SideEffect(ctx, func(ctx workflow.Context) any {
+		return lo.Keys(m)
+	}).Get(&keys)
+	return keys, err
+}

--- a/utils/workflows/maps_test.go
+++ b/utils/workflows/maps_test.go
@@ -1,0 +1,32 @@
+package wfutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortedKeysIsOrdered(t *testing.T) {
+	got := SortedKeys(map[string]int{"nor": 1, "eng": 2, "deu": 3, "abk": 4})
+	assert.Equal(t, []string{"abk", "deu", "eng", "nor"}, got)
+}
+
+// The point of the helper is that the result cannot depend on Go's randomized
+// map iteration order, so run it enough times that an unsorted implementation
+// would be seen returning something else.
+func TestSortedKeysIsStableAcrossIterations(t *testing.T) {
+	m := map[string]int{}
+	for _, k := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
+		m[k] = 0
+	}
+
+	want := SortedKeys(m)
+	for i := 0; i < 100; i++ {
+		assert.Equal(t, want, SortedKeys(m))
+	}
+}
+
+func TestSortedKeysOnEmptyAndNilMaps(t *testing.T) {
+	assert.Empty(t, SortedKeys(map[string]int{}))
+	assert.Empty(t, SortedKeys(map[string]int(nil)))
+}

--- a/workflows/ingest/json_form_mapping.go
+++ b/workflows/ingest/json_form_mapping.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bcc-code/bcc-media-flows/services/ingest"
 	"github.com/bcc-code/bcc-media-flows/services/notifications"
+	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 )
 
 // jsonFormSpec describes how a single JSON form (identified by formKey) maps
@@ -80,9 +81,10 @@ func translateJSONForm(form ingest.JSONForm) (*ingest.Metadata, OrderForm, error
 		ReceivedFilename: form.OriginalFilename,
 	}
 
-	for key, target := range spec.fields(&jp) {
+	fields := spec.fields(&jp)
+	for _, key := range wfutils.SortedKeys(fields) {
 		if value, ok := form.Fields[key]; ok {
-			*target = value
+			*fields[key] = value
 		}
 	}
 

--- a/workflows/misc/merge_import_subs.go
+++ b/workflows/misc/merge_import_subs.go
@@ -85,7 +85,8 @@ func MergeAndImportSubtitlesFromCSV(ctx workflow.Context, params MergeAndImportS
 			DestinationFolder: tempPath,
 		}).Result(ctx)
 
-		for lang, sub := range res {
+		for _, lang := range wfutils.SortedKeys(res) {
+			sub := res[lang]
 
 			if _, ok := mergeData[lang]; !ok {
 				mergeData[lang] = &common.MergeInput{


### PR DESCRIPTION
**3/6 of a stack clearing `workflowcheck`'s ten reports.** Base: `fix/wfcheck-workflow-logger` (#434).

Two workflows ranged over a map directly. Go randomizes that order, so a replay can visit the entries in a different order than the original run.

Adds `wfutils.SortedKeys`, a pure helper that sorts the keys instead of recording them. The existing `GetMapKeysSafely` solves the same problem with a `SideEffect`, which costs a history event per call and returns the keys unsorted — `merge_import_subs` would have paid that cost once per CSV row. `GetMapKeysSafely` moves next to it so the choice is visible; it is **unchanged and its ten callers are untouched**, since dropping a `SideEffect` would break replay for in-flight executions.

Neither call site was reachable as a bug today: `MergeAndImportSubtitlesFromCSV` appends into per-language slices that the outer order cannot reorder, and `translateJSONForm` assigns through pointers that are distinct per key. Both are one aliased key away from mattering, and neither needed the map order to begin with.

Verified: `workflowcheck` no longer reports the map iteration in `merge_import_subs.go`, nor `asset_ingest_json.go` at all. Five reports remain over four sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)