### PR TITLE
fix(export): bound GenerateShort's wait for the short service

### DIFF
--- a/workflows/export/generate_short.go
+++ b/workflows/export/generate_short.go
@@ -163,28 +163,9 @@ func GenerateShort(ctx workflow.Context, params GenerateShortDataParams) (*Gener
 		JobID: jobResult.JobID,
 	}
 
-	var keyframes []activities.Keyframe
-	for {
-		statusResult, err := wfutils.Execute(ctx, activities.Util.CheckJobStatusActivity, checkStatusParams).Result(ctx)
-		if err != nil {
-			logger.Error("Failed to check job status: " + err.Error())
-			return nil, err
-		}
-
-		if statusResult.Status == "completed" {
-			logger.Info("Job completed successfully")
-			keyframes = statusResult.Keyframes
-			break
-		}
-
-		if statusResult.Status != "in_progress" {
-			return nil, fmt.Errorf("job failed with status: %s", statusResult.Status)
-		}
-
-		err = workflow.Sleep(ctx, time.Second*5)
-		if err != nil {
-			return nil, err
-		}
+	keyframes, err := waitForShortJob(ctx, checkStatusParams)
+	if err != nil {
+		return nil, err
 	}
 
 	shortVideoPath := outputPath.Append(titleWithShort + "_cropped.mov")
@@ -239,4 +220,63 @@ func GenerateShort(ctx workflow.Context, params GenerateShortDataParams) (*Gener
 		AudioFiles:     clipResult.AudioFiles,
 		SubtitleFiles:  clipResult.SubtitleFiles,
 	}, nil
+}
+
+const (
+	// shortJobPollInterval is how often the short service is asked whether the
+	// job is done, once it has been running longer than shortJobFastPollFor.
+	shortJobPollInterval = 30 * time.Second
+	// shortJobFastPollFor is the initial window polled every five seconds, so a
+	// job that finishes quickly is noticed quickly.
+	shortJobFastPollFor  = 2 * time.Minute
+	shortJobFastInterval = 5 * time.Second
+	// shortJobTimeout bounds the wait. Reaching it fails the workflow with a
+	// legible error instead of letting the poll loop grow the history until the
+	// server terminates the execution for exceeding its event limit.
+	shortJobTimeout = 2 * time.Hour
+)
+
+// waitForShortJob polls the short service until the job finishes.
+//
+// Each pass costs an activity and a timer — five history events — so a fixed
+// five second interval writes roughly 3,600 events an hour. Backing off after
+// the first couple of minutes and giving up at shortJobTimeout keeps a stuck
+// job well inside the history limit, and turns "the server killed the
+// execution" into an error naming the job.
+func waitForShortJob(ctx workflow.Context, params activities.CheckJobStatusInput) ([]activities.Keyframe, error) {
+	logger := workflow.GetLogger(ctx)
+	start := workflow.Now(ctx)
+
+	for {
+		statusResult, err := wfutils.Execute(ctx, activities.Util.CheckJobStatusActivity, params).Result(ctx)
+		if err != nil {
+			logger.Error("Failed to check job status: " + err.Error())
+			return nil, err
+		}
+
+		if statusResult.Status == "completed" {
+			logger.Info("Job completed successfully")
+			return statusResult.Keyframes, nil
+		}
+
+		if statusResult.Status != "in_progress" {
+			return nil, fmt.Errorf("job failed with status: %s", statusResult.Status)
+		}
+
+		waited := workflow.Now(ctx).Sub(start)
+		if waited >= shortJobTimeout {
+			return nil, temporal.NewNonRetryableApplicationError(
+				fmt.Sprintf("short job %s still in_progress after %s", params.JobID, shortJobTimeout),
+				"ShortJobTimeout", nil)
+		}
+
+		interval := shortJobPollInterval
+		if waited < shortJobFastPollFor {
+			interval = shortJobFastInterval
+		}
+
+		if err := workflow.Sleep(ctx, interval); err != nil {
+			return nil, err
+		}
+	}
 }

