### PR TITLE
fix(workflows): fill in the activity timeouts a workflow left unset

### DIFF
--- a/utils/workflows/execute.go
+++ b/utils/workflows/execute.go
@@ -54,6 +54,33 @@ func (f Task[TR]) Wait(ctx workflow.Context) error {
 	return f.Future.Get(ctx, nil)
 }
 
+// activityOptionsWithDefaults fills in the timeouts a workflow left unset.
+//
+// A workflow only has activity options if it called
+// workflow.WithActivityOptions, and there is nothing to notice when it did not:
+// most activities are reached through helpers like CreateFolder or WriteFile
+// rather than through an Execute call the author is looking at. Without this,
+// such a workflow schedules activities with no StartToCloseTimeout — so a
+// single attempt may consume the entire schedule-to-close budget and never be
+// retried — and with a schedule-to-close that differs from the one every
+// workflow using GetDefaultActivityOptions gets.
+//
+// HeartbeatTimeout is deliberately not filled in. A heartbeat timeout on an
+// activity that never calls RecordHeartbeat turns a slow success into a
+// certain failure, and this function cannot tell which activities heartbeat.
+func activityOptionsWithDefaults(options workflow.ActivityOptions) workflow.ActivityOptions {
+	defaults := GetDefaultActivityOptions()
+
+	if options.StartToCloseTimeout == 0 {
+		options.StartToCloseTimeout = defaults.StartToCloseTimeout
+	}
+	if options.ScheduleToCloseTimeout == 0 {
+		options.ScheduleToCloseTimeout = defaults.ScheduleToCloseTimeout
+	}
+
+	return options
+}
+
 // Execute executes the specified activity with the correct task queue
 func Execute[T any, TR any](ctx workflow.Context, activity func(context.Context, T) (TR, error), params T) Task[TR] {
 	options := workflow.GetActivityOptions(ctx)
@@ -71,11 +98,7 @@ func Execute[T any, TR any](ctx workflow.Context, activity func(context.Context,
 		}
 	}
 
-	if options.ScheduleToCloseTimeout == 0 {
-		options.ScheduleToCloseTimeout = time.Hour * 3
-	}
-
-	ctx = workflow.WithActivityOptions(ctx, options)
+	ctx = workflow.WithActivityOptions(ctx, activityOptionsWithDefaults(options))
 
 	return Task[TR]{Future: workflow.ExecuteActivity(ctx, activity, params)}
 }
@@ -101,7 +124,7 @@ func ExecuteWithLowPrioQueue[T any, TR any](ctx workflow.Context, activity func(
 		}
 	}
 
-	ctx = workflow.WithActivityOptions(ctx, options)
+	ctx = workflow.WithActivityOptions(ctx, activityOptionsWithDefaults(options))
 	return Task[TR]{
 		workflow.ExecuteActivity(ctx, activity, params),
 	}

