### PR TITLE
fix(worker): verify the release binary before replacing the running one

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,11 +61,20 @@ jobs:
       - name: Build
         run: |
           go build -o "$BINARY_NAME" -ldflags="-X 'main.Version=$TAG_NAME'" -v ./cmd/worker
+      # The worker refuses to install a release binary whose .sha256 is missing
+      # or does not match, so this file is not optional. Only the first 64
+      # characters are read, which is the hash sha256sum prints first.
+      - name: Checksum
+        run: |
+          sha256sum "$BINARY_NAME" > "$BINARY_NAME.sha256"
+          cat "$BINARY_NAME.sha256"
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           draft: false
-          files: ${{env.BINARY_NAME}}
+          files: |
+            ${{env.BINARY_NAME}}
+            ${{env.BINARY_NAME}}.sha256
           tag_name: ${{env.TAG_NAME}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -265,7 +265,22 @@ func update(version string) error {
 
 	ctx := context.Background()
 
-	latest, found, err := selfupdate.DetectLatest(ctx, selfupdate.ParseSlug("bcc-code/bcc-media-flows"))
+	// SHAValidator makes the update fail closed: the release must carry a
+	// <binary>.sha256 asset whose hash matches what was downloaded, or nothing
+	// is installed. publish.yml writes that file next to every binary.
+	//
+	// This catches a truncated or corrupted download, not a compromised
+	// release pipeline — the hash is published by the same job, to the same
+	// release, so whoever can write one can write the other. Closing that
+	// needs a signature checked against a key the pipeline cannot mint.
+	updater, err := selfupdate.NewUpdater(selfupdate.Config{
+		Validator: &selfupdate.SHAValidator{},
+	})
+	if err != nil {
+		return fmt.Errorf("could not create updater: %w", err)
+	}
+
+	latest, found, err := updater.DetectLatest(ctx, selfupdate.ParseSlug("bcc-code/bcc-media-flows"))
 	if err != nil {
 		return fmt.Errorf("error occurred while detecting version: %w", err)
 	}
@@ -290,7 +305,7 @@ func update(version string) error {
 	if err != nil {
 		return fmt.Errorf("could not locate executable path")
 	}
-	if err := selfupdate.UpdateTo(ctx, latest.AssetURL, latest.AssetName, exe); err != nil {
+	if err := updater.UpdateTo(ctx, latest, exe); err != nil {
 		return fmt.Errorf("error occurred while updating binary: %w", err)
 	}
 	log.Printf("Successfully updated to version %s", latest.Version())

--- a/cmd/worker/update_test.go
+++ b/cmd/worker/update_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	selfupdate "github.com/creativeprojects/go-selfupdate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const publishWorkflow = "../../.github/workflows/publish.yml"
+
+// The worker refuses to install a release whose checksum asset is missing, so
+// the file publish.yml uploads has to be named the way the validator asks for
+// it. Nothing else connects the two.
+func TestPublishWorkflowUploadsTheChecksumTheUpdaterRequires(t *testing.T) {
+	suffix := strings.TrimPrefix((&selfupdate.SHAValidator{}).GetValidationAssetName("BINARY"), "BINARY")
+	require.Equal(t, ".sha256", suffix)
+
+	yml, err := os.ReadFile(publishWorkflow)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(yml), `sha256sum "$BINARY_NAME" > "$BINARY_NAME`+suffix+`"`,
+		"publish.yml must write the checksum file")
+	assert.Contains(t, string(yml), "${{env.BINARY_NAME}}"+suffix,
+		"publish.yml must attach the checksum file to the release")
+}
+
+// sha256sum prints "<hash>  <name>", and BINARY_NAME contains a slash, so the
+// second column is a path. The validator reads the first 64 characters and
+// ignores the rest — this pins that it really does.
+func TestSHAValidatorAcceptsSha256sumOutput(t *testing.T) {
+	binary := []byte("pretend this is the worker binary")
+	checksumFile := fmt.Sprintf("%x  bcc-code/bcc-media-flows-worker-linux-amd64\n", sha256.Sum256(binary))
+
+	err := (&selfupdate.SHAValidator{}).Validate("bcc-media-flows-worker-linux-amd64", binary, []byte(checksumFile))
+	assert.NoError(t, err)
+}
+
+func TestSHAValidatorRejectsAMismatch(t *testing.T) {
+	checksumFile := fmt.Sprintf("%x  bcc-media-flows-worker-linux-amd64\n", sha256.Sum256([]byte("the binary that was published")))
+
+	err := (&selfupdate.SHAValidator{}).Validate(
+		"bcc-media-flows-worker-linux-amd64",
+		[]byte("the binary that was downloaded"),
+		[]byte(checksumFile),
+	)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
**2/n of a stack.** Base: `fix/activity-counter-on-activity-worker` (#440).

The worker polled GitHub every five minutes and installed whatever it found, with no `selfupdate.Validator`: no checksum, no signature, no size check. A truncated download, a proxy that served the wrong bytes, or a partially uploaded release asset all became the running binary on the whole fleet within minutes.

`publish.yml` now writes `<binary>.sha256` next to each matrix artifact and attaches it to the release, and the worker builds its updater with `selfupdate.SHAValidator`. That makes the update **fail closed**: if the checksum asset is missing or does not match, nothing is installed and the error is logged. Both changes have to ship together — the first release built after this carries the file the new binary demands.

**What this does not do is authenticate the release.** The hash is produced by the same job, in the same workflow, and attached to the same release, so anyone who can write the binary can write the hash. Closing that needs a signature checked against a key the pipeline cannot mint — an ECDSA keypair with the public half compiled into the worker and the private half a repository secret. That needs a key generated out of band, so it is left as a follow-up rather than done halfway here. Happy to do it as the next branch if you generate the keypair.

Tests pin the one thing that silently breaks: that the name `publish.yml` uploads is the name the validator looks for, and that the two-column output of `sha256sum` is a form the validator accepts — `BINARY_NAME` contains a slash, so the second column is a path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)