--- a/workflows/export/generate_short_test.go
+++ b/workflows/export/generate_short_test.go
@@ -1,0 +1,92 @@
+package export
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bcc-code/bcc-media-flows/activities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+// waitForShortJobWorkflow exposes the helper to the test environment, which
+// needs a workflow to run activities and timers in.
+func waitForShortJobWorkflow(ctx workflow.Context, params activities.CheckJobStatusInput) ([]activities.Keyframe, error) {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: time.Minute,
+		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
+	})
+	return waitForShortJob(ctx, params)
+}
+
+func newShortJobEnv(t *testing.T) *testsuite.TestWorkflowEnvironment {
+	t.Helper()
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(waitForShortJobWorkflow)
+	return env
+}
+
+func TestWaitForShortJobReturnsKeyframesWhenTheJobCompletes(t *testing.T) {
+	env := newShortJobEnv(t)
+
+	env.OnActivity(activities.Util.CheckJobStatusActivity, mock.Anything, mock.Anything).
+		Return(&activities.GenerateShortRequestResult{Status: "in_progress"}, nil).Twice()
+	env.OnActivity(activities.Util.CheckJobStatusActivity, mock.Anything, mock.Anything).
+		Return(&activities.GenerateShortRequestResult{
+			Status:    "completed",
+			Keyframes: []activities.Keyframe{{}},
+		}, nil).Once()
+
+	env.ExecuteWorkflow(waitForShortJobWorkflow, activities.CheckJobStatusInput{JobID: "job-1"})
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var got []activities.Keyframe
+	require.NoError(t, env.GetWorkflowResult(&got))
+	assert.Len(t, got, 1)
+}
+
+// The loop used to have no exit other than the job finishing, so a job stuck in
+// in_progress polled every five seconds until the server terminated the
+// execution for exceeding its history limit — roughly 3,600 events an hour with
+// nothing in the error to say what happened.
+func TestWaitForShortJobGivesUpOnAJobThatNeverFinishes(t *testing.T) {
+	env := newShortJobEnv(t)
+
+	polls := 0
+	env.OnActivity(activities.Util.CheckJobStatusActivity, mock.Anything, mock.Anything).
+		Return(&activities.GenerateShortRequestResult{Status: "in_progress"}, nil).
+		Run(func(mock.Arguments) { polls++ })
+
+	env.ExecuteWorkflow(waitForShortJobWorkflow, activities.CheckJobStatusInput{JobID: "stuck-job"})
+	require.True(t, env.IsWorkflowCompleted())
+
+	err := env.GetWorkflowError()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stuck-job")
+	assert.Contains(t, err.Error(), "still in_progress")
+
+	// Two minutes at 5s plus the rest of the two hours at 30s. The exact number
+	// matters less than it being bounded and far below the history limit.
+	assert.Less(t, polls, 300, "the backoff should keep the poll count small")
+	assert.Greater(t, polls, 20, "but it should still have polled for the full window")
+}
+
+func TestWaitForShortJobFailsOnAFailedJob(t *testing.T) {
+	env := newShortJobEnv(t)
+
+	env.OnActivity(activities.Util.CheckJobStatusActivity, mock.Anything, mock.Anything).
+		Return(&activities.GenerateShortRequestResult{Status: "failed"}, nil).Once()
+
+	env.ExecuteWorkflow(waitForShortJobWorkflow, activities.CheckJobStatusInput{JobID: "job-1"})
+	require.True(t, env.IsWorkflowCompleted())
+
+	err := env.GetWorkflowError()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "job failed with status: failed")
+}


### PR DESCRIPTION
**8/n of a stack.** Base: `refactor/remove-dynamic-trigger-form` (#446). First of the *Unbounded workflow histories* findings.

The status loop had no exit but the job finishing. Each pass costs an activity and a timer — five history events — and it polled every five seconds, so a job stuck in `in_progress` wrote roughly **3,600 events an hour** until the server terminated the execution for exceeding its history limit. The failure that reached the operator said nothing about the job.

Extracted as `waitForShortJob`: five seconds for the first two minutes, thirty after that, and it gives up at two hours with a non-retryable error naming the job. A stuck job now costs a few hundred events instead of tens of thousands, and a quick job is still noticed within five seconds. Two hours matches the ceiling the vizualizer wait already uses.

The extraction is also what makes it testable — three tests drive the loop through the test environment's clock, including the stuck-job case, which is not reachable while the loop is inline in a workflow that first has to get through export data, scene detection and a child workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)