### PR TITLE
refactor: one ffmpeg.Run(Job) behind the transcode wrappers

### DIFF
--- a/activities/transcode.go
+++ b/activities/transcode.go
@@ -59,7 +59,7 @@ func (va VideoActivities) TranscodeToProResActivity(ctx context.Context, input E
 	}
 
 	return &EncodeResult{
-		OutputPath: paths.MustParse(transcodeResult.OutputPath),
+		OutputPath: paths.MustParse(transcodeResult.Path),
 	}, nil
 }
 
@@ -93,7 +93,7 @@ func (va VideoActivities) TranscodeToHyperdeckProResActivity(ctx context.Context
 	}
 
 	return &EncodeResult{
-		OutputPath: paths.MustParse(transcodeResult.OutputPath),
+		OutputPath: paths.MustParse(transcodeResult.Path),
 	}, nil
 }
 
@@ -467,7 +467,7 @@ func (va VideoActivities) TranscodeToHAPActivity(ctx context.Context, input HAPI
 	}
 
 	return &HAPResult{
-		OutputPath: paths.MustParse(transcodeResult.OutputPath),
+		OutputPath: paths.MustParse(transcodeResult.Path),
 	}, nil
 }
 

--- a/services/ffmpeg/run.go
+++ b/services/ffmpeg/run.go
@@ -1,0 +1,97 @@
+package ffmpeg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// OutputFileMode and OutputDirMode are what transcode output is left as.
+	//
+	// Group-writable rather than world-writable: these land on a shared Isilon
+	// mount where 0777 masters can be modified by anything that can reach the
+	// share.
+	OutputFileMode os.FileMode = 0664
+	OutputDirMode  os.FileMode = 0775
+)
+
+// Job is a single-input, single-output ffmpeg run.
+//
+// Args carries only the codec, filter and metadata arguments. Run supplies the
+// rest of the command line, so the pieces every wrapper was repeating —
+// progress reporting, the input flag, overwrite, the output path — are in one
+// place and in one order.
+type Job struct {
+	// Input is the file to read. Required.
+	Input string
+
+	// Output is the file to write. Its directory is created if missing.
+	Output string
+
+	// Args are the arguments between the input and the output.
+	Args []string
+
+	// Info is the probe result used to turn ffmpeg's progress output into a
+	// percentage. Run probes Input when it is nil.
+	Info *StreamInfo
+
+	// FileMode is what Output is chmodded to. Zero means OutputFileMode.
+	FileMode os.FileMode
+}
+
+// Run assembles and executes the job, and returns the stream info it probed or
+// was given.
+//
+// The output directory is created first. Writing to a directory that does not
+// exist is the single most common way for one of these to fail, because the
+// caller is usually the first thing to put a file there.
+func Run(job Job, cb ProgressCallback) (StreamInfo, error) {
+	if job.Input == "" {
+		return StreamInfo{}, fmt.Errorf("ffmpeg job has no input")
+	}
+	if job.Output == "" {
+		return StreamInfo{}, fmt.Errorf("ffmpeg job for %s has no output", job.Input)
+	}
+
+	info := StreamInfo{}
+	if job.Info != nil {
+		info = *job.Info
+	} else {
+		probed, err := GetStreamInfo(job.Input)
+		if err != nil {
+			return StreamInfo{}, err
+		}
+		info = probed
+	}
+
+	if err := os.MkdirAll(filepath.Dir(job.Output), OutputDirMode); err != nil {
+		return info, err
+	}
+
+	if _, err := Do(job.Arguments(), info, cb); err != nil {
+		return info, err
+	}
+
+	mode := job.FileMode
+	if mode == 0 {
+		mode = OutputFileMode
+	}
+	if err := os.Chmod(job.Output, mode); err != nil {
+		return info, err
+	}
+
+	return info, nil
+}
+
+// Arguments returns the full ffmpeg command line for the job.
+func (j Job) Arguments() []string {
+	args := make([]string, 0, len(j.Args)+8)
+	args = append(args,
+		"-progress", "pipe:1",
+		"-hide_banner",
+		"-i", j.Input,
+	)
+	args = append(args, j.Args...)
+	return append(args, "-y", j.Output)
+}

