### PR TITLE
fix(worker): count activities where they run, not where they were scheduled

### DIFF
--- a/analytics/service.go
+++ b/analytics/service.go
@@ -20,7 +20,15 @@ func Init(config Config) {
 	})
 }
 
+// disabled stands in for an uninitialised service. Every method checks
+// rudderClient and returns early, so this drops events instead of panicking on
+// a nil receiver in a process that never called Init.
+var disabled = &Service{}
+
 func GetService() *Service {
+	if Instance == nil {
+		return disabled
+	}
 	return Instance
 }
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -263,9 +263,6 @@ func update(version string) error {
 		return nil
 	}
 
-	// Prevent worker from restarting if there are activities executing
-	wfutils.ActivityWG.Wait()
-
 	ctx := context.Background()
 
 	latest, found, err := selfupdate.DetectLatest(ctx, selfupdate.ParseSlug("bcc-code/bcc-media-flows"))
@@ -278,6 +275,14 @@ func update(version string) error {
 
 	if latest.LessOrEqual(version) {
 		log.Printf("Current version (%s) is the latest", version)
+		return nil
+	}
+
+	// There is an update to install, and installing it restarts the process.
+	// Leave it for the next tick if this worker is in the middle of something;
+	// the caller runs this every five minutes.
+	if running := wfutils.RunningActivities.Running(); running > 0 {
+		log.Printf("Version %s is available, deferring update: %d activities running", latest.Version(), running)
 		return nil
 	}
 

--- a/utils/workflows/execute.go
+++ b/utils/workflows/execute.go
@@ -3,7 +3,6 @@ package wfutils
 import (
 	"context"
 	"reflect"
-	"sync"
 	"time"
 
 	"github.com/bcc-code/bcc-media-flows/activities"
@@ -23,8 +22,6 @@ var StrictRetryPolicy = temporal.RetryPolicy{
 	InitialInterval: 30 * time.Second,
 	MaximumInterval: 30 * time.Second,
 }
-
-var ActivityWG = sync.WaitGroup{}
 
 type Task[TR any] struct {
 	Future workflow.Future
@@ -80,15 +77,7 @@ func Execute[T any, TR any](ctx workflow.Context, activity func(context.Context,
 
 	ctx = workflow.WithActivityOptions(ctx, options)
 
-	future := workflow.ExecuteActivity(ctx, activity, params)
-
-	ActivityWG.Add(1)
-	workflow.Go(ctx, func(ctx workflow.Context) {
-		_ = future.Get(ctx, nil)
-		ActivityWG.Done()
-	})
-
-	return Task[TR]{Future: future}
+	return Task[TR]{Future: workflow.ExecuteActivity(ctx, activity, params)}
 }
 
 // ExecuteWithLowPrioQueue executes the utility activities with the low priority queue

--- a/utils/workflows/interceptors.go
+++ b/utils/workflows/interceptors.go
@@ -95,6 +95,11 @@ type AnalyticsActivityInboundInterceptor struct {
 func (c *AnalyticsActivityInboundInterceptor) ExecuteActivity(
 	ctx context.Context, in *interceptor.ExecuteActivityInput,
 ) (any, error) {
+	// Counted here rather than where the activity was scheduled: this runs in
+	// the process actually executing it, and the deferred call cannot be
+	// skipped the way a workflow coroutine can.
+	defer RunningActivities.Started()()
+
 	info := activity.GetInfo(ctx)
 	startTime := time.Now()
 	workerIdentity, _ := ctx.Value("WorkerIdentity").(string)

--- a/utils/workflows/running_activities.go
+++ b/utils/workflows/running_activities.go
@@ -1,0 +1,47 @@
+package wfutils
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// RunningActivities counts the activities executing in this process. The
+// activity interceptor maintains it, so it reflects the worker that is doing
+// the work rather than the worker that scheduled it — the two are usually
+// different, since Execute routes each activity to the queue that owns it.
+//
+// cmd/worker uses it to hold back the self-update while the worker is busy.
+var RunningActivities = &ActivityCounter{}
+
+// ActivityCounter counts in-flight activities.
+//
+// A sync.WaitGroup is the obvious fit and the wrong one: Add must not race
+// with Wait once the counter has reached zero, and activities start at
+// arbitrary times relative to whoever is reading the count, which panics with
+// "WaitGroup misuse: Add called concurrently with Wait".
+type ActivityCounter struct {
+	running atomic.Int64
+}
+
+// Started records the start of an activity and returns the function that
+// records its end. The returned function is safe to call more than once, so it
+// can be deferred without any further guard.
+func (c *ActivityCounter) Started() func() {
+	c.running.Add(1)
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			c.running.Add(-1)
+		})
+	}
+}
+
+// Running reports how many activities are executing right now.
+//
+// The answer is only true for the instant it is read: the worker can pick up
+// another task immediately afterwards. Callers that must not interrupt work in
+// progress have to stop the worker rather than trust this.
+func (c *ActivityCounter) Running() int {
+	return int(c.running.Load())
+}

--- a/utils/workflows/running_activities_test.go
+++ b/utils/workflows/running_activities_test.go
@@ -1,0 +1,110 @@
+package wfutils
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+)
+
+func TestActivityCounterCountsInFlightActivities(t *testing.T) {
+	c := &ActivityCounter{}
+	assert.Equal(t, 0, c.Running())
+
+	first := c.Started()
+	second := c.Started()
+	assert.Equal(t, 2, c.Running())
+
+	first()
+	assert.Equal(t, 1, c.Running())
+
+	second()
+	assert.Equal(t, 0, c.Running())
+}
+
+func TestActivityCounterDoneIsIdempotent(t *testing.T) {
+	c := &ActivityCounter{}
+	done := c.Started()
+
+	done()
+	done()
+	done()
+
+	assert.Equal(t, 0, c.Running(), "repeated calls must not push the count negative")
+}
+
+func TestActivityCounterUnderConcurrency(t *testing.T) {
+	c := &ActivityCounter{}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			done := c.Started()
+			assert.GreaterOrEqual(t, c.Running(), 1)
+			done()
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 0, c.Running())
+}
+
+type countingActivityInput struct {
+	Fail bool
+}
+
+// countDuringActivity reports what the counter said while it was running, which
+// is the thing the self-update gate reads.
+func countDuringActivity(_ context.Context, in countingActivityInput) (int, error) {
+	running := RunningActivities.Running()
+	if in.Fail {
+		return running, assert.AnError
+	}
+	return running, nil
+}
+
+func newCountingActivityEnv(t *testing.T) *testsuite.TestActivityEnvironment {
+	t.Helper()
+
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestActivityEnvironment()
+	env.SetWorkerOptions(worker.Options{
+		Interceptors: []interceptor.WorkerInterceptor{&AnalyticsWorkerInterceptor{}},
+	})
+	env.RegisterActivity(countDuringActivity)
+	return env
+}
+
+// The old accounting lived in wfutils.Execute, on the worker that scheduled the
+// activity rather than the one running it. These assert the count is visible
+// from inside the activity itself.
+func TestRunningActivitiesCountsFromInsideTheActivity(t *testing.T) {
+	require.Equal(t, 0, RunningActivities.Running())
+
+	env := newCountingActivityEnv(t)
+	val, err := env.ExecuteActivity(countDuringActivity, countingActivityInput{})
+	require.NoError(t, err)
+
+	var running int
+	require.NoError(t, val.Get(&running))
+	assert.Equal(t, 1, running, "the activity should see itself counted")
+	assert.Equal(t, 0, RunningActivities.Running(), "and be uncounted once it returns")
+}
+
+func TestRunningActivitiesIsDecrementedWhenTheActivityFails(t *testing.T) {
+	require.Equal(t, 0, RunningActivities.Running())
+
+	env := newCountingActivityEnv(t)
+	_, err := env.ExecuteActivity(countDuringActivity, countingActivityInput{Fail: true})
+	require.Error(t, err)
+
+	assert.Equal(t, 0, RunningActivities.Running(),
+		"a failed activity must not leak a count, or the worker never self-updates again")
+}


### PR DESCRIPTION
**1/n of a stack.** Base: `master`.

The self-update gate is meant to stop a worker restarting mid-activity. It could not work, for two independent reasons.

**Wrong process.** `ActivityWG` was incremented by `wfutils.Execute`, which runs in the worker executing the *workflow*. Execute's whole job on the line above is to route the activity to the queue that owns it, so the count lands on a different worker than the work. The transcode, audio and live-ingest workers register **no workflows at all**, so their counter is always zero — the gate was a no-op on precisely the workers running multi-hour ffmpeg jobs, while the worker-queue process held itself back for activities it was not running.

**Leaked counts.** `Add(1)` ran on every replay, but `Done()` only ran if that `workflow.Go` coroutine was scheduled to completion. A coroutine still blocked when the workflow function returns is abandoned, so every fire-and-forget `Execute` leaked a count permanently, as does every eviction from the workflow cache. One leak is enough: `ActivityWG.Wait()` then blocks forever and **that worker never self-updates again**, silently. Verified with a throwaway test that a `workflow.Go` blocked at workflow return never runs the rest of its body.

Accounting now happens in the activity interceptor, which runs in the process executing the activity and releases through `defer`. `Execute` loses both the bookkeeping and the extra coroutine it spawned per call; that coroutine issued no commands, so removing it does not change history and is safe for in-flight workflows.

`sync.WaitGroup` is replaced rather than moved: `Add` must not race with `Wait` once the counter has hit zero, which panics with *"WaitGroup misuse: Add called concurrently with Wait"*.

The gate itself now checks the version first and idleness second, so a busy worker no longer blocks on idle every five minutes to discover there was nothing to install — and it logs why an update was deferred. The residual race (an activity starting between the check and `reload.Exec`) is unchanged and needs a graceful `worker.Stop` to close.

`analytics.GetService()` gains a fallback for an uninitialised service: it returned nil and every method dereferences the receiver, so any process registering the interceptor without calling `Init` panicked on its first activity — which is what a test registering the interceptor does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)