### PR TITLE
fix(vizualizer): heartbeat while waiting for a visualization job

### DIFF
--- a/activities/vizualizer.go
+++ b/activities/vizualizer.go
@@ -3,10 +3,11 @@ package activities
 import (
 	"context"
 	"errors"
-	"github.com/bcc-code/bcc-media-flows/paths"
 	"time"
 
+	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/services/vizualizer"
+	"go.temporal.io/sdk/activity"
 )
 
 // Vizualizer exposes activities for the music visualization service.
@@ -48,6 +49,10 @@ func (a *VizualizerActivities) SubmitVisualization(ctx context.Context, args Sub
 // If PollInterval is zero, defaults to 2s. If Timeout is zero, no timeout.
 // If Timeout elapses, returns context.DeadlineExceeded.
 // Returns the final job status on success; errors if job failed.
+//
+// Timeout only bounds the polling. The activity's own HeartbeatTimeout and
+// ScheduleToCloseTimeout still apply, and the heartbeat is the shorter of the
+// two: GetDefaultActivityOptions sets it to ten minutes.
 type WaitForVisualizationArgs struct {
 	JobID        string
 	PollInterval time.Duration
@@ -55,6 +60,11 @@ type WaitForVisualizationArgs struct {
 }
 
 // WaitForVisualization polls until the job completes or fails.
+//
+// Each poll records a heartbeat. A visualization takes about as long as the
+// audio it renders, so without one, any job outlasting the heartbeat timeout is
+// killed mid-render and retried into the same wall — the workflow spends its
+// whole retry budget failing identically.
 func (a *VizualizerActivities) WaitForVisualization(ctx context.Context, args WaitForVisualizationArgs) (*vizualizer.JobStatusResponse, error) {
 	if args.JobID == "" {
 		return nil, errors.New("JobID is required")
@@ -83,6 +93,9 @@ func (a *VizualizerActivities) WaitForVisualization(ctx context.Context, args Wa
 			if err != nil {
 				return nil, err
 			}
+			// The status is the heartbeat detail, so a job that is progressing
+			// but slow is visible in Temporal rather than just silent.
+			activity.RecordHeartbeat(ctx, status)
 			switch status.Status {
 			case "completed":
 				return status, nil

--- a/activities/vizualizer_test.go
+++ b/activities/vizualizer_test.go
@@ -1,0 +1,91 @@
+package activities
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bcc-code/bcc-media-flows/services/vizualizer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/testsuite"
+)
+
+// vizualizerStub answers status polls with "processing" until the given number
+// of polls have happened, then "completed".
+func vizualizerStub(t *testing.T, pollsBeforeDone int) (*vizualizer.Client, *atomic.Int32) {
+	t.Helper()
+
+	var polls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := polls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if int(n) < pollsBeforeDone {
+			_, _ = w.Write([]byte(`{"job_id":"job-1","status":"processing","progress":10}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"job_id":"job-1","status":"completed","progress":100}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := vizualizer.NewClient(server.URL)
+	require.NoError(t, err)
+	return client, &polls
+}
+
+// A visualization runs as long as the audio, so it routinely outlives the ten
+// minute HeartbeatTimeout in GetDefaultActivityOptions. Without a heartbeat per
+// poll the activity is killed mid-render and every retry dies the same way.
+func TestWaitForVisualizationHeartbeatsWhileItPolls(t *testing.T) {
+	client, polls := vizualizerStub(t, 4)
+
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestActivityEnvironment()
+
+	var heartbeats atomic.Int32
+	var lastStatus vizualizer.JobStatusResponse
+	env.SetOnActivityHeartbeatListener(func(_ *activity.Info, details converter.EncodedValues) {
+		heartbeats.Add(1)
+		if details.HasValues() {
+			_ = details.Get(&lastStatus)
+		}
+	})
+
+	activities := &VizualizerActivities{Client: client}
+	env.RegisterActivity(activities.WaitForVisualization)
+
+	val, err := env.ExecuteActivity(activities.WaitForVisualization, WaitForVisualizationArgs{
+		JobID:        "job-1",
+		PollInterval: time.Millisecond,
+		Timeout:      time.Minute,
+	})
+	require.NoError(t, err)
+
+	var got vizualizer.JobStatusResponse
+	require.NoError(t, val.Get(&got))
+	assert.Equal(t, "completed", got.Status)
+
+	assert.Greater(t, polls.Load(), int32(1), "the stub should have been polled while processing")
+
+	// The count is not compared against the number of polls: the SDK throttles
+	// heartbeats and only forwards a fraction of them to the listener. What
+	// matters is that the activity heartbeats at all while the job runs.
+	assert.NotZero(t, heartbeats.Load(), "the activity must heartbeat while polling")
+	assert.Equal(t, "job-1", lastStatus.JobID,
+		"the job status should travel as the heartbeat detail")
+}
+
+func TestWaitForVisualizationRequiresAJobID(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestActivityEnvironment()
+
+	activities := &VizualizerActivities{}
+	env.RegisterActivity(activities.WaitForVisualization)
+
+	_, err := env.ExecuteActivity(activities.WaitForVisualization, WaitForVisualizationArgs{})
+	require.Error(t, err)
+}


### PR DESCRIPTION
**6/n of a stack.** Base: `fix/generate-short-options-before-first-activity` (#444).

This is the finding I pointed at from #443: the heartbeat trap, fixed at the activity rather than by weakening the defaults.

`WaitForVisualization` is a poll loop with no heartbeat, scheduled from `VXExportToVOD` under `GetDefaultActivityOptions`, which sets a **ten minute** `HeartbeatTimeout`. Its own poll `Timeout` is **two hours**. Those two numbers contradict each other: a visualization takes about as long as the audio it renders, so anything past ten minutes is killed mid-render, retried, and killed again at the same point. Ten identical failures, then the export gives up — and the render itself was fine.

Each poll now records a heartbeat, with the job status as the detail so a slow but progressing job is visible in Temporal rather than merely silent. This is the pattern `WaitForFileVisibleInStorageActivity` already uses; the other long-running activities go through `newHeartBeater`/`simpleHeartBeater` in `common.go`.

The timeout was right — the activity was the thing not holding up its end, which is why this is fixed here and not by dropping `HeartbeatTimeout` from the defaults.

I checked the other activities that heartbeat nowhere. All single API calls, or pure argument-building in `CropShortActivity`'s case. One is worth a second look and is **not** fixed here: `GetAudioDiff` makes an unbounded HTTP request to the sync service and takes `_ context.Context`, so it can neither heartbeat nor be cancelled.

Verified: the test records zero heartbeats without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)