### PR TITLE
fix: the remaining Unbounded workflow histories sub-items

### DIFF
--- a/workflows/export/merge_export_data.go
+++ b/workflows/export/merge_export_data.go
@@ -200,9 +200,7 @@ func exportDataToMergeInputs(data *vidispine.ExportData, tempDir, subtitlesDir p
 			})
 		}
 
-		// Sorted rather than ranged: this runs in workflow code now, and although
-		// each language accumulates into its own MergeInput, the checker cannot
-		// see that and neither can the next reader.
+		// Sorted: this runs in workflow code, where map order must not leak.
 		for _, lan := range wfutils.SortedKeys(clip.AudioFiles) {
 			af := clip.AudioFiles[lan]
 			if _, ok := audioMergeInputs[lan]; !ok {

--- a/workflows/export/merge_export_data.go
+++ b/workflows/export/merge_export_data.go
@@ -36,13 +36,7 @@ func MergeExportData(ctx workflow.Context, params MergeExportDataParams) (*Merge
 	logger.Info("Starting MergeExportData")
 	data := params.ExportData
 
-	var dataMergeInputs MergeInput
-	err := workflow.SideEffect(ctx, func(ctx workflow.Context) interface{} {
-		return exportDataToMergeInputs(data, params.TempDir, params.SubtitlesDir)
-	}).Get(&dataMergeInputs)
-	if err != nil {
-		return nil, err
-	}
+	dataMergeInputs := exportDataToMergeInputs(data, params.TempDir, params.SubtitlesDir)
 
 	mergeInput := dataMergeInputs.MergeInput
 	audioMergeInputs := dataMergeInputs.AudioMergeInputs
@@ -206,7 +200,11 @@ func exportDataToMergeInputs(data *vidispine.ExportData, tempDir, subtitlesDir p
 			})
 		}
 
-		for lan, af := range clip.AudioFiles {
+		// Sorted rather than ranged: this runs in workflow code now, and although
+		// each language accumulates into its own MergeInput, the checker cannot
+		// see that and neither can the next reader.
+		for _, lan := range wfutils.SortedKeys(clip.AudioFiles) {
+			af := clip.AudioFiles[lan]
 			if _, ok := audioMergeInputs[lan]; !ok {
 				audioMergeInputs[lan] = &common.MergeInput{
 					Title:     data.SafeTitle + "-" + lan,
@@ -224,7 +222,8 @@ func exportDataToMergeInputs(data *vidispine.ExportData, tempDir, subtitlesDir p
 			})
 		}
 
-		for lan, sf := range clip.SubtitleFiles {
+		for _, lan := range wfutils.SortedKeys(clip.SubtitleFiles) {
+			sf := clip.SubtitleFiles[lan]
 			if _, ok := subtitleMergeInputs[lan]; !ok {
 				subtitleMergeInputs[lan] = &common.MergeInput{
 					Title:     data.SafeTitle + "-" + lan,

--- a/workflows/export/merge_export_data_test.go
+++ b/workflows/export/merge_export_data_test.go
@@ -1,0 +1,96 @@
+package export
+
+import (
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/paths"
+	"github.com/bcc-code/bcc-media-flows/services/vidispine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func twoClipExportData() *vidispine.ExportData {
+	return &vidispine.ExportData{
+		SafeTitle: "Some_Title",
+		Clips: []*vidispine.Clip{
+			{
+				VideoFile:  "/mnt/isilon/a.mxf",
+				InSeconds:  0,
+				OutSeconds: 10,
+				AudioFiles: map[string]*vidispine.AudioFile{
+					"nor": {File: "/mnt/isilon/a-nor.wav"},
+					"eng": {File: "/mnt/isilon/a-eng.wav"},
+					"deu": {File: "/mnt/isilon/a-deu.wav"},
+				},
+				SubtitleFiles: map[string]string{
+					"nor": "/mnt/isilon/a-nor.srt",
+					"eng": "/mnt/isilon/a-eng.srt",
+				},
+				JSONTranscriptFile: "/mnt/isilon/a.json",
+			},
+			{
+				VideoFile:  "/mnt/isilon/b.mxf",
+				InSeconds:  5,
+				OutSeconds: 20,
+				AudioFiles: map[string]*vidispine.AudioFile{
+					"nor": {File: "/mnt/isilon/b-nor.wav"},
+					"eng": {File: "/mnt/isilon/b-eng.wav"},
+					"deu": {File: "/mnt/isilon/b-deu.wav"},
+				},
+				SubtitleFiles: map[string]string{
+					"nor": "/mnt/isilon/b-nor.srt",
+					"eng": "/mnt/isilon/b-eng.srt",
+				},
+			},
+		},
+	}
+}
+
+// The result is used directly in workflow code now rather than being frozen by
+// a SideEffect marker, so it has to be the same on every call — including
+// across the randomized map iteration inside.
+func TestExportDataToMergeInputsIsStableAcrossCalls(t *testing.T) {
+	tempDir := paths.MustParse("/mnt/isilon/temp")
+	subsDir := paths.MustParse("/mnt/isilon/subs")
+
+	want := exportDataToMergeInputs(twoClipExportData(), tempDir, subsDir)
+
+	for i := 0; i < 50; i++ {
+		assert.Equal(t, want, exportDataToMergeInputs(twoClipExportData(), tempDir, subsDir))
+	}
+}
+
+func TestExportDataToMergeInputsBuildsOneInputPerLanguage(t *testing.T) {
+	tempDir := paths.MustParse("/mnt/isilon/temp")
+	subsDir := paths.MustParse("/mnt/isilon/subs")
+
+	got := exportDataToMergeInputs(twoClipExportData(), tempDir, subsDir)
+
+	require.Len(t, got.AudioMergeInputs, 3)
+	require.Len(t, got.SubtitleMergeInputs, 2)
+
+	// Clip order drives item order within a language; the map iteration must not
+	// be able to reorder it.
+	nor := got.AudioMergeInputs["nor"]
+	require.Len(t, nor.Items, 2)
+	assert.Equal(t, paths.MustParse("/mnt/isilon/a-nor.wav"), nor.Items[0].Path)
+	assert.Equal(t, paths.MustParse("/mnt/isilon/b-nor.wav"), nor.Items[1].Path)
+	assert.Equal(t, "Some_Title-nor", nor.Title)
+
+	assert.Equal(t, subsDir, got.SubtitleMergeInputs["eng"].OutputDir)
+	assert.Equal(t, tempDir, got.SubtitleMergeInputs["eng"].WorkDir)
+
+	// 10 + 15 seconds of video, and only the first clip has a transcript.
+	assert.Equal(t, float64(25), got.MergeInput.Duration)
+	require.NotNil(t, got.JSONTranscriptInput)
+	assert.Equal(t, float64(10), got.JSONTranscriptInput.Duration)
+}
+
+func TestExportDataToMergeInputsHasNoTranscriptWhenNoClipHasOne(t *testing.T) {
+	data := twoClipExportData()
+	data.Clips[0].JSONTranscriptFile = ""
+
+	got := exportDataToMergeInputs(data, paths.MustParse("/mnt/isilon/temp"), paths.MustParse("/mnt/isilon/subs"))
+
+	assert.Nil(t, got.JSONTranscriptInput)
+}

--- a/workflows/export/merge_export_data_test.go
+++ b/workflows/export/merge_export_data_test.go
@@ -46,9 +46,8 @@ func twoClipExportData() *vidispine.ExportData {
 	}
 }
 
-// The result is used directly in workflow code now rather than being frozen by
-// a SideEffect marker, so it has to be the same on every call — including
-// across the randomized map iteration inside.
+// Workflow code calls this directly, so it has to give the same answer every
+// time, across the randomized map iteration inside.
 func TestExportDataToMergeInputsIsStableAcrossCalls(t *testing.T) {
 	tempDir := paths.MustParse("/mnt/isilon/temp")
 	subsDir := paths.MustParse("/mnt/isilon/subs")
@@ -69,8 +68,7 @@ func TestExportDataToMergeInputsBuildsOneInputPerLanguage(t *testing.T) {
 	require.Len(t, got.AudioMergeInputs, 3)
 	require.Len(t, got.SubtitleMergeInputs, 2)
 
-	// Clip order drives item order within a language; the map iteration must not
-	// be able to reorder it.
+	// Clip order drives item order within a language.
 	nor := got.AudioMergeInputs["nor"]
 	require.Len(t, nor.Items, 2)
 	assert.Equal(t, paths.MustParse("/mnt/isilon/a-nor.wav"), nor.Items[0].Path)

--- a/workflows/ingest/import_subtitles.go
+++ b/workflows/ingest/import_subtitles.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
+	"github.com/bcc-code/bcc-media-flows/paths"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"go.temporal.io/sdk/workflow"
 )
@@ -38,9 +39,20 @@ type Word struct {
 }
 
 type ImportSubtitlesInput struct {
-	VXID      string        `json:"vxid"`
+	VXID string `json:"vxid"`
+
+	// Subtitles carries the transcription inline. A workflow argument is stored
+	// in the WorkflowExecutionStarted event, and a word-level transcription of a
+	// long programme is megabytes, so this both bloats the history and can push
+	// the start over Temporal's payload limit. Prefer SubtitlesFile.
 	Subtitles Transcription `json:"subtitles"`
-	Language  string        `json:"language"`
+
+	// SubtitlesFile points at the same JSON on shared storage. When set it is
+	// read by an activity and Subtitles is ignored, keeping the payload out of
+	// the history entirely.
+	SubtitlesFile *paths.Path `json:"subtitlesFile,omitempty"`
+
+	Language string `json:"language"`
 }
 
 // convertSecondsToSRTTimestamp converts a float64 number of seconds to SRT timestamp format: HH:MM:SS,mmm
@@ -95,6 +107,11 @@ func ImportSubtitles(ctx workflow.Context, input ImportSubtitlesInput) error {
 		return fmt.Errorf("missing language")
 	}
 
+	subtitles, err := resolveSubtitles(ctx, input)
+	if err != nil {
+		return err
+	}
+
 	outputPath, err := wfutils.GetWorkflowAuxOutputFolder(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get aux output folder: %w", err)
@@ -103,14 +120,14 @@ func ImportSubtitles(ctx workflow.Context, input ImportSubtitlesInput) error {
 	srtFilePath := outputPath.Append(input.VXID + "_subtitles.srt")
 	jsonFilePath := outputPath.Append(input.VXID + "_subtitles.json")
 
-	srtData := ToSRT(input.Subtitles.Segments, false)
+	srtData := ToSRT(subtitles.Segments, false)
 
 	err = wfutils.WriteFile(ctx, srtFilePath, []byte(srtData))
 	if err != nil {
 		return fmt.Errorf("failed to write SRT file: %w", err)
 	}
 
-	jsonData, err := json.MarshalIndent(input.Subtitles, "", "  ")
+	jsonData, err := json.MarshalIndent(subtitles, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal subtitles to JSON: %w", err)
 	}
@@ -176,4 +193,19 @@ func ImportSubtitles(ctx workflow.Context, input ImportSubtitlesInput) error {
 
 	logger.Info("Subtitle SRT and JSON imported as shapes; SRT as sidecar (async)", "vxid", input.VXID)
 	return nil
+}
+
+// resolveSubtitles returns the transcription to import, reading it from shared
+// storage when the caller passed a path rather than the whole thing.
+func resolveSubtitles(ctx workflow.Context, input ImportSubtitlesInput) (Transcription, error) {
+	if input.SubtitlesFile == nil {
+		return input.Subtitles, nil
+	}
+
+	subtitles, err := wfutils.UnmarshalJSONFile[Transcription](ctx, *input.SubtitlesFile)
+	if err != nil {
+		return Transcription{}, fmt.Errorf("failed to read subtitles from %s: %w", input.SubtitlesFile.Local(), err)
+	}
+
+	return *subtitles, nil
 }

--- a/workflows/ingest/import_subtitles.go
+++ b/workflows/ingest/import_subtitles.go
@@ -41,15 +41,13 @@ type Word struct {
 type ImportSubtitlesInput struct {
 	VXID string `json:"vxid"`
 
-	// Subtitles carries the transcription inline. A workflow argument is stored
-	// in the WorkflowExecutionStarted event, and a word-level transcription of a
-	// long programme is megabytes, so this both bloats the history and can push
-	// the start over Temporal's payload limit. Prefer SubtitlesFile.
+	// Subtitles carries the transcription inline, which puts it in the
+	// WorkflowExecutionStarted event. A word-level transcription of a long
+	// programme can exceed Temporal's payload limit. Prefer SubtitlesFile.
 	Subtitles Transcription `json:"subtitles"`
 
-	// SubtitlesFile points at the same JSON on shared storage. When set it is
-	// read by an activity and Subtitles is ignored, keeping the payload out of
-	// the history entirely.
+	// SubtitlesFile points at the same JSON on shared storage. When set, it is
+	// read by an activity and Subtitles is ignored.
 	SubtitlesFile *paths.Path `json:"subtitlesFile,omitempty"`
 
 	Language string `json:"language"`
@@ -195,8 +193,8 @@ func ImportSubtitles(ctx workflow.Context, input ImportSubtitlesInput) error {
 	return nil
 }
 
-// resolveSubtitles returns the transcription to import, reading it from shared
-// storage when the caller passed a path rather than the whole thing.
+// resolveSubtitles reads the transcription from storage when the caller passed
+// a path instead of the whole thing.
 func resolveSubtitles(ctx workflow.Context, input ImportSubtitlesInput) (Transcription, error) {
 	if input.SubtitlesFile == nil {
 		return input.Subtitles, nil

--- a/workflows/ingest/import_subtitles_test.go
+++ b/workflows/ingest/import_subtitles_test.go
@@ -149,9 +149,8 @@ func (s *ImportSubtitlesTestSuite) Test_ImportSubtitlesWorkflow() {
 	s.NoError(err)
 }
 
-// A word-level transcription of a long programme is megabytes, and a workflow
-// argument lives in the WorkflowExecutionStarted event. Passing a path instead
-// keeps it out of the history; the workflow reads it and behaves identically.
+// Given a path instead of the transcription, the workflow reads it and behaves
+// identically.
 func (s *ImportSubtitlesTestSuite) Test_ImportSubtitlesFromFile() {
 	vxid := "VX-123"
 	segments := []Segment{

--- a/workflows/ingest/import_subtitles_test.go
+++ b/workflows/ingest/import_subtitles_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/bcc-code/bcc-media-flows/activities"
 	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
 	"github.com/bcc-code/bcc-media-flows/paths"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	//vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
@@ -146,6 +147,75 @@ func (s *ImportSubtitlesTestSuite) Test_ImportSubtitlesWorkflow() {
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
 	s.NoError(err)
+}
+
+// A word-level transcription of a long programme is megabytes, and a workflow
+// argument lives in the WorkflowExecutionStarted event. Passing a path instead
+// keeps it out of the history; the workflow reads it and behaves identically.
+func (s *ImportSubtitlesTestSuite) Test_ImportSubtitlesFromFile() {
+	vxid := "VX-123"
+	segments := []Segment{
+		{Start: 0.0, End: 1.0, Text: "Hello"},
+		{Start: 1.5, End: 2.5, Text: "World"},
+	}
+	stored := Transcription{Segments: segments}
+	subtitlesFile := paths.Path{Drive: paths.Drive{Value: "isilon"}, Path: "Production/aux/incoming.json"}
+
+	input := ImportSubtitlesInput{
+		VXID:          vxid,
+		Language:      "en",
+		SubtitlesFile: &subtitlesFile,
+	}
+
+	storedJSON, err := json.Marshal(stored)
+	s.NoError(err)
+
+	s.env.OnActivity(activities.Util.ReadFile, mock.Anything, activities.FileInput{Path: subtitlesFile}).
+		Return(storedJSON, nil).Once()
+
+	s.env.OnActivity(activities.Vidispine.ImportFileAsShapeActivity, mock.Anything, mock.Anything).Return(&vsactivity.ImportFileResult{JobID: "job"}, nil)
+	s.env.OnActivity(activities.Util.CreateFolder, mock.Anything, mock.Anything).Return("", nil)
+
+	datePath := time.Now().Format("2006/01/02")
+	testPath := "Production/aux/" + datePath + "/VX-123_subtitles"
+
+	jsonString, err := json.MarshalIndent(stored, "", "  ")
+	s.NoError(err)
+
+	s.env.OnActivity(activities.Util.WriteFile, mock.Anything, activities.WriteFileInput{
+		Path: paths.Path{Drive: paths.Drive{Value: "isilon"}, Path: testPath + ".json"},
+		Data: []byte(jsonString),
+	}).Return("", nil).Once()
+
+	s.env.OnActivity(activities.Util.WriteFile, mock.Anything, activities.WriteFileInput{
+		Path: paths.Path{Drive: paths.Drive{Value: "isilon"}, Path: testPath + ".srt"},
+		Data: []byte("1\n00:00:00,000 --> 00:00:01,000\nHello\n\n2\n00:00:01,500 --> 00:00:02,500\nWorld\n\n"),
+	}).Return("", nil).Once()
+
+	s.env.OnActivity(activities.Vidispine.ImportFileAsSidecarActivity, mock.Anything, mock.Anything).Return(nil, nil)
+	s.env.OnActivity(activities.Vidispine.JobCompleteOrErr, mock.Anything, mock.Anything).Return(true, nil)
+
+	s.env.ExecuteWorkflow(ImportSubtitles, input)
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+}
+
+func (s *ImportSubtitlesTestSuite) Test_ImportSubtitlesFromMissingFile() {
+	subtitlesFile := paths.Path{Drive: paths.Drive{Value: "isilon"}, Path: "Production/aux/gone.json"}
+
+	s.env.OnActivity(activities.Util.ReadFile, mock.Anything, activities.FileInput{Path: subtitlesFile}).
+		Return(nil, assert.AnError)
+
+	s.env.ExecuteWorkflow(ImportSubtitles, ImportSubtitlesInput{
+		VXID:          "VX-123",
+		Language:      "en",
+		SubtitlesFile: &subtitlesFile,
+	})
+	s.True(s.env.IsWorkflowCompleted())
+
+	err := s.env.GetWorkflowError()
+	s.Error(err)
+	s.Contains(err.Error(), "failed to read subtitles")
 }
 
 func TestImportSubtitlesTestSuite(t *testing.T) {

--- a/workflows/misc/slow_move_files.go
+++ b/workflows/misc/slow_move_files.go
@@ -70,6 +70,11 @@ func StartFilesWorkerFlow(ctx context.Context, params MoveMBFileParams) error {
 
 const MoveMBFileSignalName = "move_mb_file"
 
+// moveFilesIdleTimeout is how long the worker flow waits for another request
+// before completing. The next request starts it again through
+// SignalWithStartWorkflow.
+const moveFilesIdleTimeout = 10 * time.Second
+
 type MBStorage struct {
 	VXID     string
 	BasePath string
@@ -147,13 +152,26 @@ func FindStorageForVXID(vxid string) *MBStorage {
 	return nil
 }
 
+// MoveFilesWorkerFlow drains move requests signalled to the fixed "move_mb_file"
+// execution, and exits once none has arrived for idleTimeout.
+//
+// A steady stream of requests keeps one run alive indefinitely, and every move
+// adds activity events to the same history, so the run continues as new once
+// the server says the history is getting long. Continuing only while the
+// channel is empty means no queued request is dropped on the way over.
 func MoveFilesWorkerFlow(ctx workflow.Context) error {
 	ch := workflow.GetSignalChannel(ctx, MoveMBFileSignalName)
 
 	msg := &MoveMBFileParams{}
 
 	for {
-		ok, _ := ch.ReceiveWithTimeout(ctx, 10*time.Second, msg)
+		if workflow.GetInfo(ctx).GetContinueAsNewSuggested() && ch.Len() == 0 {
+			workflow.GetLogger(ctx).Info("History is long, continuing as new",
+				"events", workflow.GetInfo(ctx).GetCurrentHistoryLength())
+			return workflow.NewContinueAsNewError(ctx, MoveFilesWorkerFlow)
+		}
+
+		ok, _ := ch.ReceiveWithTimeout(ctx, moveFilesIdleTimeout, msg)
 		if !ok {
 			break
 		}

--- a/workflows/misc/slow_move_files.go
+++ b/workflows/misc/slow_move_files.go
@@ -70,9 +70,8 @@ func StartFilesWorkerFlow(ctx context.Context, params MoveMBFileParams) error {
 
 const MoveMBFileSignalName = "move_mb_file"
 
-// moveFilesIdleTimeout is how long the worker flow waits for another request
-// before completing. The next request starts it again through
-// SignalWithStartWorkflow.
+// moveFilesIdleTimeout is how long to wait for another request before
+// completing. SignalWithStartWorkflow starts the flow again for the next one.
 const moveFilesIdleTimeout = 10 * time.Second
 
 type MBStorage struct {
@@ -152,19 +151,19 @@ func FindStorageForVXID(vxid string) *MBStorage {
 	return nil
 }
 
-// MoveFilesWorkerFlow drains move requests signalled to the fixed "move_mb_file"
-// execution, and exits once none has arrived for idleTimeout.
+// MoveFilesWorkerFlow drains move requests signalled to the fixed
+// "move_mb_file" execution, and exits once none has arrived for
+// moveFilesIdleTimeout.
 //
-// A steady stream of requests keeps one run alive indefinitely, and every move
-// adds activity events to the same history, so the run continues as new once
-// the server says the history is getting long. Continuing only while the
-// channel is empty means no queued request is dropped on the way over.
+// A steady stream of requests would otherwise keep one run, and one history,
+// alive indefinitely, so it continues as new when the server suggests it.
 func MoveFilesWorkerFlow(ctx workflow.Context) error {
 	ch := workflow.GetSignalChannel(ctx, MoveMBFileSignalName)
 
 	msg := &MoveMBFileParams{}
 
 	for {
+		// Only while the channel is empty, so no queued request is dropped.
 		if workflow.GetInfo(ctx).GetContinueAsNewSuggested() && ch.Len() == 0 {
 			workflow.GetLogger(ctx).Info("History is long, continuing as new",
 				"events", workflow.GetInfo(ctx).GetCurrentHistoryLength())

--- a/workflows/scheduled/files_cleanup.go
+++ b/workflows/scheduled/files_cleanup.go
@@ -11,12 +11,9 @@ import (
 
 // CleanupResult reports what a cleanup run removed.
 //
-// Counts rather than paths: the workflow sweeps around sixty folders and the
-// result is written into the workflow's completion event, so returning every
-// deleted path put a fortnight of temp files into the history — and into every
-// caller that fetches the result. The paths themselves are in the activity
-// results and the worker logs, which is where anyone chasing a specific file
-// looks anyway.
+// Counts rather than paths: this is the workflow's completion event, and the
+// paths of a fortnight of temp files across sixty folders do not belong in the
+// history. They are in the activity results and the worker logs.
 type CleanupResult struct {
 	DeletedCount        int
 	DeletedCountPerRoot map[string]int
@@ -129,9 +126,6 @@ func CleanupTemp(ctx workflow.Context) (*CleanupResult, error) {
 			return nil, err
 		}
 
-		// Counted after the error check: the old log line ran before it and
-		// reported the running total rather than this folder's, so it printed 0
-		// for the first folder however much it had deleted.
 		logger.Info("Deleted files", "root", folder, "count", len(deletedFilesLoop))
 
 		deletedPerRoot[folder] = len(deletedFilesLoop)

--- a/workflows/scheduled/files_cleanup.go
+++ b/workflows/scheduled/files_cleanup.go
@@ -9,9 +9,17 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
+// CleanupResult reports what a cleanup run removed.
+//
+// Counts rather than paths: the workflow sweeps around sixty folders and the
+// result is written into the workflow's completion event, so returning every
+// deleted path put a fortnight of temp files into the history — and into every
+// caller that fetches the result. The paths themselves are in the activity
+// results and the worker logs, which is where anyone chasing a specific file
+// looks anyway.
 type CleanupResult struct {
-	DeletedFiles []string
-	DeletedCount int
+	DeletedCount        int
+	DeletedCountPerRoot map[string]int
 }
 
 func CleanupTemp(ctx workflow.Context) (*CleanupResult, error) {
@@ -100,7 +108,8 @@ func CleanupTemp(ctx workflow.Context) (*CleanupResult, error) {
 		"/mnt/isilon/Export": workflow.Now(ctx).Add(-14 * 24 * time.Hour),
 	}
 
-	deletedFiles := []string{}
+	deletedTotal := 0
+	deletedPerRoot := map[string]int{}
 
 	folders, err := wfutils.GetMapKeysSafely(ctx, foldersToCleanup)
 	if err != nil {
@@ -115,14 +124,18 @@ func CleanupTemp(ctx workflow.Context) (*CleanupResult, error) {
 			OlderThan: olderThan,
 		}).Result(ctx)
 
-		logger.Info("Deleted files", "count", len(deletedFiles))
-
 		if err != nil {
 			logger.Error("Error during temp files cleanup", "error", err)
 			return nil, err
 		}
 
-		deletedFiles = append(deletedFiles, deletedFilesLoop...)
+		// Counted after the error check: the old log line ran before it and
+		// reported the running total rather than this folder's, so it printed 0
+		// for the first folder however much it had deleted.
+		logger.Info("Deleted files", "root", folder, "count", len(deletedFilesLoop))
+
+		deletedPerRoot[folder] = len(deletedFilesLoop)
+		deletedTotal += len(deletedFilesLoop)
 
 		err = wfutils.ExecuteWithLowPrioQueue(ctx, activities.Util.DeleteEmptyDirectories, activities.CleanupInput{
 			Root: paths.MustParse(folder),
@@ -135,8 +148,8 @@ func CleanupTemp(ctx workflow.Context) (*CleanupResult, error) {
 	}
 
 	res := &CleanupResult{
-		DeletedFiles: deletedFiles,
-		DeletedCount: len(deletedFiles),
+		DeletedCount:        deletedTotal,
+		DeletedCountPerRoot: deletedPerRoot,
 	}
 
 	return res, nil

--- a/workflows/scheduled/scheduled_test.go
+++ b/workflows/scheduled/scheduled_test.go
@@ -83,8 +83,7 @@ func (s *ScheduledTestSuite) Test_CleanupTemp() {
 	s.env.GetWorkflowResult(&result)
 	s.Greater(result.DeletedCount, 0)
 
-	// Two files per folder, counted per root rather than listed: the result goes
-	// into the workflow's completion event, and this sweeps around sixty folders.
+	// Two files per folder, counted per root rather than listed.
 	s.NotEmpty(result.DeletedCountPerRoot)
 	s.Equal(2*len(result.DeletedCountPerRoot), result.DeletedCount)
 	for root, count := range result.DeletedCountPerRoot {

--- a/workflows/scheduled/scheduled_test.go
+++ b/workflows/scheduled/scheduled_test.go
@@ -82,6 +82,14 @@ func (s *ScheduledTestSuite) Test_CleanupTemp() {
 	var result CleanupResult
 	s.env.GetWorkflowResult(&result)
 	s.Greater(result.DeletedCount, 0)
+
+	// Two files per folder, counted per root rather than listed: the result goes
+	// into the workflow's completion event, and this sweeps around sixty folders.
+	s.NotEmpty(result.DeletedCountPerRoot)
+	s.Equal(2*len(result.DeletedCountPerRoot), result.DeletedCount)
+	for root, count := range result.DeletedCountPerRoot {
+		s.Equal(2, count, "unexpected count for %s", root)
+	}
 }
 
 func TestScheduledTestSuite(t *testing.T) {


### PR DESCRIPTION
**10/n of a stack.** Base: `fix/incremental-ingest-signal-selector` (#448). One commit per sub-item — the last three of the *Unbounded workflow histories* finding, after the two loops in #447 and #448.

### `MoveFilesWorkerFlow` continues as new — `909ef4d`

The finding calls it an eternal fixed-ID signal workflow whose history is never reset. **It is not eternal**: `ReceiveWithTimeout` gives up after ten seconds and the run completes, restarted by the next `SignalWithStartWorkflow`.

The real exposure is narrower. Requests arriving less than ten seconds apart keep one run alive indefinitely, and every move adds a `GetShapes` plus one `MoveFileWait` per shape to the same history — a bulk move never lets the run end. It now continues as new when the server suggests it, and only while the signal channel is empty so no queued request is dropped. A request landing after the check is handled by the server, which turns an unhandled signal at completion into a new workflow task.

### `MergeExportData` stops persisting a marker — `049131a`

`exportDataToMergeInputs` ran inside a `workflow.SideEffect`, which writes its return value into the history as a marker: every clip path, language and offset, recorded once as the marker and again in the activity inputs derived from it. The function reads no clock, file or global, so the `SideEffect` bought nothing.

It does range over the per-clip audio and subtitle maps, so those keys are now sorted — each language accumulates into its own `MergeInput` so the order was already immaterial, but running in workflow code it has to be visibly so, to `workflowcheck` and to the next reader.

No `workflow.GetVersion` guard: this changes what the workflow writes to its history, so an export started before the deploy fails to replay it. None has to survive the deploy.

### `CleanupTemp` returns counts — `36d239c`

It sweeps ~60 folders and returned every deleted path as its result, which goes into the completion event. `DeletedFiles` is replaced by `DeletedCountPerRoot`, which is what the result is actually read for — seeing a folder that is not being cleaned. Paths remain in the activity results and worker logs.

Also moved the per-folder log line below the error check, where it can report the folder it just finished: as written it logged the running total, so it printed `0` for the first folder however much it had deleted.

### `ImportSubtitles` can take a path — `ea0e06d`

A word-level transcription of a long programme is megabytes, and a workflow argument lives in the `WorkflowExecutionStarted` event. A big enough one does not merely bloat the history, it exceeds Temporal's payload limit and the workflow cannot start.

`SubtitlesFile` is an alternative input read by an activity. `Subtitles` is **kept, not replaced** — nothing in this repository starts `ImportSubtitles`, so the field cannot go until whatever produces the transcription has moved over.

### Dropped: `VXExport` sending children narrowed clips

The fifth sub-item, trimming the per-destination `ExportData` copies down to the clip fields the children read, is no longer in this PR. The parent history already carries the full `ExportData` twice — the `GetExportDataActivity` result and the `MergeExportData` child input, which has to be complete — so narrowing the destination copies saved a fraction of what was already there, on a payload never close to Temporal's limit. It bought that by making any field a child later reads silently zero. Not worth the trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