--- a/services/ffmpeg/run.go
+++ b/services/ffmpeg/run.go
@@ -18,10 +18,9 @@ const (
 
 // Job is a single-input, single-output ffmpeg run.
 //
-// Args carries only the codec, filter and metadata arguments. Run supplies the
-// rest of the command line, so the pieces every wrapper was repeating —
-// progress reporting, the input flag, overwrite, the output path — are in one
-// place and in one order.
+// Args carries only the codec, filter and metadata arguments; Run supplies the
+// rest of the command line — progress reporting, the input flag, overwrite and
+// the output path — in a fixed order.
 type Job struct {
 	// Input is the file to read. Required.
 	Input string
@@ -51,9 +50,8 @@ type Job struct {
 // Run assembles and executes the job, and returns the stream info it probed or
 // was given.
 //
-// The output directory is created first. Writing to a directory that does not
-// exist is the single most common way for one of these to fail, because the
-// caller is usually the first thing to put a file there.
+// The output directory is created first: the caller is usually the first thing
+// to put a file there.
 func Run(job Job, cb ProgressCallback) (StreamInfo, error) {
 	if job.Input == "" {
 		return StreamInfo{}, fmt.Errorf("ffmpeg job has no input")
@@ -131,8 +129,8 @@ func FileInputs(paths []string) []Input {
 // because its inputs and its filter graph are built together and cannot be
 // separated into a Job.
 //
-// It still creates the output directory and sets the output's mode, which is
-// the half of Run that has nothing to do with the arguments.
+// It creates the output directory and sets the output's mode, and leaves the
+// argument list exactly as given.
 func RunArgs(args []string, output string, info StreamInfo, cb ProgressCallback) error {
 	if output == "" {
 		return fmt.Errorf("ffmpeg command has no output")

--- a/services/ffmpeg/run.go
+++ b/services/ffmpeg/run.go
@@ -26,6 +26,10 @@ type Job struct {
 	// Input is the file to read. Required.
 	Input string
 
+	// ExtraInputs are further files to read, in order, after Input. Their
+	// stream indices start at 1.
+	ExtraInputs []string
+
 	// Output is the file to write. Its directory is created if missing.
 	Output string
 
@@ -86,12 +90,15 @@ func Run(job Job, cb ProgressCallback) (StreamInfo, error) {
 
 // Arguments returns the full ffmpeg command line for the job.
 func (j Job) Arguments() []string {
-	args := make([]string, 0, len(j.Args)+8)
+	args := make([]string, 0, len(j.Args)+2*len(j.ExtraInputs)+8)
 	args = append(args,
 		"-progress", "pipe:1",
 		"-hide_banner",
 		"-i", j.Input,
 	)
+	for _, input := range j.ExtraInputs {
+		args = append(args, "-i", input)
+	}
 	args = append(args, j.Args...)
 	return append(args, "-y", j.Output)
 }

--- a/services/ffmpeg/run.go
+++ b/services/ffmpeg/run.go
@@ -26,9 +26,13 @@ type Job struct {
 	// Input is the file to read. Required.
 	Input string
 
-	// ExtraInputs are further files to read, in order, after Input. Their
-	// stream indices start at 1.
-	ExtraInputs []string
+	// InputArgs are options that apply to Input and therefore have to precede
+	// its -i, such as -f lavfi for a synthesised source.
+	InputArgs []string
+
+	// ExtraInputs are further inputs, in order, after Input. Their stream
+	// indices start at 1.
+	ExtraInputs []Input
 
 	// Output is the file to write. Its directory is created if missing.
 	Output string
@@ -88,17 +92,59 @@ func Run(job Job, cb ProgressCallback) (StreamInfo, error) {
 	return info, nil
 }
 
+// Input is one ffmpeg input, with the options that belong to it.
+type Input struct {
+	// Args are options that apply to this input and precede its -i, such as
+	// -itsoffset.
+	Args []string
+
+	// Path is the file, or the source description for a synthesised input.
+	Path string
+}
+
 // Arguments returns the full ffmpeg command line for the job.
 func (j Job) Arguments() []string {
-	args := make([]string, 0, len(j.Args)+2*len(j.ExtraInputs)+8)
-	args = append(args,
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-i", j.Input,
-	)
+	args := make([]string, 0, len(j.Args)+4*len(j.ExtraInputs)+8)
+	args = append(args, "-progress", "pipe:1", "-hide_banner")
+	args = append(args, j.InputArgs...)
+	args = append(args, "-i", j.Input)
+
 	for _, input := range j.ExtraInputs {
-		args = append(args, "-i", input)
+		args = append(args, input.Args...)
+		args = append(args, "-i", input.Path)
 	}
+
 	args = append(args, j.Args...)
 	return append(args, "-y", j.Output)
+}
+
+// FileInputs turns plain paths into inputs with no per-input options.
+func FileInputs(paths []string) []Input {
+	inputs := make([]Input, 0, len(paths))
+	for _, path := range paths {
+		inputs = append(inputs, Input{Path: path})
+	}
+	return inputs
+}
+
+// RunArgs is Run for a command whose argument list the caller assembles itself,
+// because its inputs and its filter graph are built together and cannot be
+// separated into a Job.
+//
+// It still creates the output directory and sets the output's mode, which is
+// the half of Run that has nothing to do with the arguments.
+func RunArgs(args []string, output string, info StreamInfo, cb ProgressCallback) error {
+	if output == "" {
+		return fmt.Errorf("ffmpeg command has no output")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(output), OutputDirMode); err != nil {
+		return err
+	}
+
+	if _, err := Do(args, info, cb); err != nil {
+		return err
+	}
+
+	return os.Chmod(output, OutputFileMode)
 }

--- a/services/ffmpeg/run_test.go
+++ b/services/ffmpeg/run_test.go
@@ -1,0 +1,84 @@
+package ffmpeg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobArguments(t *testing.T) {
+	args := Job{
+		Input:  "/in/source.mxf",
+		Output: "/out/result.wav",
+		Args:   []string{"-codec:a", "pcm_s24le"},
+	}.Arguments()
+
+	assert.Equal(t, []string{
+		"-progress", "pipe:1",
+		"-hide_banner",
+		"-i", "/in/source.mxf",
+		"-codec:a", "pcm_s24le",
+		"-y", "/out/result.wav",
+	}, args)
+}
+
+// The output path has to come last and after -y, and the input before the
+// codec arguments: ffmpeg reads options positionally, so an argument's meaning
+// depends on which file it precedes.
+func TestJobArgumentsWithNoArgs(t *testing.T) {
+	args := Job{Input: "/in/a.mov", Output: "/out/b.mov"}.Arguments()
+
+	assert.Equal(t, "-i", args[len(args)-4])
+	assert.Equal(t, "/in/a.mov", args[len(args)-3])
+	assert.Equal(t, "-y", args[len(args)-2])
+	assert.Equal(t, "/out/b.mov", args[len(args)-1])
+}
+
+func TestRunRejectsAnIncompleteJob(t *testing.T) {
+	_, err := Run(Job{Output: "/out/x.wav"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no input")
+
+	_, err = Run(Job{Input: "/in/x.mxf"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no output")
+}
+
+// Writing into a directory that does not exist is the most common way for one
+// of these to fail, because the caller is usually the first thing to put a file
+// there.
+func TestRunCreatesTheOutputDirectory(t *testing.T) {
+	root := t.TempDir()
+	output := filepath.Join(root, "nested", "deeper", "out.wav")
+
+	// The ffmpeg call fails on a nonexistent input, but only after the directory
+	// has been made — which is what this is checking.
+	_, err := Run(Job{
+		Input:  filepath.Join(root, "missing.mxf"),
+		Output: output,
+		Info:   &StreamInfo{},
+	}, nil)
+	require.Error(t, err)
+
+	info, statErr := os.Stat(filepath.Dir(output))
+	require.NoError(t, statErr, "the output directory should exist even though the run failed")
+	assert.True(t, info.IsDir())
+}
+
+func TestRunUsesTheGivenInfoWithoutProbing(t *testing.T) {
+	root := t.TempDir()
+
+	// A nonexistent input would fail probing with a different error; passing Info
+	// means Run gets as far as trying to run ffmpeg.
+	_, err := Run(Job{
+		Input:  filepath.Join(root, "missing.mxf"),
+		Output: filepath.Join(root, "out.wav"),
+		Info:   &StreamInfo{TotalSeconds: 10},
+	}, nil)
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "ffprobe")
+}

--- a/services/ffmpeg/run_test.go
+++ b/services/ffmpeg/run_test.go
@@ -47,9 +47,8 @@ func TestRunRejectsAnIncompleteJob(t *testing.T) {
 	assert.Contains(t, err.Error(), "no output")
 }
 
-// Writing into a directory that does not exist is the most common way for one
-// of these to fail, because the caller is usually the first thing to put a file
-// there.
+// The caller is usually the first thing to put a file in the output directory,
+// so Run has to create it.
 func TestRunCreatesTheOutputDirectory(t *testing.T) {
 	root := t.TempDir()
 	output := filepath.Join(root, "nested", "deeper", "out.wav")

--- a/services/ffmpeg/run_test.go
+++ b/services/ffmpeg/run_test.go
@@ -86,7 +86,7 @@ func TestRunUsesTheGivenInfoWithoutProbing(t *testing.T) {
 func TestJobArgumentsWithExtraInputs(t *testing.T) {
 	args := Job{
 		Input:       "/in/video.mxf",
-		ExtraInputs: []string{"/in/nor.wav", "/in/eng.wav"},
+		ExtraInputs: FileInputs([]string{"/in/nor.wav", "/in/eng.wav"}),
 		Output:      "/out/result.mov",
 		Args:        []string{"-map", "1"},
 	}.Arguments()
@@ -101,5 +101,32 @@ func TestJobArgumentsWithExtraInputs(t *testing.T) {
 		"-i", "/in/eng.wav",
 		"-map", "1",
 		"-y", "/out/result.mov",
+	}, args)
+}
+
+// -itsoffset and -f lavfi apply to the input they precede, so they cannot be
+// lumped in with the codec arguments.
+func TestJobArgumentsWithPerInputOptions(t *testing.T) {
+	args := Job{
+		InputArgs: []string{"-f", "lavfi"},
+		Input:     "color=c=black:s=1920x1080",
+		ExtraInputs: []Input{
+			{Args: []string{"-itsoffset", "-0.022"}, Path: "/in/nor.wav"},
+			{Path: "/in/nor.srt"},
+		},
+		Output: "/out/muxed.mxf",
+		Args:   []string{"-c:v", "copy"},
+	}.Arguments()
+
+	assert.Equal(t, []string{
+		"-progress", "pipe:1",
+		"-hide_banner",
+		"-f", "lavfi",
+		"-i", "color=c=black:s=1920x1080",
+		"-itsoffset", "-0.022",
+		"-i", "/in/nor.wav",
+		"-i", "/in/nor.srt",
+		"-c:v", "copy",
+		"-y", "/out/muxed.mxf",
 	}, args)
 }

--- a/services/ffmpeg/run_test.go
+++ b/services/ffmpeg/run_test.go
@@ -82,3 +82,24 @@ func TestRunUsesTheGivenInfoWithoutProbing(t *testing.T) {
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "ffprobe")
 }
+
+func TestJobArgumentsWithExtraInputs(t *testing.T) {
+	args := Job{
+		Input:       "/in/video.mxf",
+		ExtraInputs: []string{"/in/nor.wav", "/in/eng.wav"},
+		Output:      "/out/result.mov",
+		Args:        []string{"-map", "1"},
+	}.Arguments()
+
+	// The extra inputs sit between the primary input and the arguments, so the
+	// stream indices the arguments refer to are the order they were given in.
+	assert.Equal(t, []string{
+		"-progress", "pipe:1",
+		"-hide_banner",
+		"-i", "/in/video.mxf",
+		"-i", "/in/nor.wav",
+		"-i", "/in/eng.wav",
+		"-map", "1",
+		"-y", "/out/result.mov",
+	}, args)
+}

--- a/services/transcode/audio.go
+++ b/services/transcode/audio.go
@@ -308,13 +308,7 @@ func GenerateToneFile(frequency int, duration float64, sampleRate int, timecode 
 }
 
 func TrimFile(inFile, outFile paths.Path, start, end float64, cb ffmpeg.ProgressCallback) error {
-	params := []string{
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-y",
-		"-i", inFile.Local(),
-		"-ss", fmt.Sprintf("%f", start),
-	}
+	params := []string{"-ss", fmt.Sprintf("%f", start)}
 
 	if end != 0 {
 		params = append(params,
@@ -323,19 +317,19 @@ func TrimFile(inFile, outFile paths.Path, start, end float64, cb ffmpeg.Progress
 
 	params = append(params,
 		"-map", "0",
-		"-c", "copy",
-		outFile.Local())
+		"-c", "copy")
 
-	_, err := ffmpeg.Do(params, ffmpeg.StreamInfo{}, cb)
+	_, err := ffmpeg.Run(ffmpeg.Job{
+		Input:  inFile.Local(),
+		Output: outFile.Local(),
+		Args:   params,
+		Info:   &ffmpeg.StreamInfo{},
+	}, cb)
 	return err
 }
 
 func Convert51to4Mono(inFile, outFile paths.Path, cb ffmpeg.ProgressCallback) error {
 	params := []string{
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-y",
-		"-i", inFile.Local(),
 		"-map", "0:v",
 		"-c:v", "copy", // Copy video unchanged
 		"-filter_complex", // Process audio
@@ -351,10 +345,14 @@ func Convert51to4Mono(inFile, outFile paths.Path, cb ffmpeg.ProgressCallback) er
 		"-map", "[BL2]",
 		"-map", "[BR2]",
 		"-c:a", "pcm_s24le", // We can not use -c copy here, because the channel layout is changed, but this should be the default codec in any case
-		outFile.Local(),
 	}
 
-	_, err := ffmpeg.Do(params, ffmpeg.StreamInfo{}, cb)
+	_, err := ffmpeg.Run(ffmpeg.Job{
+		Input:  inFile.Local(),
+		Output: outFile.Local(),
+		Args:   params,
+		Info:   &ffmpeg.StreamInfo{},
+	}, cb)
 	return err
 }
 

--- a/services/transcode/audio.go
+++ b/services/transcode/audio.go
@@ -104,151 +104,68 @@ func AudioIsSilent(path paths.Path) (bool, error) {
 }
 
 func AudioAac(input common.AudioInput, cb ffmpeg.ProgressCallback) (*common.AudioResult, error) {
-	params := []string{
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-i", input.Path.Local(),
-		"-c:a", "libfdk_aac",
-		"-b:a", input.Bitrate,
-	}
+	outputFilePath := bitrateSuffixedOutput(input, "aac")
 
-	outputFilePath := filepath.Join(input.DestinationPath.Local(), input.Path.Base())
-	outputFilePath = fmt.Sprintf("%s-%s.aac", outputFilePath[:len(outputFilePath)-len(filepath.Ext(outputFilePath))], input.Bitrate)
-
-	params = append(params, "-y", outputFilePath)
-
-	info, err := ffmpeg.GetStreamInfo(input.Path.Local())
+	_, err := ffmpeg.Run(ffmpeg.Job{
+		Input:  input.Path.Local(),
+		Output: outputFilePath,
+		Args: []string{
+			"-c:a", "libfdk_aac",
+			"-b:a", input.Bitrate,
+		},
+	}, cb)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = ffmpeg.Do(params, info, cb)
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.Chmod(outputFilePath, os.ModePerm)
-	if err != nil {
-		return nil, err
-	}
-
-	outputPath, err := paths.Parse(outputFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	fileInfo, err := os.Stat(outputFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	return &common.AudioResult{
-		OutputPath: outputPath,
-		Bitrate:    input.Bitrate,
-		Format:     "aac",
-		FileSize:   fileInfo.Size(),
-	}, nil
+	return audioResult(outputFilePath, input.Bitrate, "aac")
 }
 
 // PrepareForTranscription prepares the audio file for transcription by converting it to a mono wav file
 func PrepareForTranscription(input common.AudioInput, cb ffmpeg.ProgressCallback) (*common.AudioResult, error) {
-	outputFilePath := filepath.Join(input.DestinationPath.Local(), input.Path.Base())
-	outputFilePath = fmt.Sprintf("%s-%s.wav", outputFilePath[:len(outputFilePath)-len(filepath.Ext(outputFilePath))], input.Bitrate)
+	outputFilePath := bitrateSuffixedOutput(input, "wav")
 
-	params := []string{
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-y",
-		"-i", input.Path.Local(),
-		"-map", "0:a:0",
-		"-ac", "1",
-		outputFilePath,
-	}
-
-	info, err := ffmpeg.GetStreamInfo(input.Path.Local())
+	_, err := ffmpeg.Run(ffmpeg.Job{
+		Input:  input.Path.Local(),
+		Output: outputFilePath,
+		Args: []string{
+			"-map", "0:a:0",
+			"-ac", "1",
+		},
+	}, cb)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = ffmpeg.Do(params, info, cb)
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.Chmod(outputFilePath, os.ModePerm)
-	if err != nil {
-		return nil, err
-	}
-
-	outputPath, err := paths.Parse(outputFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	fileInfo, err := os.Stat(outputFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	return &common.AudioResult{
-		OutputPath: outputPath,
-		Bitrate:    input.Bitrate,
-		Format:     "wav",
-		FileSize:   fileInfo.Size(),
-	}, nil
+	return audioResult(outputFilePath, input.Bitrate, "wav")
 }
 
 func AudioWav(input common.WavAudioInput, cb ffmpeg.ProgressCallback) (*common.AudioResult, error) {
 	outputFilePath := input.DestinationPath.Append(input.Path.BaseNoExt() + ".wav").Local()
 
-	params := []string{
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-i", input.Path.Local(),
-		"-codec:a", "pcm_s24le",
-	}
+	args := []string{"-codec:a", "pcm_s24le"}
 
 	if input.Timecode != "" {
 		tcSamples, err := utils.TCToSamples(input.Timecode, 25, 48000)
 		if err != nil {
 			return nil, err
 		}
-		params = append(params, "-metadata", fmt.Sprintf("time_reference=%d", tcSamples))
-		params = append(params, "-write_bext", "1")
+		args = append(args,
+			"-metadata", fmt.Sprintf("time_reference=%d", tcSamples),
+			"-write_bext", "1",
+		)
 	}
 
-	params = append(params, "-y", outputFilePath)
-
-	info, err := ffmpeg.GetStreamInfo(input.Path.Local())
+	_, err := ffmpeg.Run(ffmpeg.Job{
+		Input:  input.Path.Local(),
+		Output: outputFilePath,
+		Args:   args,
+	}, cb)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = ffmpeg.Do(params, info, cb)
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.Chmod(outputFilePath, os.ModePerm)
-	if err != nil {
-		return nil, err
-	}
-
-	outputPath, err := paths.Parse(outputFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	fileInfo, err := os.Stat(outputFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	return &common.AudioResult{
-		OutputPath: outputPath,
-		Format:     "wav",
-		FileSize:   fileInfo.Size(),
-	}, nil
+	return audioResult(outputFilePath, "", "wav")
 }
 
 func getQfactorFromBitrate(input string) int {
@@ -280,12 +197,7 @@ func getQfactorFromBitrate(input string) int {
 }
 
 func AudioMP3(input common.AudioInput, cb ffmpeg.ProgressCallback) (*common.AudioResult, error) {
-	params := []string{
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-i", input.Path.Local(),
-		"-c:a", "libmp3lame",
-	}
+	params := []string{"-c:a", "libmp3lame"}
 
 	if input.ForceCBR {
 		params = append(params, "-b:a", input.Bitrate)
@@ -293,42 +205,18 @@ func AudioMP3(input common.AudioInput, cb ffmpeg.ProgressCallback) (*common.Audi
 		params = append(params, "-q:a", fmt.Sprint(getQfactorFromBitrate(input.Bitrate)))
 	}
 
-	outputFilePath := filepath.Join(input.DestinationPath.Local(), input.Path.Base())
-	outputFilePath = fmt.Sprintf("%s-%s.mp3", outputFilePath[:len(outputFilePath)-len(filepath.Ext(outputFilePath))], input.Bitrate)
+	outputFilePath := bitrateSuffixedOutput(input, "mp3")
 
-	params = append(params, "-y", outputFilePath)
-
-	info, err := ffmpeg.GetStreamInfo(input.Path.Local())
+	_, err := ffmpeg.Run(ffmpeg.Job{
+		Input:  input.Path.Local(),
+		Output: outputFilePath,
+		Args:   params,
+	}, cb)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = ffmpeg.Do(params, info, cb)
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.Chmod(outputFilePath, os.ModePerm)
-	if err != nil {
-		return nil, err
-	}
-
-	outputPath, err := paths.Parse(outputFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	fileInfo, err := os.Stat(outputFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	return &common.AudioResult{
-		OutputPath: outputPath,
-		Bitrate:    input.Bitrate,
-		Format:     "mp3",
-		FileSize:   fileInfo.Size(),
-	}, nil
+	return audioResult(outputFilePath, input.Bitrate, "mp3")
 }
 
 func SplitAudioChannels(filePath, outputDir paths.Path, cb ffmpeg.ProgressCallback) (paths.Files, error) {
@@ -468,4 +356,31 @@ func Convert51to4Mono(inFile, outFile paths.Path, cb ffmpeg.ProgressCallback) er
 
 	_, err := ffmpeg.Do(params, ffmpeg.StreamInfo{}, cb)
 	return err
+}
+
+// bitrateSuffixedOutput is the "<destination>/<input base without extension>-<bitrate>.<ext>"
+// naming the audio encoders share.
+func bitrateSuffixedOutput(input common.AudioInput, ext string) string {
+	name := fmt.Sprintf("%s-%s.%s", input.Path.BaseNoExt(), input.Bitrate, ext)
+	return input.DestinationPath.Append(name).Local()
+}
+
+// audioResult stats the finished file and describes it.
+func audioResult(outputFilePath, bitrate, format string) (*common.AudioResult, error) {
+	outputPath, err := paths.Parse(outputFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	fileInfo, err := os.Stat(outputFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.AudioResult{
+		OutputPath: outputPath,
+		Bitrate:    bitrate,
+		Format:     format,
+		FileSize:   fileInfo.Size(),
+	}, nil
 }

--- a/services/transcode/avc_intra.go
+++ b/services/transcode/avc_intra.go
@@ -2,7 +2,6 @@ package transcode
 
 import (
 	"github.com/bcc-code/bcc-media-flows/utils"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -25,16 +24,7 @@ func AvcIntra(input AVCIntraEncodeInput, progressCallback ffmpeg.ProgressCallbac
 	filename := filepath.Base(strings.TrimSuffix(input.FilePath, filepath.Ext(input.FilePath))) + ".mxf"
 	outputPath := filepath.Join(input.OutputDir, filename)
 
-	probe, err := ffmpeg.ProbeFile(input.FilePath)
-	if err != nil {
-		return nil, err
-	}
-	info := ffmpeg.ProbeResultToInfo(probe)
-
 	params := []string{
-		"-hide_banner",
-		"-progress", "pipe:1",
-		"-i", input.FilePath,
 		"-c:a", "pcm_s24le",
 		"-c:v", "libx264",
 		"-ar", "48000",
@@ -75,12 +65,9 @@ func AvcIntra(input AVCIntraEncodeInput, progressCallback ffmpeg.ProgressCallbac
 		videoFilters = append(videoFilters, "yadif=0:-1:0")
 	}
 
-	if input.BurnInSubtitle != nil {
-		assFile, err := CreateBurninASSFile(*input.SubtitleStyle, *input.BurnInSubtitle)
-		if err != nil {
-			return nil, err
-		}
-		videoFilters = append(videoFilters, "ass="+assFile.Local())
+	videoFilters, err := appendBurnInFilter(videoFilters, input.SubtitleStyle, input.BurnInSubtitle)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(videoFilters) > 0 {
@@ -90,20 +77,13 @@ func AvcIntra(input AVCIntraEncodeInput, progressCallback ffmpeg.ProgressCallbac
 		)
 	}
 
-	params = append(
-		params,
-		"-map", "v",
-		"-map", "a?",
-		"-y",
-		outputPath,
-	)
+	params = append(params, "-map", "v", "-map", "a?")
 
-	_, err = ffmpeg.Do(params, info, progressCallback)
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.Chmod(outputPath, os.ModePerm)
+	_, err = ffmpeg.Run(ffmpeg.Job{
+		Input:  input.FilePath,
+		Output: outputPath,
+		Args:   params,
+	}, progressCallback)
 	if err != nil {
 		return nil, err
 	}

--- a/services/transcode/h264.go
+++ b/services/transcode/h264.go
@@ -23,10 +23,6 @@ type H264EncodeInput struct {
 	SubtitleStyle  *paths.Path
 }
 
-type EncodeResult struct {
-	Path string
-}
-
 func H264(input H264EncodeInput, progressCallback ffmpeg.ProgressCallback) (*EncodeResult, error) {
 	filename := filepath.Base(strings.TrimSuffix(input.FilePath, filepath.Ext(input.FilePath))) + ".mxf"
 	outputPath := filepath.Join(input.OutputDir, filename)

--- a/services/transcode/h264.go
+++ b/services/transcode/h264.go
@@ -1,7 +1,6 @@
 package transcode
 
 import (
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -54,9 +53,6 @@ func H264(input H264EncodeInput, progressCallback ffmpeg.ProgressCallback) (*Enc
 	}
 
 	params := []string{
-		"-hide_banner",
-		"-progress", "pipe:1",
-		"-i", input.FilePath,
 		"-c:v", h264encoder,
 		"-ar", "48000",
 	}
@@ -103,13 +99,9 @@ func H264(input H264EncodeInput, progressCallback ffmpeg.ProgressCallback) (*Enc
 		videoFilters = append(videoFilters, "yadif=0:-1:0")
 	}
 
-	if input.BurnInSubtitle != nil {
-		assFile, err := CreateBurninASSFile(*input.SubtitleStyle, *input.BurnInSubtitle)
-		if err != nil {
-			return nil, err
-		}
-		//defer os.Remove(assFile.Local()) ??
-		videoFilters = append(videoFilters, "ass="+assFile.Local())
+	videoFilters, err = appendBurnInFilter(videoFilters, input.SubtitleStyle, input.BurnInSubtitle)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(videoFilters) > 0 {
@@ -119,18 +111,12 @@ func H264(input H264EncodeInput, progressCallback ffmpeg.ProgressCallback) (*Enc
 		)
 	}
 
-	params = append(
-		params,
-		"-y",
-		outputPath,
-	)
-
-	_, err = ffmpeg.Do(params, info, progressCallback)
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.Chmod(outputPath, os.ModePerm)
+	_, err = ffmpeg.Run(ffmpeg.Job{
+		Input:  input.FilePath,
+		Output: outputPath,
+		Args:   params,
+		Info:   &info,
+	}, progressCallback)
 	if err != nil {
 		return nil, err
 	}

--- a/services/transcode/hap.go
+++ b/services/transcode/hap.go
@@ -25,11 +25,7 @@ type HAPInput struct {
 	Format    HAPFormat
 }
 
-type HAPResult struct {
-	OutputPath string
-}
-
-func HAP(input HAPInput, progressCallback ffmpeg.ProgressCallback) (*HAPResult, error) {
+func HAP(input HAPInput, progressCallback ffmpeg.ProgressCallback) (*EncodeResult, error) {
 	info, err := ffmpeg.GetStreamInfo(input.FilePath)
 	if err != nil {
 		return nil, err
@@ -98,19 +94,18 @@ func HAP(input HAPInput, progressCallback ffmpeg.ProgressCallback) (*HAPResult, 
 		format = HAPFormatHAPAlpha
 	}
 
-	videoParams := []string{
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-i", input.FilePath,
-		"-c:v", "hap",
-		"-format", format.Value,
-		"-r", "50",
-		"-map", "0:v:0",
-		"-an", // Explicitly exclude audio
-		"-y", tempVideoPath,
-	}
-
-	_, err = ffmpeg.Do(videoParams, info, progressCallback)
+	_, err = ffmpeg.Run(ffmpeg.Job{
+		Input:  input.FilePath,
+		Output: tempVideoPath,
+		Args: []string{
+			"-c:v", "hap",
+			"-format", format.Value,
+			"-r", "50",
+			"-map", "0:v:0",
+			"-an", // Explicitly exclude audio
+		},
+		Info: &info,
+	}, progressCallback)
 	if err != nil {
 		// Clean up audio files on error
 		for _, af := range audioFiles {
@@ -124,16 +119,7 @@ func HAP(input HAPInput, progressCallback ffmpeg.ProgressCallback) (*HAPResult, 
 
 	// Step 3: Mux audio tracks back if any were extracted
 	if len(audioFiles) > 0 {
-		muxParams := []string{
-			"-progress", "pipe:1",
-			"-hide_banner",
-			"-i", tempVideoPath,
-		}
-
-		// Add all audio files as inputs
-		for _, audioFile := range audioFiles {
-			muxParams = append(muxParams, "-i", audioFile)
-		}
+		var muxParams []string
 
 		// Map video stream first
 		muxParams = append(muxParams, "-map", "0:v:0")
@@ -147,10 +133,13 @@ func HAP(input HAPInput, progressCallback ffmpeg.ProgressCallback) (*HAPResult, 
 		muxParams = append(muxParams, "-c:v", "copy")
 		muxParams = append(muxParams, "-c:a", "pcm_s24le")
 
-		// Output to final path
-		muxParams = append(muxParams, "-y", outputPath)
-
-		_, err = ffmpeg.Do(muxParams, info, progressCallback)
+		_, err = ffmpeg.Run(ffmpeg.Job{
+			Input:       tempVideoPath,
+			ExtraInputs: ffmpeg.FileInputs(audioFiles),
+			Output:      outputPath,
+			Args:        muxParams,
+			Info:        &info,
+		}, progressCallback)
 		if err != nil {
 			// Clean up temporary files on error
 			_ = os.Remove(tempVideoPath) // Ignore cleanup errors
@@ -167,12 +156,7 @@ func HAP(input HAPInput, progressCallback ffmpeg.ProgressCallback) (*HAPResult, 
 		}
 	}
 
-	err = os.Chmod(outputPath, os.ModePerm)
-	if err != nil {
-		return nil, err
-	}
-
-	return &HAPResult{
-		OutputPath: outputPath,
+	return &EncodeResult{
+		Path: outputPath,
 	}, nil
 }

--- a/services/transcode/hap_test.go
+++ b/services/transcode/hap_test.go
@@ -40,7 +40,7 @@ func Test_HAP(t *testing.T) {
 		return
 	}
 
-	streamInfo, err := ffmpeg.GetStreamInfo(r.OutputPath)
+	streamInfo, err := ffmpeg.GetStreamInfo(r.Path)
 	assert.NoError(t, err)
 
 	assert.True(t, streamInfo.HasVideo)
@@ -85,7 +85,7 @@ func Test_HAP_PlainFormat(t *testing.T) {
 		return
 	}
 
-	streamInfo, err := ffmpeg.GetStreamInfo(r.OutputPath)
+	streamInfo, err := ffmpeg.GetStreamInfo(r.Path)
 	assert.NoError(t, err)
 
 	assert.True(t, streamInfo.HasVideo)
@@ -133,7 +133,7 @@ func Test_HAP_WithAlpha(t *testing.T) {
 		return
 	}
 
-	streamInfo, err := ffmpeg.GetStreamInfo(r.OutputPath)
+	streamInfo, err := ffmpeg.GetStreamInfo(r.Path)
 	assert.NoError(t, err)
 
 	assert.True(t, streamInfo.HasVideo)
@@ -167,7 +167,7 @@ func Test_HAP_WithAudio(t *testing.T) {
 		return
 	}
 
-	streamInfo, err := ffmpeg.GetStreamInfo(r.OutputPath)
+	streamInfo, err := ffmpeg.GetStreamInfo(r.Path)
 	assert.NoError(t, err)
 
 	assert.True(t, streamInfo.HasVideo)

--- a/services/transcode/linear_normalize.go
+++ b/services/transcode/linear_normalize.go
@@ -2,11 +2,8 @@ package transcode
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/bcc-code/bcc-media-flows/paths"
 
 	"github.com/bcc-code/bcc-media-flows/common"
 	"github.com/bcc-code/bcc-media-flows/services/ffmpeg"
@@ -19,7 +16,6 @@ func AdjustAudioLevel(input common.AudioInput, adjustment float64, cb ffmpeg.Pro
 	outputFilePath = outputFilePath[:len(outputFilePath)-len(filepath.Ext(outputFilePath))] + "_normalized" + filepath.Ext(outputFilePath)
 
 	params := []string{
-		"-i", input.Path.Local(),
 		"-c:v", "copy",
 		"-c:a", "pcm_s24le", // Preserve 24-bit audio
 	}
@@ -62,30 +58,16 @@ func AdjustAudioLevel(input common.AudioInput, adjustment float64, cb ffmpeg.Pro
 
 	params = append(params, "-filter_complex", strings.Join(filterParams, ";"))
 	params = append(params, mapParams...)
-	params = append(params, "-y", outputFilePath)
 
-	_, err = ffmpeg.Do(params, info, cb)
+	_, err = ffmpeg.Run(ffmpeg.Job{
+		Input:  input.Path.Local(),
+		Output: outputFilePath,
+		Args:   params,
+		Info:   &info,
+	}, cb)
 	if err != nil {
 		return nil, err
 	}
 
-	err = os.Chmod(outputFilePath, os.ModePerm)
-	if err != nil {
-		return nil, err
-	}
-
-	outputPath, err := paths.Parse(outputFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	fileInfo, err := os.Stat(outputFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	return &common.AudioResult{
-		OutputPath: outputPath,
-		FileSize:   fileInfo.Size(),
-	}, nil
+	return audioResult(outputFilePath, "", "")
 }

--- a/services/transcode/merge.go
+++ b/services/transcode/merge.go
@@ -2,7 +2,6 @@ package transcode
 
 import (
 	"fmt"
-	"log"
 	"math"
 	"os"
 	"os/exec"
@@ -39,11 +38,6 @@ func getFramerate(input common.MergeInput) (int, error) {
 // MergeVideo takes a list of video files and merges them into one file.
 func MergeVideo(input common.MergeInput, progressCallback ffmpeg.ProgressCallback) (*common.MergeResult, error) {
 	var params []string
-
-	for _, i := range input.Items {
-		params = append(params, "-i", i.Path.Local())
-	}
-
 	var filterComplex string
 
 	for index, i := range input.Items {
@@ -77,8 +71,6 @@ func MergeVideo(input common.MergeInput, progressCallback ffmpeg.ProgressCallbac
 	outputFilePath := filepath.Join(input.OutputDir.Local(), filepath.Clean(input.Title)+".mxf")
 
 	params = append(params,
-		"-progress", "pipe:1",
-		"-hide_banner",
 		"-strict", "unofficial",
 		"-filter_complex", filterComplex,
 		"-map", "[v]",
@@ -91,18 +83,9 @@ func MergeVideo(input common.MergeInput, progressCallback ffmpeg.ProgressCallbac
 		"-color_primaries", "bt709",
 		"-color_trc", "bt709",
 		"-colorspace", "bt709",
-		"-y",
-		outputFilePath,
 	)
 
-	_, err = ffmpeg.Do(params, ffmpeg.StreamInfo{
-		TotalSeconds: input.Duration,
-	}, progressCallback)
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.Chmod(outputFilePath, os.ModePerm)
+	_, err = runMergeJob(input, outputFilePath, params, progressCallback)
 	if err != nil {
 		return nil, err
 	}
@@ -179,17 +162,8 @@ func mergeItemToStereoStream(index int, tag string, item common.MergeInputItem) 
 // MergeAudio merges MXF audio files into one stereo file.
 func MergeAudio(input common.MergeInput, progressCallback ffmpeg.ProgressCallback) (*common.MergeResult, error) {
 	params := []string{
-		"-progress", "pipe:1",
-		"-hide_banner",
-	}
-
-	for _, i := range input.Items {
-		params = append(params, "-i", i.Path.Local())
-	}
-
-	params = append(params,
 		"-c:a", "pcm_s16le",
-	)
+	}
 
 	var filterComplex string
 
@@ -212,10 +186,9 @@ func MergeAudio(input common.MergeInput, progressCallback ffmpeg.ProgressCallbac
 
 	outputFilePath := filepath.Join(input.OutputDir.Local(), filepath.Clean(input.Title)+".wav")
 
-	params = append(params, "-filter_complex", filterComplex, "-map", "[a]", "-y", outputFilePath)
+	params = append(params, "-filter_complex", filterComplex, "-map", "[a]")
 
-	log.Default().Println(strings.Join(params, " "))
-	_, err := ffmpeg.Do(params, ffmpeg.StreamInfo{}, progressCallback)
+	_, err := runMergeJob(input, outputFilePath, params, progressCallback)
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +252,7 @@ func MergeSubtitlesByOffset(input common.MergeInput, progressCallback ffmpeg.Pro
 
 	subtitlesFile := filepath.Join(input.WorkDir.Local(), input.Title+"-subtitles.txt")
 
-	err := os.WriteFile(subtitlesFile, []byte(content), os.ModePerm)
+	err := os.WriteFile(subtitlesFile, []byte(content), ffmpeg.OutputFileMode)
 	if err != nil {
 		return nil, err
 	}
@@ -294,17 +267,14 @@ func MergeSubtitlesByOffset(input common.MergeInput, progressCallback ffmpeg.Pro
 	concatStr := fmt.Sprintf("concat:%s", strings.Join(files, "|"))
 
 	outputFilePath := filepath.Join(input.OutputDir.Local(), filepath.Clean(input.Title)+".srt")
-	params := []string{
-		"-hide_banner",
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-i", concatStr,
-		"-c", "copy",
-		"-y",
-		outputFilePath,
-	}
-
-	_, err = ffmpeg.Do(params, ffmpeg.StreamInfo{}, progressCallback)
+	// The input is ffmpeg's concat: pseudo-protocol rather than one of the merge
+	// items, so this does not go through runMergeJob.
+	_, err = ffmpeg.Run(ffmpeg.Job{
+		Input:  concatStr,
+		Output: outputFilePath,
+		Args:   []string{"-c", "copy"},
+		Info:   &ffmpeg.StreamInfo{},
+	}, progressCallback)
 	if err != nil {
 		return nil, err
 	}
@@ -356,7 +326,7 @@ func MergeSubtitles(input common.MergeInput, progressCallback ffmpeg.ProgressCal
 			contents := fmt.Sprintf("1\n%s --> %s\n\n", formatDuration(item.Start), formatDuration(item.End))
 			err = os.WriteFile(file,
 				[]byte(contents),
-				os.ModePerm,
+				ffmpeg.OutputFileMode,
 			)
 			if err != nil {
 				return nil, err
@@ -389,7 +359,7 @@ func MergeSubtitles(input common.MergeInput, progressCallback ffmpeg.ProgressCal
 
 	subtitlesFile := filepath.Join(input.WorkDir.Local(), input.Title+"-subtitles.txt")
 
-	err := os.WriteFile(subtitlesFile, []byte(content), os.ModePerm)
+	err := os.WriteFile(subtitlesFile, []byte(content), ffmpeg.OutputFileMode)
 	if err != nil {
 		return nil, err
 	}
@@ -404,17 +374,14 @@ func MergeSubtitles(input common.MergeInput, progressCallback ffmpeg.ProgressCal
 	concatStr := fmt.Sprintf("concat:%s", strings.Join(files, "|"))
 
 	outputFilePath := filepath.Join(input.OutputDir.Local(), filepath.Clean(input.Title)+".srt")
-	params := []string{
-		"-hide_banner",
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-i", concatStr,
-		"-c", "copy",
-		"-y",
-		outputFilePath,
-	}
-
-	_, err = ffmpeg.Do(params, ffmpeg.StreamInfo{}, progressCallback)
+	// The input is ffmpeg's concat: pseudo-protocol rather than one of the merge
+	// items, so this does not go through runMergeJob.
+	_, err = ffmpeg.Run(ffmpeg.Job{
+		Input:  concatStr,
+		Output: outputFilePath,
+		Args:   []string{"-c", "copy"},
+		Info:   &ffmpeg.StreamInfo{},
+	}, progressCallback)
 	if err != nil {
 		return nil, err
 	}
@@ -440,11 +407,39 @@ func ensureValidSrtFile(f string) error {
 		return err
 	}
 	if info.Size() == 0 {
-		err = os.WriteFile(f, []byte("1\n00:00:00,000 --> 00:00:00,000\n"), os.ModePerm)
+		err = os.WriteFile(f, []byte("1\n00:00:00,000 --> 00:00:00,000\n"), ffmpeg.OutputFileMode)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// runMergeJob runs one of the merge functions, whose inputs are always the
+// merge items in order — the filter graphs refer to them by that index — and
+// whose progress is measured against the merged duration rather than any one
+// input.
+func runMergeJob(
+	input common.MergeInput,
+	output string,
+	args []string,
+	cb ffmpeg.ProgressCallback,
+) (ffmpeg.StreamInfo, error) {
+	if len(input.Items) == 0 {
+		return ffmpeg.StreamInfo{}, fmt.Errorf("nothing to merge into %s", output)
+	}
+
+	inputs := make([]string, 0, len(input.Items))
+	for _, item := range input.Items {
+		inputs = append(inputs, item.Path.Local())
+	}
+
+	return ffmpeg.Run(ffmpeg.Job{
+		Input:       inputs[0],
+		ExtraInputs: ffmpeg.FileInputs(inputs[1:]),
+		Output:      output,
+		Args:        args,
+		Info:        &ffmpeg.StreamInfo{TotalSeconds: input.Duration},
+	}, cb)
 }

--- a/services/transcode/merge.go
+++ b/services/transcode/merge.go
@@ -416,10 +416,9 @@ func ensureValidSrtFile(f string) error {
 	return nil
 }
 
-// runMergeJob runs one of the merge functions, whose inputs are always the
-// merge items in order — the filter graphs refer to them by that index — and
-// whose progress is measured against the merged duration rather than any one
-// input.
+// runMergeJob runs a merge: the inputs are the merge items in order — the
+// filter graphs refer to them by that index — and progress is measured against
+// the merged duration rather than any one input.
 func runMergeJob(
 	input common.MergeInput,
 	output string,

--- a/services/transcode/multitrack.go
+++ b/services/transcode/multitrack.go
@@ -25,17 +25,14 @@ func MultitrackMux(files paths.Files, outputPath paths.Path, cb ffmpeg.ProgressC
 		return nil, err
 	}
 
-	params := []string{
-		"-f", "lavfi", "-i", fmt.Sprintf("color=c=black:s=1920x1080:r=25:d=%f", info.TotalSeconds),
-	}
-
+	extraInputs := make([]ffmpeg.Input, 0, len(files))
 	for _, f := range files {
-		params = append(params, "-i", f.Local())
+		extraInputs = append(extraInputs, ffmpeg.Input{Path: f.Local()})
 	}
 
 	outputPath = outputPath.Append(files[0].Base() + ".mxf")
 
-	params = append(params, "-map", "v")
+	params := []string{"-map", "v"}
 	for i, _ := range files {
 		t := i + 1
 		params = append(params, "-filter_complex", fmt.Sprintf("[%d:a:0]channelsplit=channel_layout=stereo[l%d][r%d]", t, t, t))
@@ -48,11 +45,19 @@ func MultitrackMux(files paths.Files, outputPath paths.Path, cb ffmpeg.ProgressC
 		"-c:v", "libx264",
 		"-c:a", "pcm_s24le",
 		"-t", fmt.Sprintf("%f", info.TotalSeconds),
-		"-y",
-		outputPath.Local(),
 	)
 
-	_, err = ffmpeg.Do(params, ffmpeg.StreamInfo{}, cb)
+	_, err = ffmpeg.Run(ffmpeg.Job{
+		// The video is a synthesised black frame, so -f lavfi has to precede the
+		// input it describes; the audio files follow it and the filter graph refers
+		// to them from index 1.
+		InputArgs:   []string{"-f", "lavfi"},
+		Input:       fmt.Sprintf("color=c=black:s=1920x1080:r=25:d=%f", info.TotalSeconds),
+		ExtraInputs: extraInputs,
+		Output:      outputPath.Local(),
+		Args:        params,
+		Info:        &ffmpeg.StreamInfo{},
+	}, cb)
 	if err != nil {
 		return nil, err
 	}

--- a/services/transcode/mux.go
+++ b/services/transcode/mux.go
@@ -3,7 +3,6 @@ package transcode
 import (
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -43,35 +42,25 @@ func Mux(input common.MuxInput, progressCallback ffmpeg.ProgressCallback) (*comm
 
 	outputFilePath := filepath.Join(input.DestinationPath.Local(), input.FileName+".mp4")
 
-	if err := os.MkdirAll(filepath.Dir(outputFilePath), os.ModePerm); err != nil {
-		return nil, err
-	}
-
-	params := []string{
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-i", input.VideoFilePath.Local(),
-	}
-
 	audioFiles := languageFilesForPaths(input.AudioFilePaths)
 	subtitleFiles := languageFilesForPaths(input.SubtitleFilePaths)
 
+	var extraInputs []ffmpeg.Input
 	for _, f := range audioFiles {
-		// -itsoffset -0.022 is there because AAC inserts a delay at the start of the audio file making it out of sync with the video
-		params = append(params,
-			"-itsoffset", "-0.022", "-i", f.Path.Local(),
-		)
+		extraInputs = append(extraInputs, ffmpeg.Input{
+			// -itsoffset -0.022 is there because AAC inserts a delay at the start of the audio file making it out of sync with the video
+			Args: []string{"-itsoffset", "-0.022"},
+			Path: f.Path.Local(),
+		})
 	}
 
 	for _, f := range subtitleFiles {
-		params = append(params,
-			"-i", f.Path.Local(),
-		)
+		extraInputs = append(extraInputs, ffmpeg.Input{Path: f.Path.Local()})
 	}
 
 	streams := 0
-	params = append(
-		params,
+	params := append(
+		[]string{},
 		"-map", fmt.Sprintf("%d:v", streams),
 		fmt.Sprintf("-metadata:s:%d", streams), "language=eng",
 	)
@@ -98,18 +87,20 @@ func Mux(input common.MuxInput, progressCallback ffmpeg.ProgressCallback) (*comm
 		"-c:v", "copy",
 		"-c:a", "copy",
 		"-c:s", "mov_text",
-		"-y", outputFilePath,
 	)
 
-	_, err = ffmpeg.Do(params, info, progressCallback)
-	if err != nil {
-		log.Default().Println("mux failed", err)
-		return nil, fmt.Errorf("mux failed, %s", strings.Join(params, " "))
+	job := ffmpeg.Job{
+		Input:       input.VideoFilePath.Local(),
+		ExtraInputs: extraInputs,
+		Output:      outputFilePath,
+		Args:        params,
+		Info:        &info,
 	}
 
-	err = os.Chmod(outputFilePath, os.ModePerm)
+	_, err = ffmpeg.Run(job, progressCallback)
 	if err != nil {
-		return nil, err
+		log.Default().Println("mux failed", err)
+		return nil, fmt.Errorf("mux failed, %s", strings.Join(job.Arguments(), " "))
 	}
 
 	outputPath, err := paths.Parse(outputFilePath)

--- a/services/transcode/mux_mxf_simple.go
+++ b/services/transcode/mux_mxf_simple.go
@@ -3,7 +3,6 @@ package transcode
 import (
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -22,21 +21,14 @@ func MuxToSimpleMXF(input common.SimpleMuxInput, progressCallback ffmpeg.Progres
 
 	outputFilePath := filepath.Join(input.DestinationPath.Local(), input.FileName+".mxf")
 
-	params := []string{
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-i", input.VideoFilePath.Local(),
-	}
-
+	var extraInputs []ffmpeg.Input
 	for _, f := range input.AudioFilePaths {
-		params = append(params,
-			"-i", f.Local(),
-		)
+		extraInputs = append(extraInputs, ffmpeg.Input{Path: f.Local()})
 	}
 
 	streams := 0
-	params = append(
-		params,
+	params := append(
+		[]string{},
 		"-map", fmt.Sprintf("%d:v", streams),
 	)
 	streams++
@@ -52,18 +44,20 @@ func MuxToSimpleMXF(input common.SimpleMuxInput, progressCallback ffmpeg.Progres
 		"-c:v", "copy",
 		"-ar", "48000",
 		"-c:a", "pcm_s24le",
-		"-y", outputFilePath,
 	)
 
-	_, err = ffmpeg.Do(params, info, progressCallback)
-	if err != nil {
-		log.Default().Println("mux failed", err)
-		return nil, fmt.Errorf("mux failed, %s", strings.Join(params, " "))
+	job := ffmpeg.Job{
+		Input:       input.VideoFilePath.Local(),
+		ExtraInputs: extraInputs,
+		Output:      outputFilePath,
+		Args:        params,
+		Info:        &info,
 	}
 
-	err = os.Chmod(outputFilePath, os.ModePerm)
+	_, err = ffmpeg.Run(job, progressCallback)
 	if err != nil {
-		return nil, err
+		log.Default().Println("mux failed", err)
+		return nil, fmt.Errorf("mux failed, %s", strings.Join(job.Arguments(), " "))
 	}
 
 	outputPath, err := paths.Parse(outputFilePath)

--- a/services/transcode/playout_mux.go
+++ b/services/transcode/playout_mux.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/bcc-code/bcc-media-flows/paths"
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -234,14 +233,13 @@ func PlayoutMux(input common.PlayoutMuxInput, progressCallback ffmpeg.ProgressCa
 	if err != nil {
 		return nil, err
 	}
-	_, err = ffmpeg.Do(params, info, progressCallback)
+	// RunArgs rather than a Job: generateFFmpegParamsForPlayoutMux adds inputs
+	// and builds the filter graph in one pass, tracking stream indices as it
+	// goes, so its inputs cannot be lifted out of the argument list.
+	err = ffmpeg.RunArgs(params, outputFilePath, info, progressCallback)
 	if err != nil {
 		log.Default().Println("mux failed", err)
 		return nil, fmt.Errorf("mux failed, %s", strings.Join(params, " "))
-	}
-	err = os.Chmod(outputFilePath, os.ModePerm)
-	if err != nil {
-		return nil, err
 	}
 
 	outputPath, err := paths.Parse(outputFilePath)

--- a/services/transcode/prepend-silence.go
+++ b/services/transcode/prepend-silence.go
@@ -10,17 +10,19 @@ import (
 // PrependSilence prepends a given file with a given length of silence.
 // The sample rate of the output file is the same as the input file.
 func PrependSilence(file paths.Path, outputPath paths.Path, length float64, sampleRate int, cb ffmpeg.ProgressCallback) (*paths.Path, error) {
-	params := []string{
-		"-f", "lavfi",
-		"-i", fmt.Sprintf("aevalsrc=0|0:d=%f", length),
-		"-i", file.Local(),
-		"-filter_complex", fmt.Sprintf("[0:a][1:a]concat=n=2:v=0:a=1"),
-		"-ar", fmt.Sprintf("%d", sampleRate),
-		"-y",
-		outputPath.Local(),
-	}
-
-	_, err := ffmpeg.Do(params, ffmpeg.StreamInfo{}, cb)
+	_, err := ffmpeg.Run(ffmpeg.Job{
+		// The silence is synthesised, so -f lavfi describes the first input; the
+		// real file follows it and the concat filter refers to the two as 0 and 1.
+		InputArgs:   []string{"-f", "lavfi"},
+		Input:       fmt.Sprintf("aevalsrc=0|0:d=%f", length),
+		ExtraInputs: []ffmpeg.Input{{Path: file.Local()}},
+		Output:      outputPath.Local(),
+		Args: []string{
+			"-filter_complex", "[0:a][1:a]concat=n=2:v=0:a=1",
+			"-ar", fmt.Sprintf("%d", sampleRate),
+		},
+		Info: &ffmpeg.StreamInfo{},
+	}, cb)
 	if err != nil {
 		return nil, err
 	}

--- a/services/transcode/preview.go
+++ b/services/transcode/preview.go
@@ -309,9 +309,7 @@ func Preview(input PreviewInput, progressCallback ffmpeg.ProgressCallback) (*Pre
 
 	// RunArgs rather than a Job: which files are inputs depends on whether the
 	// source has video, audio or both, and -ss applies to the watermark input it
-	// precedes. The only coverage of that arrangement is behind the integration
-	// build tag, so the argument list is left exactly as it is built and only the
-	// output handling is shared.
+	// precedes.
 	err = ffmpeg.RunArgs(params, outputPath, ffmpeg.ProbeResultToInfo(info), progressCallback)
 	if err != nil {
 		return nil, err

--- a/services/transcode/preview.go
+++ b/services/transcode/preview.go
@@ -197,6 +197,8 @@ func AudioPreview(input PreviewInput, progressCallback ffmpeg.ProgressCallback) 
 		return out, nil
 	}
 
+	// One output per language, so there is no single output for Run or RunArgs to
+	// create a directory for and chmod.
 	_, err = ffmpeg.Do(previewData.FFMPEGParams, ffmpeg.ProbeResultToInfo(info), progressCallback)
 	if err != nil {
 		return nil, err
@@ -305,12 +307,12 @@ func Preview(input PreviewInput, progressCallback ffmpeg.ProgressCallback) (*Pre
 		outputPath,
 	)
 
-	_, err = ffmpeg.Do(params, ffmpeg.ProbeResultToInfo(info), progressCallback)
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.Chmod(outputPath, os.ModePerm)
+	// RunArgs rather than a Job: which files are inputs depends on whether the
+	// source has video, audio or both, and -ss applies to the watermark input it
+	// precedes. The only coverage of that arrangement is behind the integration
+	// build tag, so the argument list is left exactly as it is built and only the
+	// output handling is shared.
+	err = ffmpeg.RunArgs(params, outputPath, ffmpeg.ProbeResultToInfo(info), progressCallback)
 	if err != nil {
 		return nil, err
 	}

--- a/services/transcode/prores.go
+++ b/services/transcode/prores.go
@@ -23,16 +23,12 @@ type ProResInput struct {
 	SubtitleStyle  *paths.Path
 }
 
-type ProResResult struct {
-	OutputPath string
-}
-
 const (
 	ProResProfileHQ   = "3"
 	ProResProfile4444 = "4"
 )
 
-func ProRes(input ProResInput, progressCallback ffmpeg.ProgressCallback) (*ProResResult, error) {
+func ProRes(input ProResInput, progressCallback ffmpeg.ProgressCallback) (*EncodeResult, error) {
 	filename := filepath.Base(strings.TrimSuffix(input.FilePath, filepath.Ext(input.FilePath))) + ".mov"
 
 	var params []string
@@ -132,7 +128,7 @@ func ProRes(input ProResInput, progressCallback ffmpeg.ProgressCallback) (*ProRe
 		return nil, err
 	}
 
-	return &ProResResult{
-		OutputPath: outputPath,
+	return &EncodeResult{
+		Path: outputPath,
 	}, nil
 }

--- a/services/transcode/prores.go
+++ b/services/transcode/prores.go
@@ -1,7 +1,6 @@
 package transcode
 
 import (
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -36,15 +35,7 @@ const (
 func ProRes(input ProResInput, progressCallback ffmpeg.ProgressCallback) (*ProResResult, error) {
 	filename := filepath.Base(strings.TrimSuffix(input.FilePath, filepath.Ext(input.FilePath))) + ".mov"
 
-	params := []string{
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-i", input.FilePath,
-	}
-
-	for _, i := range input.AudioPaths {
-		params = append(params, "-i", i)
-	}
+	var params []string
 
 	params = append(params,
 		"-c:v", "prores_ks",
@@ -60,12 +51,9 @@ func ProRes(input ProResInput, progressCallback ffmpeg.ProgressCallback) (*ProRe
 		"yadif=0:-1:0",
 	}
 
-	if input.BurnInSubtitle != nil {
-		assFile, err := CreateBurninASSFile(*input.SubtitleStyle, *input.BurnInSubtitle)
-		if err != nil {
-			return nil, err
-		}
-		videoFilters = append(videoFilters, "ass="+assFile.Local())
+	videoFilters, err := appendBurnInFilter(videoFilters, input.SubtitleStyle, input.BurnInSubtitle)
+	if err != nil {
+		return nil, err
 	}
 
 	if input.ForHyperdeck {
@@ -132,24 +120,14 @@ func ProRes(input ProResInput, progressCallback ffmpeg.ProgressCallback) (*ProRe
 		}
 	}
 
-	params = append(
-		params,
-		"-map", "v",
-		"-y",
-		outputPath,
-	)
+	params = append(params, "-map", "v")
 
-	info, err := ffmpeg.GetStreamInfo(input.FilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = ffmpeg.Do(params, info, progressCallback)
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.Chmod(outputPath, os.ModePerm)
+	_, err = ffmpeg.Run(ffmpeg.Job{
+		Input:       input.FilePath,
+		ExtraInputs: input.AudioPaths,
+		Output:      outputPath,
+		Args:        params,
+	}, progressCallback)
 	if err != nil {
 		return nil, err
 	}

--- a/services/transcode/prores.go
+++ b/services/transcode/prores.go
@@ -124,7 +124,7 @@ func ProRes(input ProResInput, progressCallback ffmpeg.ProgressCallback) (*ProRe
 
 	_, err = ffmpeg.Run(ffmpeg.Job{
 		Input:       input.FilePath,
-		ExtraInputs: input.AudioPaths,
+		ExtraInputs: ffmpeg.FileInputs(input.AudioPaths),
 		Output:      outputPath,
 		Args:        params,
 	}, progressCallback)

--- a/services/transcode/prores_test.go
+++ b/services/transcode/prores_test.go
@@ -44,7 +44,7 @@ func Test_ProRes(t *testing.T) {
 		return // Exit early if r is nil to avoid panic
 	}
 
-	streamInfo, err := ffmpeg.GetStreamInfo(r.OutputPath)
+	streamInfo, err := ffmpeg.GetStreamInfo(r.Path)
 	assert.NoError(t, err)
 
 	assert.True(t, streamInfo.HasVideo)
@@ -95,7 +95,7 @@ func Test_ProResHyperdeck(t *testing.T) {
 		return // Exit early if r is nil to avoid panic
 	}
 
-	streamInfo, err := ffmpeg.GetStreamInfo(r.OutputPath)
+	streamInfo, err := ffmpeg.GetStreamInfo(r.Path)
 	assert.NoError(t, err)
 
 	assert.True(t, streamInfo.HasVideo)

--- a/services/transcode/result.go
+++ b/services/transcode/result.go
@@ -1,0 +1,7 @@
+package transcode
+
+// EncodeResult names the file an encode produced. Every encoder in this package
+// returns it.
+type EncodeResult struct {
+	Path string
+}

--- a/services/transcode/subtitles.go
+++ b/services/transcode/subtitles.go
@@ -203,3 +203,21 @@ func writeEvent(outFile *os.File, startTime, endTime string, textLines []string,
 func convertTimeFormat(srtTime string) string {
 	return convertTimestamp(strings.Replace(srtTime[:12], ",", ".", 1))
 }
+
+// appendBurnInFilter adds the subtitle burn-in video filter, if there is a
+// subtitle to burn in. The three video encoders each had their own copy.
+func appendBurnInFilter(filters []string, style, subtitle *paths.Path) ([]string, error) {
+	if subtitle == nil {
+		return filters, nil
+	}
+	if style == nil {
+		return nil, fmt.Errorf("burn-in subtitle %s given with no style", subtitle.Local())
+	}
+
+	assFile, err := CreateBurninASSFile(*style, *subtitle)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(filters, "ass="+assFile.Local()), nil
+}

--- a/services/transcode/subtitles.go
+++ b/services/transcode/subtitles.go
@@ -201,7 +201,7 @@ func convertTimeFormat(srtTime string) string {
 }
 
 // appendBurnInFilter adds the subtitle burn-in video filter, if there is a
-// subtitle to burn in. The three video encoders each had their own copy.
+// subtitle to burn in.
 func appendBurnInFilter(filters []string, style, subtitle *paths.Path) ([]string, error) {
 	if subtitle == nil {
 		return filters, nil

--- a/services/transcode/subtitles.go
+++ b/services/transcode/subtitles.go
@@ -21,25 +21,19 @@ func SubtitleBurnIn(videoFile, subtitleFile, subtitleHeader, outputPath paths.Pa
 		return nil, fmt.Errorf("could not create burn-in ASS file for %s: %w", subtitleFile.Local(), err)
 	}
 
-	params := []string{
-		"-i", videoFile.Local(),
-		"-vf", "ass=" + assFile.Local(),
-		"-c:a", "copy",
-	}
-
 	base := videoFile.Base()
 	filename := base[0 : len(base)-len(videoFile.Ext())]
 
 	output := outputPath.Append(filename + ".subs" + videoFile.Ext())
 
-	params = append(params, output.Local())
-
-	info, err := ffmpeg.GetStreamInfo(videoFile.Local())
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = ffmpeg.Do(params, info, progressCallback)
+	_, err = ffmpeg.Run(ffmpeg.Job{
+		Input:  videoFile.Local(),
+		Output: output.Local(),
+		Args: []string{
+			"-vf", "ass=" + assFile.Local(),
+			"-c:a", "copy",
+		},
+	}, progressCallback)
 	if err != nil {
 		return nil, err
 	}
@@ -65,11 +59,13 @@ func CreateBurninASSFile(subtitleHeader, subtitleFile paths.Path) (*paths.Path, 
 		return &out, specialASSConverter(string(headerData), subtitleFile.Local(), out.Local(), 0.00005)
 	}
 
-	_, err = ffmpeg.Do([]string{
-		"-y",
-		"-i", subtitleFile.Local(),
-		out.Local(),
-	}, ffmpeg.StreamInfo{}, nil)
+	// Converting a subtitle file to ASS, so there is nothing to probe and no
+	// progress to report.
+	_, err = ffmpeg.Run(ffmpeg.Job{
+		Input:  subtitleFile.Local(),
+		Output: out.Local(),
+		Info:   &ffmpeg.StreamInfo{},
+	}, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +86,7 @@ func CreateBurninASSFile(subtitleHeader, subtitleFile paths.Path) (*paths.Path, 
 		lines = append(lines, l)
 	}
 
-	err = os.WriteFile(out.Local(), []byte(string(headerData)+"\n"+strings.Join(lines, "\n")), os.ModePerm)
+	err = os.WriteFile(out.Local(), []byte(string(headerData)+"\n"+strings.Join(lines, "\n")), ffmpeg.OutputFileMode)
 	if err != nil {
 		return nil, err
 	}

--- a/services/transcode/video.go
+++ b/services/transcode/video.go
@@ -2,7 +2,6 @@ package transcode
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/bcc-code/bcc-media-flows/common"
@@ -12,19 +11,12 @@ import (
 )
 
 func VideoH264(input common.VideoInput, cb ffmpeg.ProgressCallback) (*common.VideoResult, error) {
-	params := []string{
-		"-hide_banner",
-		"-progress", "pipe:1",
-		"-i", input.Path.Local(),
-	}
-
+	var extraInputs []ffmpeg.Input
 	if input.WatermarkPath != nil {
-		params = append(params,
-			"-i", input.WatermarkPath.Local(),
-		)
+		extraInputs = append(extraInputs, ffmpeg.Input{Path: input.WatermarkPath.Local()})
 	}
 
-	params = append(params,
+	params := []string{
 		"-c:v", "libx264",
 		"-profile:v", "high422",
 		"-preset", "slow",
@@ -36,7 +28,7 @@ func VideoH264(input common.VideoInput, cb ffmpeg.ProgressCallback) (*common.Vid
 		"-x264opts", "no-scenecut",
 		"-crf", "22",
 		"-write_tmcd", "0",
-	)
+	}
 
 	info, err := ffmpeg.GetStreamInfo(input.Path.Local())
 	if err != nil {
@@ -91,18 +83,15 @@ func VideoH264(input common.VideoInput, cb ffmpeg.ProgressCallback) (*common.Vid
 
 	outputFilePath := filepath.Join(input.DestinationPath.Local(), filename)
 
-	params = append(params,
-		"-y", outputFilePath,
-	)
-
-	_, err = ffmpeg.Do(params, info, cb)
+	_, err = ffmpeg.Run(ffmpeg.Job{
+		Input:       input.Path.Local(),
+		ExtraInputs: extraInputs,
+		Output:      outputFilePath,
+		Args:        params,
+		Info:        &info,
+	}, cb)
 	if err != nil {
 		return nil, err
-	}
-
-	err = os.Chmod(outputFilePath, os.ModePerm)
-	if err != nil {
-		fmt.Printf("Failed to set permissions on %s: %s", outputFilePath, err)
 	}
 
 	outputPath, err := paths.Parse(outputFilePath)

--- a/services/transcode/xdcam.go
+++ b/services/transcode/xdcam.go
@@ -2,7 +2,6 @@ package transcode
 
 import (
 	"github.com/bcc-code/bcc-media-flows/utils"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -19,18 +18,16 @@ type XDCAMEncodeInput struct {
 	Interlace  bool
 }
 
-func generateFfmpegParamsForXDCAM(input XDCAMEncodeInput, output string) []string {
+// xdcamArgs returns the codec arguments, i.e. everything ffmpeg.Job puts
+// between the input and the output.
+func xdcamArgs(input XDCAMEncodeInput) []string {
 	params := []string{
-		"-progress", "pipe:1",
-		"-hide_banner",
-		"-i", input.FilePath,
 		"-c:a", "copy",
 		"-c:v", "mpeg2video",
 		"-pix_fmt", "yuv422p",
 		"-color_primaries", "bt709",
 		"-color_trc", "bt709",
 		"-colorspace", "bt709",
-		"-y",
 	}
 
 	if input.Bitrate != "" {
@@ -62,30 +59,18 @@ func generateFfmpegParamsForXDCAM(input XDCAMEncodeInput, output string) []strin
 		)
 	}
 
-	params = append(
-		params,
-		output,
-	)
-
 	return params
 }
 
 func XDCAM(input XDCAMEncodeInput, progressCallback ffmpeg.ProgressCallback) (*EncodeResult, error) {
 	filename := filepath.Base(strings.TrimSuffix(input.FilePath, filepath.Ext(input.FilePath))) + ".mxf"
 	outputPath := filepath.Join(input.OutputDir, filename)
-	params := generateFfmpegParamsForXDCAM(input, outputPath)
 
-	info, err := ffmpeg.GetStreamInfo(input.FilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = ffmpeg.Do(params, info, progressCallback)
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.Chmod(outputPath, os.ModePerm)
+	_, err := ffmpeg.Run(ffmpeg.Job{
+		Input:  input.FilePath,
+		Output: outputPath,
+		Args:   xdcamArgs(input),
+	}, progressCallback)
 	if err != nil {
 		return nil, err
 	}

--- a/services/transcode/xdcam_test.go
+++ b/services/transcode/xdcam_test.go
@@ -5,21 +5,30 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bcc-code/bcc-media-flows/services/ffmpeg"
 	"github.com/stretchr/testify/assert"
 )
 
+// The golden line is the whole command, assembled the way ffmpeg.Run assembles
+// it, so this still covers the ordering that matters — arguments before the
+// output, output last.
 func Test_GenerateFFmpegParamsForXDCAM(t *testing.T) {
-	const golden = `-progress pipe:1 -hide_banner -i something.mxf -c:a copy -c:v mpeg2video -pix_fmt yuv422p -color_primaries bt709 -color_trc bt709 -colorspace bt709 -y -b:v 50M -s 1920x1080 -r 25 -flags +ilme+ildct -vf setfield=tff,fieldorder=tff something/something.mxf`
+	const golden = `-progress pipe:1 -hide_banner -i something.mxf -c:a copy -c:v mpeg2video -pix_fmt yuv422p -color_primaries bt709 -color_trc bt709 -colorspace bt709 -b:v 50M -s 1920x1080 -r 25 -flags +ilme+ildct -vf setfield=tff,fieldorder=tff -y something/something.mxf`
 
-	const outputPath = "something/something.mxf"
-	cmd := generateFfmpegParamsForXDCAM(XDCAMEncodeInput{
+	input := XDCAMEncodeInput{
 		FilePath:   "something.mxf",
 		OutputDir:  "out/",
 		Resolution: utils.Resolution1080,
 		FrameRate:  25,
 		Bitrate:    "50M",
 		Interlace:  true,
-	}, outputPath)
+	}
 
-	assert.Equal(t, strings.Join(cmd, " "), golden)
+	cmd := ffmpeg.Job{
+		Input:  input.FilePath,
+		Output: "something/something.mxf",
+		Args:   xdcamArgs(input),
+	}.Arguments()
+
+	assert.Equal(t, golden, strings.Join(cmd, " "))
 }

--- a/services/transcode/xdcam_test.go
+++ b/services/transcode/xdcam_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 // The golden line is the whole command, assembled the way ffmpeg.Run assembles
-// it, so this still covers the ordering that matters — arguments before the
-// output, output last.
+// it, so it covers the ordering that matters — arguments before the output,
+// output last.
 func Test_GenerateFFmpegParamsForXDCAM(t *testing.T) {
 	const golden = `-progress pipe:1 -hide_banner -i something.mxf -c:a copy -c:v mpeg2video -pix_fmt yuv422p -color_primaries bt709 -color_trc bt709 -colorspace bt709 -b:v 50M -s 1920x1080 -r 25 -flags +ilme+ildct -vf setfield=tff,fieldorder=tff -y something/something.mxf`
 


### PR DESCRIPTION
**14/n of a stack.** Base: `fix/activity-queue-routing-map` (#452). Closes *One `ffmpeg.Run(Job)` collapses ~23 wrappers and fixes the MkdirAll class*, one commit per step.

### The primitive — `80bc94f`, extended in `72968d1`

`Job` carries the input, the output and the arguments between them; `Run` supplies progress reporting, the input flags, overwrite and the output path in a fixed order, and returns the stream info so a caller that needs it does not probe twice.

Two rounds of shaping: `-itsoffset` before an audio input in `Mux`, and `-f lavfi` before the synthesised sources in `MultitrackMux` and `PrependSilence`, are options that belong to one specific input and cannot be lumped in with the codec arguments. So `ExtraInputs` is a slice of `Input`, each carrying its own options, and `InputArgs` does the same for the primary.

**Two deliberate behaviour changes, not ports:**

- **It creates the output directory.** This is the `MkdirAll` class — 29 of 30 output-producing functions could fail writing into a directory that does not exist. `Mux` was the only one that called `MkdirAll`, having hit it in production; its call is gone because `Run` does it for everything now.
- **Output is 0664 in a 0775 directory rather than `os.ModePerm`.** 0777 on a shared Isilon mount makes every master world-writable. **This is the one change here worth a second opinion:** if anything downstream writes to these files as a different user rather than a group member, it will notice. There are now zero `os.ModePerm` uses left in the package — the sidecar subtitle lists and placeholder SRTs were 0777 too.

### The migration — `0169857`, `2b0e583`, `a72ffb6`, `72968d1`, `cbfb374`, `1fda51e`

`AudioAac`, `PrepareForTranscription`, `AudioWav`, `AudioMP3`, `TrimFile`, `Convert51to4Mono`, `AdjustAudioLevel`, `PrependSilence`, `ProRes`, `AvcIntra`, `H264`, `XDCAM`, `VideoH264`, `Mux`, `MuxToSimpleMXF`, `MultitrackMux`, `MergeVideo`, `MergeAudio`, `MergeSubtitles`, `MergeSubtitlesByOffset`, `SubtitleBurnIn`, the ASS conversion in `CreateBurninASSFile`, and HAP's video encode and audio remux.

Dedup that came with it: `bitrateSuffixedOutput` for the `<dest>/<base>-<bitrate>.<ext>` idiom spelled three ways; `audioResult` for four copies of parse-stat-describe; `appendBurnInFilter` for the burn-in prep copy-pasted in three encoders — which now fails on a subtitle given without a style instead of dereferencing nil, as all three copies did; `runMergeJob` for the four merges; and one `EncodeResult` where there were three identical types differing only in whether the field was `Path` or `OutputPath`.

### Three places that deliberately do not use a Job

- **`PlayoutMux`** and **`Preview`** use `ffmpeg.RunArgs`, which does the `MkdirAll` and the chmod but leaves the caller's argv alone. `generateFFmpegParamsForPlayoutMux` adds inputs while building the twelve-language filter graph, tracking stream indices as it goes; `Preview`'s inputs depend on whether the source has video, audio or both. Neither can be restructured with confidence from the tests available — `Preview`'s only argv coverage is behind the integration build tag.
- **`SplitAudioChannels`, `ExtractAudioChannels`, `AudioPreview` and HAP's audio extraction** write several outputs from one invocation, so there is no single output to create a directory for. They stay on `Do`.

So it is 23 wrappers behind `Run`/`RunArgs` and four that genuinely do not fit, rather than the flat ~23 the audit estimated.

### What verifies it

The package's tests encode real files with ffmpeg and probe the results — 45 seconds of actual transcoding — which is what makes a change of this shape checkable rather than hopeful. All pass, `make test` is green, `go vet` clean. `xdcamArgs`'s golden test still asserts the whole command line, assembled through `ffmpeg.Job`, so the ordering it exists to protect is still covered.

Still open from this finding and not attempted: the ~55 shared lines between `MergeSubtitles` and `MergeSubtitlesByOffset`, and `Mux` vs `MuxToSimpleMXF` being the same function with and without language metadata. Both are real, and both are about the *arguments*, which is the part this PR deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)