### PR TITLE
refactor(wfutils): one body behind Execute and ExecuteWithLowPrioQueue

### DIFF
--- a/utils/workflows/execute.go
+++ b/utils/workflows/execute.go
@@ -83,19 +83,37 @@ func activityOptionsWithDefaults(options workflow.ActivityOptions) workflow.Acti
 
 // Execute executes the specified activity with the correct task queue
 func Execute[T any, TR any](ctx workflow.Context, activity func(context.Context, T) (TR, error), params T) Task[TR] {
-	options := workflow.GetActivityOptions(ctx)
-	options.TaskQueue = activities.GetQueueForActivity(activity)
+	return executeOnQueue(ctx, activities.GetQueueForActivity(activity), activity, params)
+}
 
-	switch options.TaskQueue {
-	case environment.GetWorkerQueue():
-		if options.RetryPolicy == nil {
-			options.RetryPolicy = &LooseRetryPolicy
-		}
-	// usual reason for this failing is invalid files or tweaks to ffmpeg commands
-	case environment.GetTranscodeQueue(), environment.GetAudioQueue():
-		if options.RetryPolicy == nil {
-			options.RetryPolicy = &StrictRetryPolicy
-		}
+// ExecuteWithLowPrioQueue executes the utility activities with the low priority queue
+func ExecuteWithLowPrioQueue[T any, TR any](ctx workflow.Context, activity func(context.Context, T) (TR, error), params T) Task[TR] {
+	queue := activities.GetQueueForActivity(activity)
+
+	// Compared against the constant, not GetWorkerQueue(): in debug mode that
+	// accessor returns the debug queue, and the debug worker polls only that
+	// queue, so moving its activities to low-priority would leave them
+	// unscheduled.
+	if queue == environment.QueueWorker {
+		queue = environment.QueueLowPriority
+	}
+
+	return executeOnQueue(ctx, queue, activity, params)
+}
+
+// executeOnQueue schedules the activity on queue with the options the workflow
+// set, and the defaults for whatever it did not.
+func executeOnQueue[T any, TR any](
+	ctx workflow.Context,
+	queue string,
+	activity func(context.Context, T) (TR, error),
+	params T,
+) Task[TR] {
+	options := workflow.GetActivityOptions(ctx)
+	options.TaskQueue = queue
+
+	if options.RetryPolicy == nil {
+		options.RetryPolicy = retryPolicyForQueue(queue)
 	}
 
 	ctx = workflow.WithActivityOptions(ctx, activityOptionsWithDefaults(options))
@@ -103,29 +121,33 @@ func Execute[T any, TR any](ctx workflow.Context, activity func(context.Context,
 	return Task[TR]{Future: workflow.ExecuteActivity(ctx, activity, params)}
 }
 
-// ExecuteWithLowPrioQueue executes the utility activities with the low priority queue
-func ExecuteWithLowPrioQueue[T any, TR any](ctx workflow.Context, activity func(context.Context, T) (TR, error), params T) Task[TR] {
-	options := workflow.GetActivityOptions(ctx)
+// retryPolicyForQueue picks how hard to retry from the kind of work the queue
+// carries, for workflows that did not choose a policy themselves.
+func retryPolicyForQueue(queue string) *temporal.RetryPolicy {
+	return retryPolicyForQueueNames(
+		queue,
+		environment.GetWorkerQueue(),
+		environment.GetTranscodeQueue(),
+		environment.GetAudioQueue(),
+	)
+}
 
-	options.TaskQueue = activities.GetQueueForActivity(activity)
-	if options.TaskQueue == environment.QueueWorker {
-		options.TaskQueue = environment.QueueLowPriority
-	}
-
-	switch options.TaskQueue {
-	case environment.GetWorkerQueue():
-		if options.RetryPolicy == nil {
-			options.RetryPolicy = &LooseRetryPolicy
-		}
-	// usual reason for this failing is invalid files or tweaks to ffmpeg commands
-	case environment.GetTranscodeQueue(), environment.GetAudioQueue():
-		if options.RetryPolicy == nil {
-			options.RetryPolicy = &StrictRetryPolicy
-		}
-	}
-
-	ctx = workflow.WithActivityOptions(ctx, activityOptionsWithDefaults(options))
-	return Task[TR]{
-		workflow.ExecuteActivity(ctx, activity, params),
+// retryPolicyForQueueNames takes the queue names as arguments so the debug
+// arrangement, where all three collapse onto one queue, can be exercised
+// without the process-wide QUEUE variable that decides them.
+func retryPolicyForQueueNames(queue, worker, transcode, audio string) *temporal.RetryPolicy {
+	switch queue {
+	// Worker first: in debug mode one worker runs everything and all three names
+	// are the debug queue, so this ordering is what keeps the behaviour of the
+	// ordered switch it replaces.
+	case worker:
+		return &LooseRetryPolicy
+	// A transcode or audio failure is usually an invalid file or a tweak needed
+	// to an ffmpeg command, and neither is fixed by trying ten times.
+	case transcode, audio:
+		return &StrictRetryPolicy
+	// Low priority and live ingest carry the same work as the worker queue.
+	default:
+		return &LooseRetryPolicy
 	}
 }

--- a/utils/workflows/execute_test.go
+++ b/utils/workflows/execute_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bcc-code/bcc-media-flows/environment"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/activity"
@@ -92,4 +93,91 @@ func TestExecuteKeepsTheOptionsTheWorkflowSet(t *testing.T) {
 	var budget time.Duration
 	require.NoError(t, env.GetWorkflowResult(&budget))
 	assert.Equal(t, 30*time.Minute, budget)
+}
+
+func TestRetryPolicyForQueueNames(t *testing.T) {
+	const (
+		worker    = "worker"
+		transcode = "transcode"
+		audio     = "audio"
+	)
+
+	assert.Equal(t, &LooseRetryPolicy, retryPolicyForQueueNames(worker, worker, transcode, audio))
+	assert.Equal(t, &StrictRetryPolicy, retryPolicyForQueueNames(transcode, worker, transcode, audio))
+	assert.Equal(t, &StrictRetryPolicy, retryPolicyForQueueNames(audio, worker, transcode, audio))
+
+	// The queues the switch never named. They fell through to no policy at all,
+	// which leaves the SDK retrying until the schedule-to-close budget runs out.
+	assert.Equal(t, &LooseRetryPolicy,
+		retryPolicyForQueueNames(environment.QueueLowPriority, worker, transcode, audio))
+	assert.Equal(t, &LooseRetryPolicy,
+		retryPolicyForQueueNames(environment.QueueLiveIngest, worker, transcode, audio))
+}
+
+// With QUEUE=debug every accessor returns the debug queue and one worker runs
+// everything, so the ordering of the cases is what decides the answer.
+func TestRetryPolicyForQueueNamesUnderDebug(t *testing.T) {
+	const debug = "debug"
+
+	assert.Equal(t, &LooseRetryPolicy, retryPolicyForQueueNames(debug, debug, debug, debug))
+}
+
+// queueActivity reports the queue it was scheduled on.
+type scheduledOn struct {
+	Queue               string
+	StartToCloseTimeout time.Duration
+}
+
+func reportSchedulingActivity(ctx context.Context, _ any) (scheduledOn, error) {
+	info := activity.GetInfo(ctx)
+	return scheduledOn{
+		Queue:               info.TaskQueue,
+		StartToCloseTimeout: info.StartToCloseTimeout,
+	}, nil
+}
+
+func runSchedulingWorkflow(t *testing.T, wf any) scheduledOn {
+	t.Helper()
+
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterActivity(reportSchedulingActivity)
+
+	env.ExecuteWorkflow(wf)
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var got scheduledOn
+	require.NoError(t, env.GetWorkflowResult(&got))
+	return got
+}
+
+func executeWorkflow(ctx workflow.Context) (scheduledOn, error) {
+	return Execute(ctx, reportSchedulingActivity, any(nil)).Result(ctx)
+}
+
+func executeLowPrioWorkflow(ctx workflow.Context) (scheduledOn, error) {
+	return ExecuteWithLowPrioQueue(ctx, reportSchedulingActivity, any(nil)).Result(ctx)
+}
+
+func TestExecuteSchedulesOnTheQueueThatOwnsTheActivity(t *testing.T) {
+	got := runSchedulingWorkflow(t, executeWorkflow)
+
+	assert.Equal(t, environment.GetWorkerQueue(), got.Queue)
+	assert.Equal(t, GetDefaultActivityOptions().StartToCloseTimeout, got.StartToCloseTimeout)
+}
+
+// The two entry points differ only in the queue they pick; everything the
+// workflow did not set has to be filled in the same way for both. It used to
+// be filled in only by Execute.
+func TestExecuteWithLowPrioQueueMovesTheActivityAndKeepsTheDefaults(t *testing.T) {
+	got := runSchedulingWorkflow(t, executeLowPrioWorkflow)
+
+	if environment.GetWorkerQueue() == environment.QueueWorker {
+		assert.Equal(t, environment.QueueLowPriority, got.Queue)
+	} else {
+		// Debug: one worker polls one queue, so nothing is moved off it.
+		assert.Equal(t, environment.GetWorkerQueue(), got.Queue)
+	}
+	assert.Equal(t, GetDefaultActivityOptions().StartToCloseTimeout, got.StartToCloseTimeout)
 }


### PR DESCRIPTION
**12/n of a stack.** Base: `refactor/remove-dynamic-trigger-rpc` (#450). Closes *ExecuteWithLowPrioQueue has drifted from Execute*.

The two differed only in the queue they pick, but each had its own copy of the scheduling code and the copies had drifted. Two of the three divergences the audit listed are already gone earlier in this stack — the `ActivityWG` bookkeeping no longer exists (#440) and both call `activityOptionsWithDefaults` (#443) — leaving the duplicated retry-policy switch. Both now call `executeOnQueue` with a queue.

**Extracting it exposed a gap the duplication hid.** The switch only names the worker, transcode and audio queues, so an activity on any other queue got no retry policy at all unless the workflow set one — and low-priority is by definition a queue the switch does not name, so `ExecuteWithLowPrioQueue` routed activities to exactly the case that falls through. Latent today because both callers pass `GetDefaultActivityOptions`, which carries a policy. `retryPolicyForQueue` now has a default branch: low priority and live ingest carry the same kind of work as the worker queue, so they get the same loose policy.

Two details worth keeping in mind when reading the diff, both about **debug mode**:

- The low-priority remap compares against `environment.QueueWorker`, the constant, **not** `GetWorkerQueue()`. With `QUEUE=debug` the accessor returns the debug queue and the debug worker polls only that queue, so remapping there would leave the activity unscheduled. The asymmetry is deliberate.
- Debug also collapses the worker, transcode and audio accessors onto one value, which made the original a switch with three identical cases where the first won. The extracted version keeps worker first for that reason, and `retryPolicyForQueueNames` takes the names as arguments so a test can exercise the collapsed arrangement — the `QUEUE` variable that decides them is read at package-var time, so `t.Setenv` cannot reach it.

Worth knowing while reviewing: the test environment here runs with `QUEUE=debug`, so anything asserting on the accessors is asserting the collapsed arrangement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)