### PR TITLE
fix(export): set GenerateShort's activity options before its first activity

### DIFF
--- a/workflows/export/generate_short.go
+++ b/workflows/export/generate_short.go
@@ -65,6 +65,11 @@ func GenerateShort(ctx workflow.Context, params GenerateShortDataParams) (*Gener
 		return nil, err
 	}
 
+	// Set before the first activity, so every activity in the workflow runs
+	// under the same options.
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
+	ctx = wfutils.WithChildSearchAttributes(ctx, params.VXID)
+
 	exportData, err := wfutils.Execute(ctx, activities.Vidispine.GetExportDataActivity, vsactivity.GetExportDataParams{
 		VXID:        params.VXID,
 		Languages:   []string{"nor", "deu", "eng"},
@@ -82,10 +87,6 @@ func GenerateShort(ctx workflow.Context, params GenerateShortDataParams) (*Gener
 	}
 
 	// transcriptFile := exportData.Clips[0].JSONTranscriptFile
-
-	activityOptions := wfutils.GetDefaultActivityOptions()
-	ctx = workflow.WithActivityOptions(ctx, activityOptions)
-	ctx = wfutils.WithChildSearchAttributes(ctx, params.VXID)
 
 	tempFolder, err := wfutils.GetWorkflowTempFolder(ctx)
 	if err != nil {


### PR DESCRIPTION
**5/n of a stack.** Base: `fix/activity-option-defaults` (#443).

`GetExportDataActivity` ran eighteen lines above the `WithActivityOptions` call, so it was the one activity in the workflow scheduled without the workflow's own options — it took whatever `Execute` fills in instead.

`WithChildSearchAttributes` sat on the same two lines, so that activity was also missing the VXID search attribute that makes an execution findable.

Both lines move above the call. Nothing between the top of the workflow and there touches `ctx`, so this only widens the scope they already had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)