--- a/utils/workflows/execute_test.go
+++ b/utils/workflows/execute_test.go
@@ -1,0 +1,95 @@
+package wfutils
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+func TestActivityOptionsWithDefaultsFillsMissingTimeouts(t *testing.T) {
+	got := activityOptionsWithDefaults(workflow.ActivityOptions{})
+
+	defaults := GetDefaultActivityOptions()
+	assert.Equal(t, defaults.StartToCloseTimeout, got.StartToCloseTimeout)
+	assert.Equal(t, defaults.ScheduleToCloseTimeout, got.ScheduleToCloseTimeout)
+}
+
+func TestActivityOptionsWithDefaultsKeepsWhatTheWorkflowSet(t *testing.T) {
+	set := workflow.ActivityOptions{
+		StartToCloseTimeout:    7 * time.Minute,
+		ScheduleToCloseTimeout: 9 * time.Minute,
+		HeartbeatTimeout:       3 * time.Minute,
+	}
+
+	assert.Equal(t, set, activityOptionsWithDefaults(set))
+}
+
+// A heartbeat timeout on an activity that never calls RecordHeartbeat fails
+// every run longer than the timeout, so it must not be filled in for a workflow
+// that did not ask for one.
+func TestActivityOptionsWithDefaultsNeverAddsAHeartbeatTimeout(t *testing.T) {
+	require.NotZero(t, GetDefaultActivityOptions().HeartbeatTimeout,
+		"otherwise this test passes for the wrong reason")
+
+	got := activityOptionsWithDefaults(workflow.ActivityOptions{})
+
+	assert.Zero(t, got.HeartbeatTimeout)
+}
+
+// attemptBudget reports how long this attempt is allowed to run, which is the
+// start-to-close timeout the activity was scheduled with.
+func attemptBudget(ctx context.Context, _ any) (time.Duration, error) {
+	info := activity.GetInfo(ctx)
+	return info.Deadline.Sub(info.StartedTime).Round(time.Minute), nil
+}
+
+// noOptionsWorkflow is a workflow that never calls WithActivityOptions, which is
+// the case the defaults exist for.
+func noOptionsWorkflow(ctx workflow.Context) (time.Duration, error) {
+	return Execute(ctx, attemptBudget, any(nil)).Result(ctx)
+}
+
+func TestExecuteAppliesDefaultsWhenTheWorkflowSetsNoOptions(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterActivity(attemptBudget)
+
+	env.ExecuteWorkflow(noOptionsWorkflow)
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	// Without the defaults this is 3h: no start-to-close is set, so the server
+	// falls back to the schedule-to-close budget and one attempt can eat all of it.
+	var budget time.Duration
+	require.NoError(t, env.GetWorkflowResult(&budget))
+	assert.Equal(t, GetDefaultActivityOptions().StartToCloseTimeout, budget)
+}
+
+// The same workflow, but with options set: Execute must not override them.
+func setOptionsWorkflow(ctx workflow.Context) (time.Duration, error) {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout:    30 * time.Minute,
+		ScheduleToCloseTimeout: 45 * time.Minute,
+	})
+	return Execute(ctx, attemptBudget, any(nil)).Result(ctx)
+}
+
+func TestExecuteKeepsTheOptionsTheWorkflowSet(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterActivity(attemptBudget)
+
+	env.ExecuteWorkflow(setOptionsWorkflow)
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var budget time.Duration
+	require.NoError(t, env.GetWorkflowResult(&budget))
+	assert.Equal(t, 30*time.Minute, budget)
+}


### PR DESCRIPTION
**4/n of a stack.** Base: `refactor/remove-xml-ingest-entrypoint` (#442).

A workflow only has activity options if it called `workflow.WithActivityOptions`, and nothing tells the author when it did not: activities are mostly reached through helpers like `CreateFolder` or `WriteFile` rather than through an `Execute` call in view. **Four registered workflows are in that position** — `BulkExportShorts`, `ExportShort`, `ImportSubtitles` and `MoveFilesWorkerFlow` (the audit listed the first three) — and `Execute` backfilled only `ScheduleToCloseTimeout`.

Two consequences:

- `StartToCloseTimeout` stayed zero, so the server falls back to the schedule-to-close budget. A single attempt is allowed to run the full three hours, and the ten-attempt retry policy above it has nothing left to retry into.
- That three hours is a number nobody chose. Every workflow that *does* call `WithActivityOptions` gets 4h/12h from `GetDefaultActivityOptions`, so the workflows that forgot ran under a tighter, quieter regime than the ones that did not.

`Execute` now fills any unset timeout from `GetDefaultActivityOptions`, and so does `ExecuteWithLowPrioQueue`, which had no timeout backfill at all — latent only because both its callers happen to set options.

**`HeartbeatTimeout` is deliberately left alone.** Filling it in would put a ten-minute heartbeat timeout on activities that never call `RecordHeartbeat`, turning a slow success into a certain failure, and `Execute` cannot tell which activities heartbeat. (That is its own finding — `activities/vizualizer.go` is already in exactly that trap.)

Verified: with the old backfill the no-options workflow reports a **3h** attempt budget where the test expects 4h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)