### PR TITLE
fix(misc): parse the sub-merge CSV without gocsv's package globals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/glebarez/go-sqlite v1.22.0
 	github.com/go-resty/resty/v2 v2.16.5
-	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1
 	github.com/google/uuid v1.6.0
 	github.com/jlaffaye/ftp v0.2.0
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,6 @@ github.com/go-playground/validator/v10 v10.20.0/go.mod h1:dbuPbCMFw/DrkbEynArYaC
 github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
 github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1 h1:FWNFq4fM1wPfcK40yHE5UO3RUdSNPaBC+j3PokzA6OQ=
-github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-yaml v1.9.5/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=

--- a/workflows/misc/merge_import_subs.go
+++ b/workflows/misc/merge_import_subs.go
@@ -1,9 +1,9 @@
 package miscworkflows
 
 import (
+	"bytes"
 	"encoding/csv"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
@@ -13,7 +13,6 @@ import (
 	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/services/telegram"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
-	"github.com/gocarina/gocsv"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -157,21 +156,50 @@ func MergeAndImportSubtitlesFromCSV(ctx workflow.Context, params MergeAndImportS
 }
 
 type SubtitleEntry struct {
-	SubtransID  string `csv:"Subtrans ID"`
-	TimecodeStr string `csv:"Timecode start"`
+	SubtransID  string
+	TimecodeStr string
 }
 
+const (
+	subtransIDColumn = "Subtrans ID"
+	timecodeColumn   = "Timecode start"
+)
+
+// parseSubMergeData reads the two columns this workflow needs out of the
+// uploaded CSV, matching them by header name so extra columns and column
+// reordering are both tolerated.
 func parseSubMergeData(input []byte, separator rune) ([]SubtitleEntry, error) {
-	var entries []SubtitleEntry
+	reader := csv.NewReader(bytes.NewReader(input))
+	reader.Comma = separator
 
-	gocsv.SetCSVReader(func(in io.Reader) gocsv.CSVReader {
-		r := csv.NewReader(in)
-		r.Comma = separator
-		return r
-	})
-
-	if err := gocsv.UnmarshalBytes(input, &entries); err != nil {
+	records, err := reader.ReadAll()
+	if err != nil {
 		return nil, err
+	}
+	if len(records) == 0 {
+		return nil, nil
+	}
+
+	idIndex, timecodeIndex := -1, -1
+	for i, name := range records[0] {
+		switch strings.TrimSpace(name) {
+		case subtransIDColumn:
+			idIndex = i
+		case timecodeColumn:
+			timecodeIndex = i
+		}
+	}
+	if idIndex < 0 || timecodeIndex < 0 {
+		return nil, fmt.Errorf("CSV is missing a %q or %q column, got: %s",
+			subtransIDColumn, timecodeColumn, strings.Join(records[0], string(separator)))
+	}
+
+	entries := make([]SubtitleEntry, 0, len(records)-1)
+	for _, record := range records[1:] {
+		entries = append(entries, SubtitleEntry{
+			SubtransID:  record[idIndex],
+			TimecodeStr: record[timecodeIndex],
+		})
 	}
 
 	return entries, nil

--- a/workflows/misc/merge_import_subs_test.go
+++ b/workflows/misc/merge_import_subs_test.go
@@ -1,0 +1,107 @@
+package miscworkflows
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSubMergeData(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		separator rune
+		want      []SubtitleEntry
+	}{
+		{
+			name:      "comma separated",
+			input:     "Subtrans ID,Timecode start\n123,00:00:01:500\n456,00:01:02:250\n",
+			separator: ',',
+			want: []SubtitleEntry{
+				{SubtransID: "123", TimecodeStr: "00:00:01:500"},
+				{SubtransID: "456", TimecodeStr: "00:01:02:250"},
+			},
+		},
+		{
+			name:      "semicolon separated",
+			input:     "Subtrans ID;Timecode start\n123;00:00:01:500\n",
+			separator: ';',
+			want:      []SubtitleEntry{{SubtransID: "123", TimecodeStr: "00:00:01:500"}},
+		},
+		{
+			name:      "columns matched by name, not position",
+			input:     "Title,Timecode start,Subtrans ID\nsomething,00:00:01:500,123\n",
+			separator: ',',
+			want:      []SubtitleEntry{{SubtransID: "123", TimecodeStr: "00:00:01:500"}},
+		},
+		{
+			name:      "header only",
+			input:     "Subtrans ID,Timecode start\n",
+			separator: ',',
+			want:      []SubtitleEntry{},
+		},
+		{
+			name:      "empty input",
+			input:     "",
+			separator: ',',
+			want:      nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseSubMergeData([]byte(test.input), test.separator)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestParseSubMergeDataRejectsMissingColumns(t *testing.T) {
+	_, err := parseSubMergeData([]byte("Subtrans ID,Timecode\n123,00:00:01:500\n"), ',')
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Timecode start")
+}
+
+// The parser used to configure gocsv through a package-level global, so two
+// workflows parsing with different separators could pick up each other's.
+func TestParseSubMergeDataSeparatorIsNotShared(t *testing.T) {
+	const rows = 200
+
+	comma := "Subtrans ID,Timecode start\n" + strings.Repeat("123,00:00:01:500\n", rows)
+	semicolon := "Subtrans ID;Timecode start\n" + strings.Repeat("456;00:00:02:500\n", rows)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			got, err := parseSubMergeData([]byte(comma), ',')
+			assert.NoError(t, err)
+			assert.Len(t, got, rows)
+			if len(got) > 0 {
+				assert.Equal(t, "123", got[0].SubtransID)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			got, err := parseSubMergeData([]byte(semicolon), ';')
+			assert.NoError(t, err)
+			assert.Len(t, got, rows)
+			if len(got) > 0 {
+				assert.Equal(t, "456", got[0].SubtransID)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestGetSeparatorRune(t *testing.T) {
+	assert.Equal(t, ';', getSeparatorRune(";"))
+	assert.Equal(t, ',', getSeparatorRune(""))
+	assert.Equal(t, '\t', getSeparatorRune("\t"))
+	assert.Equal(t, ';', getSeparatorRune(";extra"))
+}


### PR DESCRIPTION
**4/6 of a stack clearing `workflowcheck`'s ten reports.** Base: `fix/wfcheck-map-iteration` (#435).

This one was worse than the conservative false positive it looked like.

`parseSubMergeData` configured the CSV separator by calling `gocsv.SetCSVReader`, which installs a reader factory into a **package-level variable shared by every workflow in the worker**. Two `MergeAndImportSubtitlesFromCSV` executions with different separators race: whichever set the global last decides how both parse. The result is not an error but a single-column row, i.e. an empty Subtrans ID handed to `GetSubtitlesActivity`.

Replaced with `encoding/csv` reading the two columns this workflow needs by header name. Same tolerance for reordered and extra columns, no shared state, and no reflection — which is also what `workflowcheck` was reporting, since its whole complaint about gocsv was the `reflect.Value.Set` chain underneath.

Two deliberate behaviour changes:
- a CSV missing `Subtrans ID` or `Timecode start` is now an **error**. gocsv left the fields empty and carried on, so a renamed column silently produced entries the workflow could not resolve.
- empty input returns no entries instead of an error.

gocsv was the only user of the dependency and is dropped from `go.mod`.

Verified: the new tests fail against the old parser — the missing-column case with *"An error is expected but got nil"*, and the concurrency case under `-race` with rows parsed using the other goroutine's separator. `workflowcheck` is down to four reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)