### PR TITLE
refactor(vb_export): one frame behind the destination children

### DIFF
--- a/workflows/vb_export/child.go
+++ b/workflows/vb_export/child.go
@@ -1,0 +1,123 @@
+package vb_export
+
+import (
+	"github.com/bcc-code/bcc-media-flows/activities"
+	"github.com/bcc-code/bcc-media-flows/paths"
+	"github.com/bcc-code/bcc-media-flows/services/rclone"
+	"github.com/bcc-code/bcc-media-flows/services/telegram"
+	"github.com/bcc-code/bcc-media-flows/utils"
+	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
+	"go.temporal.io/sdk/workflow"
+)
+
+type transcodeFunc func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path, isImage bool) (paths.Path, error)
+
+// vbExportDestination describes one delivery destination. Exactly one of copySource
+// and transcode must be set.
+type vbExportDestination struct {
+	flow      string
+	folder    string
+	outputDir string
+
+	// ext is ignored when imageAware, which delivers an image under its own
+	// extension and everything else as .mov.
+	ext        string
+	imageAware bool
+
+	copySource func(VBExportChildWorkflowParams) paths.Path
+	transcode  transcodeFunc
+}
+
+func runVBExportChild(ctx workflow.Context, params VBExportChildWorkflowParams, dest vbExportDestination) (*VBExportResult, error) {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("Starting VB export", "flow", dest.flow)
+
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
+
+	var isImage bool
+	if dest.imageAware {
+		var err error
+		isImage, err = wfutils.IsImage(ctx, params.InputFile)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	filePath := params.InputFile
+	destName := ""
+	if dest.copySource != nil {
+		filePath = dest.copySource(params)
+		destName = filePath.Base()
+	} else {
+		ext := dest.ext
+		if dest.imageAware {
+			ext = ".mov"
+			if isImage {
+				ext = params.InputFile.Ext()
+			}
+		}
+
+		extraFileName := ""
+		if params.SubtitleFile != nil && !isImage {
+			extraFileName = "_SUB_NOR"
+		}
+
+		destName = params.OriginalFilenameWithoutExt + extraFileName + ext
+	}
+
+	rcloneDestination := deliveryFolder.Append(dest.folder, destName)
+
+	err := wfutils.RcloneWaitForFileGone(ctx, rcloneDestination, telegram.ChatOslofjord, 10)
+	if err != nil {
+		return nil, err
+	}
+
+	if dest.transcode != nil {
+		outputDir := params.TempDir.Append(dest.outputDir)
+		err = wfutils.CreateFolder(ctx, outputDir)
+		if err != nil {
+			return nil, err
+		}
+
+		filePath, err = dest.transcode(ctx, params, outputDir, isImage)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = wfutils.RcloneCopyFileWithNotifications(ctx, filePath, rcloneDestination, rclone.PriorityHigh, rcloneNotificationOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	notifyExportDone(ctx, params, dest.flow, filePath)
+
+	return &VBExportResult{
+		ID:    params.ParentParams.VXID,
+		Title: params.OriginalFilenameWithoutExt,
+	}, nil
+}
+
+func transcodeToProRes(interlace, alpha bool) transcodeFunc {
+	return func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path, isImage bool) (paths.Path, error) {
+		if isImage {
+			return params.InputFile, nil
+		}
+
+		res, err := wfutils.Execute(ctx, activities.Video.TranscodeToProResActivity, activities.EncodeParams{
+			FilePath:       params.InputFile,
+			OutputDir:      outputDir,
+			Resolution:     utils.Resolution1080,
+			FrameRate:      50,
+			Interlace:      interlace,
+			BurnInSubtitle: params.SubtitleFile,
+			SubtitleStyle:  params.SubtitleStyle,
+			Alpha:          alpha,
+		}).Result(ctx)
+		if err != nil {
+			return paths.Path{}, err
+		}
+
+		return res.OutputPath, nil
+	}
+}

--- a/workflows/vb_export/child.go
+++ b/workflows/vb_export/child.go
@@ -10,7 +10,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-type transcodeFunc func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path, isImage bool) (paths.Path, error)
+type transcodeFunc func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path) (paths.Path, error)
 
 // vbExportDestination describes one delivery destination. Exactly one of copySource
 // and transcode must be set.
@@ -26,6 +26,10 @@ type vbExportDestination struct {
 
 	copySource func(VBExportChildWorkflowParams) paths.Path
 	transcode  transcodeFunc
+
+	// image runs in place of transcode when the input is an image. Nil delivers the
+	// input untouched.
+	image transcodeFunc
 }
 
 func runVBExportChild(ctx workflow.Context, params VBExportChildWorkflowParams, dest vbExportDestination) (*VBExportResult, error) {
@@ -79,9 +83,16 @@ func runVBExportChild(ctx workflow.Context, params VBExportChildWorkflowParams, 
 			return nil, err
 		}
 
-		filePath, err = dest.transcode(ctx, params, outputDir, isImage)
-		if err != nil {
-			return nil, err
+		produce := dest.transcode
+		if isImage {
+			produce = dest.image
+		}
+
+		if produce != nil {
+			filePath, err = produce(ctx, params, outputDir)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -99,11 +110,7 @@ func runVBExportChild(ctx workflow.Context, params VBExportChildWorkflowParams, 
 }
 
 func transcodeToProRes(interlace, alpha bool) transcodeFunc {
-	return func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path, isImage bool) (paths.Path, error) {
-		if isImage {
-			return params.InputFile, nil
-		}
-
+	return func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path) (paths.Path, error) {
 		res, err := wfutils.Execute(ctx, activities.Video.TranscodeToProResActivity, activities.EncodeParams{
 			FilePath:       params.InputFile,
 			OutputDir:      outputDir,

--- a/workflows/vb_export/child.go
+++ b/workflows/vb_export/child.go
@@ -109,22 +109,25 @@ func runVBExportChild(ctx workflow.Context, params VBExportChildWorkflowParams, 
 	}, nil
 }
 
-func transcodeToProRes(interlace, alpha bool) transcodeFunc {
-	return func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path) (paths.Path, error) {
-		res, err := wfutils.Execute(ctx, activities.Video.TranscodeToProResActivity, activities.EncodeParams{
-			FilePath:       params.InputFile,
-			OutputDir:      outputDir,
-			Resolution:     utils.Resolution1080,
-			FrameRate:      50,
-			Interlace:      interlace,
-			BurnInSubtitle: params.SubtitleFile,
-			SubtitleStyle:  params.SubtitleStyle,
-			Alpha:          alpha,
-		}).Result(ctx)
-		if err != nil {
-			return paths.Path{}, err
-		}
+type proRes struct {
+	interlace bool
+	alpha     bool
+}
 
-		return res.OutputPath, nil
+func (p proRes) transcode(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path) (paths.Path, error) {
+	res, err := wfutils.Execute(ctx, activities.Video.TranscodeToProResActivity, activities.EncodeParams{
+		FilePath:       params.InputFile,
+		OutputDir:      outputDir,
+		Resolution:     utils.Resolution1080,
+		FrameRate:      50,
+		Interlace:      p.interlace,
+		BurnInSubtitle: params.SubtitleFile,
+		SubtitleStyle:  params.SubtitleStyle,
+		Alpha:          p.alpha,
+	}).Result(ctx)
+	if err != nil {
+		return paths.Path{}, err
 	}
+
+	return res.OutputPath, nil
 }

--- a/workflows/vb_export/child.go
+++ b/workflows/vb_export/child.go
@@ -15,9 +15,7 @@ type transcodeFunc func(ctx workflow.Context, params VBExportChildWorkflowParams
 // vbExportDestination describes one delivery destination. Exactly one of copySource
 // and transcode must be set.
 type vbExportDestination struct {
-	flow      string
-	folder    string
-	outputDir string
+	destination Destination
 
 	// ext is ignored when imageAware, which delivers an image under its own
 	// extension and everything else as .mov.
@@ -34,7 +32,7 @@ type vbExportDestination struct {
 
 func runVBExportChild(ctx workflow.Context, params VBExportChildWorkflowParams, dest vbExportDestination) (*VBExportResult, error) {
 	logger := workflow.GetLogger(ctx)
-	logger.Info("Starting VB export", "flow", dest.flow)
+	logger.Info("Starting VB export", "destination", dest.destination.Value)
 
 	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
@@ -69,7 +67,7 @@ func runVBExportChild(ctx workflow.Context, params VBExportChildWorkflowParams, 
 		destName = params.OriginalFilenameWithoutExt + extraFileName + ext
 	}
 
-	rcloneDestination := deliveryFolder.Append(dest.folder, destName)
+	rcloneDestination := deliveryFolder.Append(dest.destination.DeliveryFolder(), destName)
 
 	err := wfutils.RcloneWaitForFileGone(ctx, rcloneDestination, telegram.ChatOslofjord, 10)
 	if err != nil {
@@ -77,7 +75,7 @@ func runVBExportChild(ctx workflow.Context, params VBExportChildWorkflowParams, 
 	}
 
 	if dest.transcode != nil {
-		outputDir := params.TempDir.Append(dest.outputDir)
+		outputDir := params.TempDir.Append(dest.destination.OutputDirName())
 		err = wfutils.CreateFolder(ctx, outputDir)
 		if err != nil {
 			return nil, err
@@ -101,7 +99,7 @@ func runVBExportChild(ctx workflow.Context, params VBExportChildWorkflowParams, 
 		return nil, err
 	}
 
-	notifyExportDone(ctx, params, dest.flow, filePath)
+	notifyExportDone(ctx, params, dest.destination, filePath)
 
 	return &VBExportResult{
 		ID:    params.ParentParams.VXID,

--- a/workflows/vb_export/vb_export.go
+++ b/workflows/vb_export/vb_export.go
@@ -66,6 +66,19 @@ func (d Destination) Description() string {
 	return destinationDescriptions[d]
 }
 
+var destinationWorkflows = map[Destination]any{
+	DestinationAbekas:    VBExportToAbekas,
+	DestinationRawAbekas: VBExportToRawAbekas,
+	DestinationBStage:    VBExportToBStage,
+	DestinationGfx:       VBExportToGfx,
+	DestinationHippoV2:   VBExportToHippoV2,
+	DestinationHippoHap:  VBExportToHippoHap,
+	DestinationDubbing:   VBExportToDubbing,
+	DestinationHyperdeck: VBExportToHyperdeck,
+	DestinationXDCAM:     VBExportToXDCAM,
+	DestinationCasparCG:  VBExportToCasparCG,
+}
+
 var (
 	rcloneNotificationOptions = &activities.TelegramNotificationOptions{
 		ChatID:               telegram.ChatOslofjord,
@@ -222,30 +235,8 @@ func VBExport(ctx workflow.Context, params VBExportParams) ([]wfutils.ResultOrEr
 			AnalyzeResult:              *analyzeResult,
 		}
 
-		var w any
-		switch *dest {
-		case DestinationAbekas:
-			w = VBExportToAbekas
-		case DestinationRawAbekas:
-			w = VBExportToRawAbekas
-		case DestinationBStage:
-			w = VBExportToBStage
-		case DestinationHyperdeck:
-			w = VBExportToHyperdeck
-		case DestinationGfx:
-			w = VBExportToGfx
-		case DestinationHippoV2:
-			w = VBExportToHippoV2
-		case DestinationHippoHap:
-			w = VBExportToHippoHap
-		case DestinationDubbing:
-			w = VBExportToDubbing
-		case DestinationXDCAM:
-			w = VBExportToXDCAM
-		case DestinationCasparCG:
-			w = VBExportToCasparCG
-
-		default:
+		w, ok := destinationWorkflows[*dest]
+		if !ok {
 			return nil, fmt.Errorf("destination not implemented: %s", dest)
 		}
 

--- a/workflows/vb_export/vb_export.go
+++ b/workflows/vb_export/vb_export.go
@@ -66,6 +66,30 @@ func (d Destination) Description() string {
 	return destinationDescriptions[d]
 }
 
+// destinationFolders are the subfolders of deliveryFolder each destination is
+// delivered to. Abekas has a second one, Abekas-WAV, for audio-only exports.
+var destinationFolders = map[Destination]string{
+	DestinationAbekas:    "Abekas-AVCI",
+	DestinationRawAbekas: "Abekas-RAW",
+	DestinationBStage:    "B-Stage",
+	DestinationGfx:       "GFX",
+	DestinationHippoV2:   "Hippo",
+	DestinationHippoHap:  "Hippo",
+	DestinationDubbing:   "Reaper-Wav",
+	DestinationHyperdeck: "Hyperdeck-ProRes",
+	DestinationXDCAM:     "XDCAM",
+	DestinationCasparCG:  "CasparCG",
+}
+
+func (d Destination) DeliveryFolder() string {
+	return destinationFolders[d]
+}
+
+// OutputDirName is the per-destination subfolder of the workflow's temp dir.
+func (d Destination) OutputDirName() string {
+	return d.Value + "_output"
+}
+
 var destinationWorkflows = map[Destination]any{
 	DestinationAbekas:    VBExportToAbekas,
 	DestinationRawAbekas: VBExportToRawAbekas,
@@ -272,7 +296,7 @@ func VBExport(ctx workflow.Context, params VBExportParams) ([]wfutils.ResultOrEr
 	return results, err
 }
 
-func notifyExportDone(ctx workflow.Context, params VBExportChildWorkflowParams, flow string, tempExportPath paths.Path) {
-	message := fmt.Sprintf("🟩 Export of `%s` finished.\nDestination: `%s`, Preview: `%s`", params.ParentParams.VXID, flow, tempExportPath.Local())
+func notifyExportDone(ctx workflow.Context, params VBExportChildWorkflowParams, destination Destination, tempExportPath paths.Path) {
+	message := fmt.Sprintf("🟩 Export of `%s` finished.\nDestination: `%s`, Preview: `%s`", params.ParentParams.VXID, destination.Value, tempExportPath.Local())
 	wfutils.SendTelegramText(ctx, telegram.ChatOslofjord, message)
 }

--- a/workflows/vb_export/vb_export_abekas.go
+++ b/workflows/vb_export/vb_export_abekas.go
@@ -32,7 +32,7 @@ func VBExportToAbekas(ctx workflow.Context, params VBExportChildWorkflowParams) 
 
 	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
-	abekasOutputDir := params.TempDir.Append("abekas_output")
+	abekasOutputDir := params.TempDir.Append(DestinationAbekas.OutputDirName())
 	err := wfutils.CreateFolder(ctx, abekasOutputDir)
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func VBExportToAbekas(ctx workflow.Context, params VBExportChildWorkflowParams) 
 	}
 
 	if analyzeResult.HasAlpha {
-		rcloneDestination := deliveryFolder.Append("Abekas-AVCI", params.InputFile.Base())
+		rcloneDestination := deliveryFolder.Append(DestinationAbekas.DeliveryFolder(), params.InputFile.Base())
 
 		err = wfutils.RcloneWaitForFileGone(ctx, rcloneDestination, telegram.ChatOslofjord, 10)
 		if err != nil {
@@ -75,7 +75,7 @@ func VBExportToAbekas(ctx workflow.Context, params VBExportChildWorkflowParams) 
 			return nil, err
 		}
 
-		notifyExportDone(ctx, params, "abekas", params.InputFile)
+		notifyExportDone(ctx, params, DestinationAbekas, params.InputFile)
 		return &VBExportResult{
 			ID:    params.ParentParams.VXID,
 			Title: params.OriginalFilenameWithoutExt,
@@ -87,7 +87,7 @@ func VBExportToAbekas(ctx workflow.Context, params VBExportChildWorkflowParams) 
 		extraFileName += "_SUB_NOR"
 	}
 
-	rcloneDestination := deliveryFolder.Append("Abekas-AVCI", params.OriginalFilenameWithoutExt+extraFileName+".mxf")
+	rcloneDestination := deliveryFolder.Append(DestinationAbekas.DeliveryFolder(), params.OriginalFilenameWithoutExt+extraFileName+".mxf")
 
 	err = wfutils.RcloneWaitForFileGone(ctx, rcloneDestination, telegram.ChatOslofjord, 10)
 	if err != nil {
@@ -132,7 +132,7 @@ func VBExportToAbekas(ctx workflow.Context, params VBExportChildWorkflowParams) 
 		return nil, err
 	}
 
-	notifyExportDone(ctx, params, "abekas", videoResult.OutputPath)
+	notifyExportDone(ctx, params, DestinationAbekas, videoResult.OutputPath)
 
 	return &VBExportResult{
 		ID: params.ParentParams.VXID,
@@ -174,7 +174,7 @@ func VBExportToAbekasAudioOnly(ctx workflow.Context, params VBExportChildWorkflo
 		return nil, err
 	}
 
-	notifyExportDone(ctx, params, "abekas", audioRes.OutputPath)
+	notifyExportDone(ctx, params, DestinationAbekas, audioRes.OutputPath)
 
 	return &VBExportResult{
 		ID: params.ParentParams.VXID,

--- a/workflows/vb_export/vb_export_bstage.go
+++ b/workflows/vb_export/vb_export_bstage.go
@@ -1,11 +1,6 @@
 package vb_export
 
 import (
-	"github.com/bcc-code/bcc-media-flows/activities"
-	"github.com/bcc-code/bcc-media-flows/services/rclone"
-	"github.com/bcc-code/bcc-media-flows/services/telegram"
-	"github.com/bcc-code/bcc-media-flows/utils"
-	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -23,66 +18,11 @@ Audio tracks:
 - Stream1, Track 3-16: Timecode/Multitrack Audio (optional)
 */
 func VBExportToBStage(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
-	logger := workflow.GetLogger(ctx)
-	logger.Info("Starting ExportToBStage")
-
-	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
-
-	isImage, err := wfutils.IsImage(ctx, params.InputFile)
-	if err != nil {
-		return nil, err
-	}
-
-	destExt := params.InputFile.Ext()
-	if !isImage {
-		destExt = ".mov"
-	}
-
-	extraFileName := ""
-	if params.SubtitleFile != nil && !isImage {
-		extraFileName = "_SUB_NOR"
-	}
-
-	rcloneDestination := deliveryFolder.Append("B-Stage", params.OriginalFilenameWithoutExt+extraFileName+destExt)
-
-	err = wfutils.RcloneWaitForFileGone(ctx, rcloneDestination, telegram.ChatOslofjord, 10)
-	if err != nil {
-		return nil, err
-	}
-
-	bStageOutputDir := params.TempDir.Append("b-stage_output")
-	err = wfutils.CreateFolder(ctx, bStageOutputDir)
-	if err != nil {
-		return nil, err
-	}
-
-	filePath := params.InputFile
-
-	if !isImage {
-		videoResult, err := wfutils.Execute(ctx, activities.Video.TranscodeToProResActivity, activities.EncodeParams{
-			FilePath:       params.InputFile,
-			OutputDir:      bStageOutputDir,
-			Resolution:     utils.Resolution1080,
-			FrameRate:      50,
-			Interlace:      false,
-			BurnInSubtitle: params.SubtitleFile,
-			SubtitleStyle:  params.SubtitleStyle,
-			Alpha:          false,
-		}).Result(ctx)
-		if err != nil {
-			return nil, err
-		}
-		filePath = videoResult.OutputPath
-	}
-
-	err = wfutils.RcloneCopyFileWithNotifications(ctx, filePath, rcloneDestination, rclone.PriorityHigh, rcloneNotificationOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	notifyExportDone(ctx, params, "bstage", filePath)
-
-	return &VBExportResult{
-		ID: params.ParentParams.VXID,
-	}, nil
+	return runVBExportChild(ctx, params, vbExportDestination{
+		flow:       "bstage",
+		folder:     "B-Stage",
+		outputDir:  "b-stage_output",
+		imageAware: true,
+		transcode:  transcodeToProRes(false, false),
+	})
 }

--- a/workflows/vb_export/vb_export_bstage.go
+++ b/workflows/vb_export/vb_export_bstage.go
@@ -23,6 +23,6 @@ func VBExportToBStage(ctx workflow.Context, params VBExportChildWorkflowParams) 
 		folder:     "B-Stage",
 		outputDir:  "b-stage_output",
 		imageAware: true,
-		transcode:  transcodeToProRes(false, false),
+		transcode:  proRes{interlace: false, alpha: false}.transcode,
 	})
 }

--- a/workflows/vb_export/vb_export_bstage.go
+++ b/workflows/vb_export/vb_export_bstage.go
@@ -19,10 +19,8 @@ Audio tracks:
 */
 func VBExportToBStage(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
 	return runVBExportChild(ctx, params, vbExportDestination{
-		flow:       "bstage",
-		folder:     "B-Stage",
-		outputDir:  "b-stage_output",
-		imageAware: true,
-		transcode:  proRes{interlace: false, alpha: false}.transcode,
+		destination: DestinationBStage,
+		imageAware:  true,
+		transcode:   proRes{interlace: false, alpha: false}.transcode,
 	})
 }

--- a/workflows/vb_export/vb_export_caspar_cg.go
+++ b/workflows/vb_export/vb_export_caspar_cg.go
@@ -8,8 +8,7 @@ import (
 // VBExportToCasparCG copies the input file directly to the CasparCG delivery folder without transcoding.
 func VBExportToCasparCG(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
 	return runVBExportChild(ctx, params, vbExportDestination{
-		flow:       "caspar-cg",
-		folder:     "CasparCG",
-		copySource: func(p VBExportChildWorkflowParams) paths.Path { return p.OriginalFile },
+		destination: DestinationCasparCG,
+		copySource:  func(p VBExportChildWorkflowParams) paths.Path { return p.OriginalFile },
 	})
 }

--- a/workflows/vb_export/vb_export_caspar_cg.go
+++ b/workflows/vb_export/vb_export_caspar_cg.go
@@ -1,35 +1,15 @@
 package vb_export
 
 import (
-	"github.com/bcc-code/bcc-media-flows/services/rclone"
-	"github.com/bcc-code/bcc-media-flows/services/telegram"
-	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
+	"github.com/bcc-code/bcc-media-flows/paths"
 	"go.temporal.io/sdk/workflow"
 )
 
 // VBExportToCasparCG copies the input file directly to the CasparCG delivery folder without transcoding.
 func VBExportToCasparCG(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
-	logger := workflow.GetLogger(ctx)
-	logger.Info("Starting ExportToCasparCG")
-
-	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
-
-	rcloneDestination := deliveryFolder.Append("CasparCG", params.OriginalFile.Base())
-
-	err := wfutils.RcloneWaitForFileGone(ctx, rcloneDestination, telegram.ChatOslofjord, 10)
-	if err != nil {
-		return nil, err
-	}
-
-	err = wfutils.RcloneCopyFileWithNotifications(ctx, params.OriginalFile, rcloneDestination, rclone.PriorityHigh, rcloneNotificationOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	notifyExportDone(ctx, params, "caspar-cg", params.OriginalFile)
-
-	return &VBExportResult{
-		ID:    params.ParentParams.VXID,
-		Title: params.OriginalFilenameWithoutExt,
-	}, nil
+	return runVBExportChild(ctx, params, vbExportDestination{
+		flow:       "caspar-cg",
+		folder:     "CasparCG",
+		copySource: func(p VBExportChildWorkflowParams) paths.Path { return p.OriginalFile },
+	})
 }

--- a/workflows/vb_export/vb_export_dubbing.go
+++ b/workflows/vb_export/vb_export_dubbing.go
@@ -15,13 +15,13 @@ import (
 )
 
 func VBExportToDubbing(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
-	deliveryFolder := deliveryFolder.Append("Reaper-Wav", params.OriginalFilenameWithoutExt)
+	deliveryFolder := deliveryFolder.Append(DestinationDubbing.DeliveryFolder(), params.OriginalFilenameWithoutExt)
 
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting ExportToAbekas")
 	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
-	dubbingOutputDir := params.TempDir.Append("dubbing_output")
+	dubbingOutputDir := params.TempDir.Append(DestinationDubbing.OutputDirName())
 	err := wfutils.CreateFolder(ctx, dubbingOutputDir)
 	if err != nil {
 		return nil, err

--- a/workflows/vb_export/vb_export_gfx.go
+++ b/workflows/vb_export/vb_export_gfx.go
@@ -23,6 +23,6 @@ func VBExportToGfx(ctx workflow.Context, params VBExportChildWorkflowParams) (*V
 		folder:     "GFX",
 		outputDir:  "gfx_output",
 		imageAware: true,
-		transcode:  transcodeToProRes(true, true),
+		transcode:  proRes{interlace: true, alpha: true}.transcode,
 	})
 }

--- a/workflows/vb_export/vb_export_gfx.go
+++ b/workflows/vb_export/vb_export_gfx.go
@@ -19,10 +19,8 @@ Audio tracks:
 */
 func VBExportToGfx(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
 	return runVBExportChild(ctx, params, vbExportDestination{
-		flow:       "gfx",
-		folder:     "GFX",
-		outputDir:  "gfx_output",
-		imageAware: true,
-		transcode:  proRes{interlace: true, alpha: true}.transcode,
+		destination: DestinationGfx,
+		imageAware:  true,
+		transcode:   proRes{interlace: true, alpha: true}.transcode,
 	})
 }

--- a/workflows/vb_export/vb_export_gfx.go
+++ b/workflows/vb_export/vb_export_gfx.go
@@ -1,11 +1,6 @@
 package vb_export
 
 import (
-	"github.com/bcc-code/bcc-media-flows/activities"
-	"github.com/bcc-code/bcc-media-flows/services/rclone"
-	"github.com/bcc-code/bcc-media-flows/services/telegram"
-	"github.com/bcc-code/bcc-media-flows/utils"
-	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -23,66 +18,11 @@ Audio tracks:
 - Stream1, Track 3-16: Timecode/Multitrack Audio (optional)
 */
 func VBExportToGfx(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
-	logger := workflow.GetLogger(ctx)
-	logger.Info("Starting ExportToGFX")
-
-	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
-
-	isImage, err := wfutils.IsImage(ctx, params.InputFile)
-	if err != nil {
-		return nil, err
-	}
-
-	destExt := params.InputFile.Ext()
-	if !isImage {
-		destExt = ".mov"
-	}
-
-	extraFileName := ""
-	if params.SubtitleFile != nil && !isImage {
-		extraFileName = "_SUB_NOR"
-	}
-
-	rcloneDestination := deliveryFolder.Append("GFX", params.OriginalFilenameWithoutExt+extraFileName+destExt)
-
-	err = wfutils.RcloneWaitForFileGone(ctx, rcloneDestination, telegram.ChatOslofjord, 10)
-	if err != nil {
-		return nil, err
-	}
-
-	gfxOutputDir := params.TempDir.Append("gfx_output")
-	err = wfutils.CreateFolder(ctx, gfxOutputDir)
-	if err != nil {
-		return nil, err
-	}
-
-	filePath := params.InputFile
-
-	if !isImage {
-		videoResult, err := wfutils.Execute(ctx, activities.Video.TranscodeToProResActivity, activities.EncodeParams{
-			FilePath:       params.InputFile,
-			OutputDir:      gfxOutputDir,
-			Resolution:     utils.Resolution1080,
-			FrameRate:      50,
-			Interlace:      true,
-			BurnInSubtitle: params.SubtitleFile,
-			SubtitleStyle:  params.SubtitleStyle,
-			Alpha:          true,
-		}).Result(ctx)
-		if err != nil {
-			return nil, err
-		}
-		filePath = videoResult.OutputPath
-	}
-
-	err = wfutils.RcloneCopyFileWithNotifications(ctx, filePath, rcloneDestination, rclone.PriorityHigh, rcloneNotificationOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	notifyExportDone(ctx, params, "gfx", filePath)
-
-	return &VBExportResult{
-		ID: params.ParentParams.VXID,
-	}, nil
+	return runVBExportChild(ctx, params, vbExportDestination{
+		flow:       "gfx",
+		folder:     "GFX",
+		outputDir:  "gfx_output",
+		imageAware: true,
+		transcode:  transcodeToProRes(true, true),
+	})
 }

--- a/workflows/vb_export/vb_export_hippo_v2.go
+++ b/workflows/vb_export/vb_export_hippo_v2.go
@@ -3,8 +3,7 @@ package vb_export
 import (
 	"github.com/ansel1/merry/v2"
 	"github.com/bcc-code/bcc-media-flows/activities"
-	"github.com/bcc-code/bcc-media-flows/services/rclone"
-	"github.com/bcc-code/bcc-media-flows/services/telegram"
+	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/services/transcode"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"go.temporal.io/sdk/workflow"
@@ -35,89 +34,53 @@ func VBExportToHippoHap(ctx workflow.Context, params VBExportChildWorkflowParams
 }
 
 func exportToHippoHAP(ctx workflow.Context, params VBExportChildWorkflowParams, format transcode.HAPFormat, flowName string) (*VBExportResult, error) {
-	logger := workflow.GetLogger(ctx)
-	logger.Info("Starting VBExport to Hippo", "flow", flowName)
+	return runVBExportChild(ctx, params, vbExportDestination{
+		flow:       flowName,
+		folder:     "Hippo",
+		outputDir:  flowName + "_output",
+		imageAware: true,
+		transcode:  transcodeToHAP(format),
+	})
+}
 
-	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
-
-	isImage, err := wfutils.IsImage(ctx, params.InputFile)
-	if err != nil {
-		return nil, err
-	}
-
-	destExt := params.InputFile.Ext()
-	if !isImage {
-		destExt = ".mov"
-	}
-
-	extraFileName := ""
-	if params.SubtitleFile != nil && !isImage {
-		extraFileName = "_SUB_NOR"
-	}
-
-	rcloneDestination := deliveryFolder.Append("Hippo", params.OriginalFilenameWithoutExt+extraFileName+destExt)
-
-	err = wfutils.RcloneWaitForFileGone(ctx, rcloneDestination, telegram.ChatOslofjord, 10)
-	if err != nil {
-		return nil, err
-	}
-
-	hippoOutputDir := params.TempDir.Append(flowName + "_output")
-	err = wfutils.CreateFolder(ctx, hippoOutputDir)
-	if err != nil {
-		return nil, err
-	}
-
-	outputFile := hippoOutputDir.Append(params.InputFile.Base())
-
-	if !isImage {
-		outputFile = hippoOutputDir.Append(params.InputFile.SetExt("mov").Base())
+func transcodeToHAP(format transcode.HAPFormat) transcodeFunc {
+	return func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path, isImage bool) (paths.Path, error) {
+		if isImage {
+			outputFile := outputDir.Append(params.InputFile.Base())
+			_ = wfutils.CopyFile(ctx, params.InputFile, outputFile)
+			return outputFile, nil
+		}
 
 		if params.AnalyzeResult.FrameRate != 25 && params.AnalyzeResult.FrameRate != 50 {
-			return nil, merry.New("Expected 25 or 50 fps input")
+			return paths.Path{}, merry.New("Expected 25 or 50 fps input")
 		}
 
 		currentVideoFile := params.InputFile
 		if params.SubtitleFile != nil {
-			// Burn in subtitle first
 			videoResult, err := wfutils.Execute(ctx, activities.Video.TranscodeToProResActivity, activities.EncodeParams{
 				FilePath:       currentVideoFile,
-				OutputDir:      hippoOutputDir,
+				OutputDir:      outputDir,
 				Interlace:      false,
 				BurnInSubtitle: params.SubtitleFile,
 				SubtitleStyle:  params.SubtitleStyle,
 				Alpha:          params.AnalyzeResult.HasAlpha,
 			}).Result(ctx)
 			if err != nil {
-				return nil, err
+				return paths.Path{}, err
 			}
 			currentVideoFile = videoResult.OutputPath
 		}
 
 		hapResult, err := wfutils.Execute(ctx, activities.Video.TranscodeToHAPActivity, activities.HAPInput{
 			FilePath:  currentVideoFile,
-			OutputDir: hippoOutputDir,
+			OutputDir: outputDir,
 			Format:    format,
 		}).Result(ctx)
 		if err != nil {
-			return nil, err
+			return paths.Path{}, err
 		}
 
-		outputFile = hapResult.OutputPath
-	} else {
-		_ = wfutils.CopyFile(ctx, params.InputFile, outputFile)
+		// The HAP export file is deliberately left in temp storage.
+		return hapResult.OutputPath, nil
 	}
-
-	err = wfutils.RcloneCopyFileWithNotifications(ctx, outputFile, rcloneDestination, rclone.PriorityHigh, rcloneNotificationOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	// Intentionally keep the HAP export file in temp storage; it is not deleted after upload.
-
-	notifyExportDone(ctx, params, flowName, outputFile)
-
-	return &VBExportResult{
-		ID: params.ParentParams.VXID,
-	}, nil
 }

--- a/workflows/vb_export/vb_export_hippo_v2.go
+++ b/workflows/vb_export/vb_export_hippo_v2.go
@@ -18,7 +18,7 @@ Video: Various resolutions, 25p/50p, HAP Q codec with audio support
 Audio: Included in HAP output
 */
 func VBExportToHippoV2(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
-	return runVBExportChild(ctx, params, hippo("hippo_v2", transcode.HAPFormatHAPQ))
+	return runVBExportChild(ctx, params, hippo(DestinationHippoV2, transcode.HAPFormatHAPQ))
 }
 
 /*
@@ -30,17 +30,15 @@ Video: Various resolutions, 25p/50p, HAP codec with audio support
 Audio: Included in HAP output
 */
 func VBExportToHippoHap(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
-	return runVBExportChild(ctx, params, hippo("hippo_hap", transcode.HAPFormatHAP))
+	return runVBExportChild(ctx, params, hippo(DestinationHippoHap, transcode.HAPFormatHAP))
 }
 
-func hippo(flow string, format transcode.HAPFormat) vbExportDestination {
+func hippo(destination Destination, format transcode.HAPFormat) vbExportDestination {
 	return vbExportDestination{
-		flow:       flow,
-		folder:     "Hippo",
-		outputDir:  flow + "_output",
-		imageAware: true,
-		transcode:  transcodeToHAP(format),
-		image:      copyImageToOutputDir,
+		destination: destination,
+		imageAware:  true,
+		transcode:   transcodeToHAP(format),
+		image:       copyImageToOutputDir,
 	}
 }
 

--- a/workflows/vb_export/vb_export_hippo_v2.go
+++ b/workflows/vb_export/vb_export_hippo_v2.go
@@ -40,17 +40,18 @@ func exportToHippoHAP(ctx workflow.Context, params VBExportChildWorkflowParams, 
 		outputDir:  flowName + "_output",
 		imageAware: true,
 		transcode:  transcodeToHAP(format),
+		image:      copyImageToOutputDir,
 	})
 }
 
-func transcodeToHAP(format transcode.HAPFormat) transcodeFunc {
-	return func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path, isImage bool) (paths.Path, error) {
-		if isImage {
-			outputFile := outputDir.Append(params.InputFile.Base())
-			_ = wfutils.CopyFile(ctx, params.InputFile, outputFile)
-			return outputFile, nil
-		}
+func copyImageToOutputDir(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path) (paths.Path, error) {
+	outputFile := outputDir.Append(params.InputFile.Base())
+	_ = wfutils.CopyFile(ctx, params.InputFile, outputFile)
+	return outputFile, nil
+}
 
+func transcodeToHAP(format transcode.HAPFormat) transcodeFunc {
+	return func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path) (paths.Path, error) {
 		if params.AnalyzeResult.FrameRate != 25 && params.AnalyzeResult.FrameRate != 50 {
 			return paths.Path{}, merry.New("Expected 25 or 50 fps input")
 		}

--- a/workflows/vb_export/vb_export_hippo_v2.go
+++ b/workflows/vb_export/vb_export_hippo_v2.go
@@ -18,7 +18,7 @@ Video: Various resolutions, 25p/50p, HAP Q codec with audio support
 Audio: Included in HAP output
 */
 func VBExportToHippoV2(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
-	return exportToHippoHAP(ctx, params, transcode.HAPFormatHAPQ, "hippo_v2")
+	return runVBExportChild(ctx, params, hippo("hippo_v2", transcode.HAPFormatHAPQ))
 }
 
 /*
@@ -30,18 +30,18 @@ Video: Various resolutions, 25p/50p, HAP codec with audio support
 Audio: Included in HAP output
 */
 func VBExportToHippoHap(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
-	return exportToHippoHAP(ctx, params, transcode.HAPFormatHAP, "hippo_hap")
+	return runVBExportChild(ctx, params, hippo("hippo_hap", transcode.HAPFormatHAP))
 }
 
-func exportToHippoHAP(ctx workflow.Context, params VBExportChildWorkflowParams, format transcode.HAPFormat, flowName string) (*VBExportResult, error) {
-	return runVBExportChild(ctx, params, vbExportDestination{
-		flow:       flowName,
+func hippo(flow string, format transcode.HAPFormat) vbExportDestination {
+	return vbExportDestination{
+		flow:       flow,
 		folder:     "Hippo",
-		outputDir:  flowName + "_output",
+		outputDir:  flow + "_output",
 		imageAware: true,
 		transcode:  transcodeToHAP(format),
 		image:      copyImageToOutputDir,
-	})
+	}
 }
 
 func copyImageToOutputDir(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path) (paths.Path, error) {

--- a/workflows/vb_export/vb_export_hyperdeck.go
+++ b/workflows/vb_export/vb_export_hyperdeck.go
@@ -22,7 +22,7 @@ func VBExportToHyperdeck(ctx workflow.Context, params VBExportChildWorkflowParam
 	})
 }
 
-func transcodeToHyperdeckProRes(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path, _ bool) (paths.Path, error) {
+func transcodeToHyperdeckProRes(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path) (paths.Path, error) {
 	analyzeResult, err := wfutils.Execute(ctx, activities.Audio.AnalyzeFile, activities.AnalyzeFileParams{
 		FilePath: params.InputFile,
 	}).Result(ctx)

--- a/workflows/vb_export/vb_export_hyperdeck.go
+++ b/workflows/vb_export/vb_export_hyperdeck.go
@@ -2,64 +2,49 @@ package vb_export
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/bcc-code/bcc-media-flows/activities"
 	"github.com/bcc-code/bcc-media-flows/common"
-	"github.com/bcc-code/bcc-media-flows/services/rclone"
-	"github.com/bcc-code/bcc-media-flows/services/telegram"
+	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/utils"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"go.temporal.io/sdk/workflow"
-	"strings"
 )
 
 func VBExportToHyperdeck(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
-	logger := workflow.GetLogger(ctx)
-	logger.Info("Starting Hyperdeck")
+	return runVBExportChild(ctx, params, vbExportDestination{
+		flow:      "hyperdeck",
+		folder:    "Hyperdeck-ProRes",
+		outputDir: "hyperdeck_output",
+		ext:       ".mov",
+		transcode: transcodeToHyperdeckProRes,
+	})
+}
 
-	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
-
-	extraFileName := ""
-	if params.SubtitleFile != nil {
-		extraFileName += "_SUB_NOR"
-	}
-
-	rcloneDestination := deliveryFolder.Append("Hyperdeck-ProRes", params.OriginalFilenameWithoutExt+extraFileName+".mov")
-
-	err := wfutils.RcloneWaitForFileGone(ctx, rcloneDestination, telegram.ChatOslofjord, 10)
-	if err != nil {
-		return nil, err
-	}
-
-	outputDir := params.TempDir.Append("hyperdeck_output")
-	err = wfutils.CreateFolder(ctx, outputDir)
-	if err != nil {
-		return nil, err
-	}
-
+func transcodeToHyperdeckProRes(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path, _ bool) (paths.Path, error) {
 	analyzeResult, err := wfutils.Execute(ctx, activities.Audio.AnalyzeFile, activities.AnalyzeFileParams{
 		FilePath: params.InputFile,
 	}).Result(ctx)
 	if err != nil {
-		return nil, err
+		return paths.Path{}, err
 	}
 
 	if analyzeResult.HasAlpha {
-		return nil, fmt.Errorf("hyperdeck export currently does not support alpha channels")
+		return paths.Path{}, fmt.Errorf("hyperdeck export currently does not support alpha channels")
 	}
 
 	fileToTranscode := params.InputFile
 
-	// Check for 5.1 audio
-	// Used prefix to catch 5.1, 5.1(side), and any other variations
+	// The prefix catches 5.1, 5.1(side), and any other variation.
 	if len(analyzeResult.AudioStreams) == 1 && strings.HasPrefix(analyzeResult.AudioStreams[0].ChannelLayout, "5.1") {
-		// Convert a one stream 5.1 to 4 mono streams (L, R, Lb, Rb)
 		fileToTranscode = params.TempDir.Append("4mono_" + params.InputFile.Base())
 		err = wfutils.Execute(ctx, activities.Audio.Convert51to4Mono, common.AudioInput{
 			Path:            params.InputFile,
 			DestinationPath: fileToTranscode,
 		}).Wait(ctx)
 		if err != nil {
-			return nil, err
+			return paths.Path{}, err
 		}
 	}
 
@@ -73,21 +58,12 @@ func VBExportToHyperdeck(ctx workflow.Context, params VBExportChildWorkflowParam
 		SubtitleStyle:  params.SubtitleStyle,
 	}).Result(ctx)
 	if err != nil {
-		return nil, err
+		return paths.Path{}, err
 	}
 
 	if videoResult.OutputPath.Ext() != ".mov" {
-		return nil, fmt.Errorf("expected Hyperdeck ProRes output to be .mov, got %s", videoResult.OutputPath.Ext())
+		return paths.Path{}, fmt.Errorf("expected Hyperdeck ProRes output to be .mov, got %s", videoResult.OutputPath.Ext())
 	}
 
-	err = wfutils.RcloneCopyFileWithNotifications(ctx, videoResult.OutputPath, rcloneDestination, rclone.PriorityHigh, rcloneNotificationOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	notifyExportDone(ctx, params, "hyperdeck", videoResult.OutputPath)
-
-	return &VBExportResult{
-		ID: params.ParentParams.VXID,
-	}, nil
+	return videoResult.OutputPath, nil
 }

--- a/workflows/vb_export/vb_export_hyperdeck.go
+++ b/workflows/vb_export/vb_export_hyperdeck.go
@@ -14,11 +14,9 @@ import (
 
 func VBExportToHyperdeck(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
 	return runVBExportChild(ctx, params, vbExportDestination{
-		flow:      "hyperdeck",
-		folder:    "Hyperdeck-ProRes",
-		outputDir: "hyperdeck_output",
-		ext:       ".mov",
-		transcode: transcodeToHyperdeckProRes,
+		destination: DestinationHyperdeck,
+		ext:         ".mov",
+		transcode:   transcodeToHyperdeckProRes,
 	})
 }
 

--- a/workflows/vb_export/vb_export_raw_abekas.go
+++ b/workflows/vb_export/vb_export_raw_abekas.go
@@ -8,8 +8,7 @@ import (
 // VBExportToRawAbekas copies the input file directly to Abekas-RAW without transcoding.
 func VBExportToRawAbekas(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
 	return runVBExportChild(ctx, params, vbExportDestination{
-		flow:       "raw-abekas",
-		folder:     "Abekas-RAW",
-		copySource: func(p VBExportChildWorkflowParams) paths.Path { return p.InputFile },
+		destination: DestinationRawAbekas,
+		copySource:  func(p VBExportChildWorkflowParams) paths.Path { return p.InputFile },
 	})
 }

--- a/workflows/vb_export/vb_export_raw_abekas.go
+++ b/workflows/vb_export/vb_export_raw_abekas.go
@@ -1,35 +1,15 @@
 package vb_export
 
 import (
-	"github.com/bcc-code/bcc-media-flows/services/rclone"
-	"github.com/bcc-code/bcc-media-flows/services/telegram"
-	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
+	"github.com/bcc-code/bcc-media-flows/paths"
 	"go.temporal.io/sdk/workflow"
 )
 
 // VBExportToRawAbekas copies the input file directly to Abekas-RAW without transcoding.
 func VBExportToRawAbekas(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
-	logger := workflow.GetLogger(ctx)
-	logger.Info("Starting ExportToRawAbekas")
-
-	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
-
-	rcloneDestination := deliveryFolder.Append("Abekas-RAW", params.InputFile.Base())
-
-	err := wfutils.RcloneWaitForFileGone(ctx, rcloneDestination, telegram.ChatOslofjord, 10)
-	if err != nil {
-		return nil, err
-	}
-
-	err = wfutils.RcloneCopyFileWithNotifications(ctx, params.InputFile, rcloneDestination, rclone.PriorityHigh, rcloneNotificationOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	notifyExportDone(ctx, params, "raw-abekas", params.InputFile)
-
-	return &VBExportResult{
-		ID:    params.ParentParams.VXID,
-		Title: params.OriginalFilenameWithoutExt,
-	}, nil
+	return runVBExportChild(ctx, params, vbExportDestination{
+		flow:       "raw-abekas",
+		folder:     "Abekas-RAW",
+		copySource: func(p VBExportChildWorkflowParams) paths.Path { return p.InputFile },
+	})
 }

--- a/workflows/vb_export/vb_export_test.go
+++ b/workflows/vb_export/vb_export_test.go
@@ -2,12 +2,14 @@ package vb_export
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/bcc-code/bcc-media-flows/activities"
 	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
 	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/services/ffmpeg"
+	"github.com/bcc-code/bcc-media-flows/services/telegram"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsapi"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"github.com/stretchr/testify/mock"
@@ -194,15 +196,22 @@ func (s *VBExportTestSuite) Test_VBExportToXDCAM() {
 	s.Equal("VX-123", result.ID)
 }
 
-func (s *VBExportTestSuite) Test_EveryDestinationHasAWorkflow() {
+func (s *VBExportTestSuite) Test_EveryDestinationHasAWorkflowAndAFolder() {
 	for _, dest := range Destinations.Members() {
 		_, ok := destinationWorkflows[dest]
 		s.True(ok, "destination %q has no workflow", dest.Value)
+		s.NotEmpty(dest.DeliveryFolder(), "destination %q has no delivery folder", dest.Value)
 	}
 }
 
 func (s *VBExportTestSuite) Test_VBExportToBStage() {
-	s.env.OnActivity(activities.Util.SendTelegramMessage, mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+	var messages []string
+	s.env.OnActivity(activities.Util.SendTelegramMessage, mock.Anything, mock.Anything).Maybe().
+		Run(func(args mock.Arguments) {
+			if msg, ok := args.Get(1).(*telegram.Message); ok && msg != nil {
+				messages = append(messages, msg.Markdown)
+			}
+		}).Return(nil, nil)
 	s.env.OnActivity(activities.Util.CreateFolder, mock.Anything, mock.Anything).Maybe().Return(nil, nil)
 	s.env.OnActivity(activities.Util.RcloneCheckFileExists, mock.Anything, mock.Anything).Maybe().Return(false, nil)
 	s.env.OnActivity(activities.Util.RcloneWaitForJob, mock.Anything, mock.Anything).Maybe().Return(true, nil)
@@ -231,6 +240,9 @@ func (s *VBExportTestSuite) Test_VBExportToBStage() {
 	s.env.GetWorkflowResult(&result)
 	s.Equal("VX-123", result.ID)
 	s.Equal("test_video", result.Title)
+
+	s.Contains(strings.Join(messages, "\n"), "Destination: `b-stage`",
+		"the finish notification names the destination the way everything else does")
 }
 
 func (s *VBExportTestSuite) Test_VBExportToBStage_ImageIsDeliveredWithoutTranscoding() {

--- a/workflows/vb_export/vb_export_test.go
+++ b/workflows/vb_export/vb_export_test.go
@@ -233,6 +233,33 @@ func (s *VBExportTestSuite) Test_VBExportToBStage() {
 	s.Equal("test_video", result.Title)
 }
 
+func (s *VBExportTestSuite) Test_VBExportToBStage_ImageIsDeliveredWithoutTranscoding() {
+	s.env.OnActivity(activities.Util.SendTelegramMessage, mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+	s.env.OnActivity(activities.Util.CreateFolder, mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+	s.env.OnActivity(activities.Util.RcloneCheckFileExists, mock.Anything, mock.Anything).Maybe().Return(false, nil)
+	s.env.OnActivity(activities.Util.RcloneWaitForJob, mock.Anything, mock.Anything).Maybe().Return(true, nil)
+
+	mimeType := "image/png"
+	s.env.OnActivity(activities.Util.GetMimeType, mock.Anything, mock.Anything).Return(&mimeType, nil)
+
+	var copied activities.RcloneFileInput
+	s.env.OnActivity(activities.Util.RcloneCopyFile, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) { copied = args.Get(1).(activities.RcloneFileInput) }).
+		Return(1, nil)
+
+	params := childParams()
+	params.InputFile = paths.MustParse("/mnt/temp/workflows/test_image.png")
+	params.OriginalFilenameWithoutExt = "test_image"
+
+	s.env.ExecuteWorkflow(VBExportToBStage, params)
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+
+	s.env.AssertNotCalled(s.T(), "TranscodeToProResActivity", mock.Anything, mock.Anything)
+	s.Equal(params.InputFile, copied.Source)
+	s.Equal("/Delivery/FraMB/B-Stage/test_image.png", copied.Destination.Path)
+}
+
 func (s *VBExportTestSuite) Test_VBExportToRawAbekas_CopiesWithoutTranscoding() {
 	s.env.OnActivity(activities.Util.SendTelegramMessage, mock.Anything, mock.Anything).Maybe().Return(nil, nil)
 	s.env.OnActivity(activities.Util.RcloneCheckFileExists, mock.Anything, mock.Anything).Maybe().Return(false, nil)

--- a/workflows/vb_export/vb_export_test.go
+++ b/workflows/vb_export/vb_export_test.go
@@ -194,6 +194,109 @@ func (s *VBExportTestSuite) Test_VBExportToXDCAM() {
 	s.Equal("VX-123", result.ID)
 }
 
+func (s *VBExportTestSuite) Test_EveryDestinationHasAWorkflow() {
+	for _, dest := range Destinations.Members() {
+		_, ok := destinationWorkflows[dest]
+		s.True(ok, "destination %q has no workflow", dest.Value)
+	}
+}
+
+func (s *VBExportTestSuite) Test_VBExportToBStage() {
+	s.env.OnActivity(activities.Util.SendTelegramMessage, mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+	s.env.OnActivity(activities.Util.CreateFolder, mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+	s.env.OnActivity(activities.Util.RcloneCheckFileExists, mock.Anything, mock.Anything).Maybe().Return(false, nil)
+	s.env.OnActivity(activities.Util.RcloneWaitForJob, mock.Anything, mock.Anything).Maybe().Return(true, nil)
+
+	mimeType := "video/mp4"
+	s.env.OnActivity(activities.Util.GetMimeType, mock.Anything, mock.Anything).Return(&mimeType, nil)
+
+	outputPath := paths.MustParse("/mnt/temp/workflows/b-stage_output/test_video.mov")
+	s.env.OnActivity(activities.Video.TranscodeToProResActivity, mock.Anything, mock.MatchedBy(func(p activities.EncodeParams) bool {
+		return !p.Interlace && !p.Alpha
+	})).Return(&activities.EncodeResult{OutputPath: outputPath}, nil)
+
+	var copied activities.RcloneFileInput
+	s.env.OnActivity(activities.Util.RcloneCopyFile, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) { copied = args.Get(1).(activities.RcloneFileInput) }).
+		Return(1, nil)
+
+	s.env.ExecuteWorkflow(VBExportToBStage, childParams())
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+
+	s.Equal(outputPath, copied.Source)
+	s.Equal("/Delivery/FraMB/B-Stage/test_video.mov", copied.Destination.Path)
+
+	var result VBExportResult
+	s.env.GetWorkflowResult(&result)
+	s.Equal("VX-123", result.ID)
+	s.Equal("test_video", result.Title)
+}
+
+func (s *VBExportTestSuite) Test_VBExportToRawAbekas_CopiesWithoutTranscoding() {
+	s.env.OnActivity(activities.Util.SendTelegramMessage, mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+	s.env.OnActivity(activities.Util.RcloneCheckFileExists, mock.Anything, mock.Anything).Maybe().Return(false, nil)
+	s.env.OnActivity(activities.Util.RcloneWaitForJob, mock.Anything, mock.Anything).Maybe().Return(true, nil)
+
+	var copied activities.RcloneFileInput
+	s.env.OnActivity(activities.Util.RcloneCopyFile, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) { copied = args.Get(1).(activities.RcloneFileInput) }).
+		Return(1, nil)
+
+	s.env.ExecuteWorkflow(VBExportToRawAbekas, childParams())
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+
+	s.Equal(childParams().InputFile, copied.Source)
+	s.Equal("/Delivery/FraMB/Abekas-RAW/test_video.mxf", copied.Destination.Path)
+
+	var result VBExportResult
+	s.env.GetWorkflowResult(&result)
+	s.Equal("test_video", result.Title)
+}
+
+func (s *VBExportTestSuite) Test_VBExportChild_SubtitleFileNamesTheDelivery() {
+	s.env.OnActivity(activities.Util.SendTelegramMessage, mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+	s.env.OnActivity(activities.Util.CreateFolder, mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+	s.env.OnActivity(activities.Util.RcloneCheckFileExists, mock.Anything, mock.Anything).Maybe().Return(false, nil)
+	s.env.OnActivity(activities.Util.RcloneWaitForJob, mock.Anything, mock.Anything).Maybe().Return(true, nil)
+	s.env.OnActivity(activities.Video.TranscodeToXDCAMActivity, mock.Anything, mock.Anything).Return(&activities.EncodeResult{
+		OutputPath: paths.MustParse("/mnt/temp/workflows/xdcam_output/test_video.mxf"),
+	}, nil)
+
+	var copied activities.RcloneFileInput
+	s.env.OnActivity(activities.Util.RcloneCopyFile, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) { copied = args.Get(1).(activities.RcloneFileInput) }).
+		Return(1, nil)
+
+	params := childParams()
+	subtitle := paths.MustParse("/mnt/temp/workflows/test_video.srt")
+	params.SubtitleFile = &subtitle
+
+	s.env.ExecuteWorkflow(VBExportToXDCAM, params)
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+
+	s.Equal("/Delivery/FraMB/XDCAM/test_video_SUB_NOR.mxf", copied.Destination.Path)
+}
+
+func childParams() VBExportChildWorkflowParams {
+	return VBExportChildWorkflowParams{
+		ParentParams: VBExportParams{
+			VXID: "VX-123",
+		},
+		InputFile:                  paths.MustParse("/mnt/temp/workflows/test_video.mxf"),
+		OriginalFile:               paths.MustParse("/mnt/isilon/Production/masters/test_video.mxf"),
+		OriginalFilenameWithoutExt: "test_video",
+		TempDir:                    paths.MustParse("/mnt/temp/workflows"),
+		OutputDir:                  paths.MustParse("/mnt/temp/workflows/output"),
+		AnalyzeResult: ffmpeg.StreamInfo{
+			HasVideo:  true,
+			FrameRate: 25,
+		},
+	}
+}
+
 func TestVBExportTestSuite(t *testing.T) {
 	suite.Run(t, new(VBExportTestSuite))
 }

--- a/workflows/vb_export/vb_export_xdcam.go
+++ b/workflows/vb_export/vb_export_xdcam.go
@@ -2,59 +2,34 @@ package vb_export
 
 import (
 	"github.com/bcc-code/bcc-media-flows/activities"
-	"github.com/bcc-code/bcc-media-flows/services/rclone"
-	"github.com/bcc-code/bcc-media-flows/services/telegram"
+	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/utils"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"go.temporal.io/sdk/workflow"
 )
 
 func VBExportToXDCAM(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
-	logger := workflow.GetLogger(ctx)
-	logger.Info("Starting XDCAM")
+	return runVBExportChild(ctx, params, vbExportDestination{
+		flow:      "xdcam",
+		folder:    "XDCAM",
+		outputDir: "xdcam_output",
+		ext:       ".mxf",
+		transcode: func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path, _ bool) (paths.Path, error) {
+			res, err := wfutils.Execute(ctx, activities.Video.TranscodeToXDCAMActivity, activities.EncodeParams{
+				FilePath:       params.InputFile,
+				OutputDir:      outputDir,
+				Resolution:     utils.Resolution1080,
+				FrameRate:      25,
+				Interlace:      true,
+				Bitrate:        "50M",
+				BurnInSubtitle: params.SubtitleFile,
+				SubtitleStyle:  params.SubtitleStyle,
+			}).Result(ctx)
+			if err != nil {
+				return paths.Path{}, err
+			}
 
-	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
-
-	extraFileName := ""
-	if params.SubtitleFile != nil {
-		extraFileName += "_SUB_NOR"
-	}
-
-	rcloneDestination := deliveryFolder.Append("XDCAM", params.OriginalFilenameWithoutExt+extraFileName+".mxf")
-
-	err := wfutils.RcloneWaitForFileGone(ctx, rcloneDestination, telegram.ChatOslofjord, 10)
-	if err != nil {
-		return nil, err
-	}
-
-	outputDir := params.TempDir.Append("xdcam_output")
-	err = wfutils.CreateFolder(ctx, outputDir)
-	if err != nil {
-		return nil, err
-	}
-
-	videoResult, err := wfutils.Execute(ctx, activities.Video.TranscodeToXDCAMActivity, activities.EncodeParams{
-		FilePath:       params.InputFile,
-		OutputDir:      outputDir,
-		Resolution:     utils.Resolution1080,
-		FrameRate:      25,
-		Interlace:      true,
-		Bitrate:        "50M",
-		BurnInSubtitle: params.SubtitleFile,
-		SubtitleStyle:  params.SubtitleStyle,
-	}).Result(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	err = wfutils.RcloneCopyFileWithNotifications(ctx, videoResult.OutputPath, rcloneDestination, rclone.PriorityHigh, rcloneNotificationOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	notifyExportDone(ctx, params, "xdcam", videoResult.OutputPath)
-
-	return &VBExportResult{
-		ID: params.ParentParams.VXID,
-	}, nil
+			return res.OutputPath, nil
+		},
+	})
 }

--- a/workflows/vb_export/vb_export_xdcam.go
+++ b/workflows/vb_export/vb_export_xdcam.go
@@ -10,10 +10,8 @@ import (
 
 func VBExportToXDCAM(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
 	return runVBExportChild(ctx, params, vbExportDestination{
-		flow:      "xdcam",
-		folder:    "XDCAM",
-		outputDir: "xdcam_output",
-		ext:       ".mxf",
+		destination: DestinationXDCAM,
+		ext:         ".mxf",
 		transcode: func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path) (paths.Path, error) {
 			res, err := wfutils.Execute(ctx, activities.Video.TranscodeToXDCAMActivity, activities.EncodeParams{
 				FilePath:       params.InputFile,

--- a/workflows/vb_export/vb_export_xdcam.go
+++ b/workflows/vb_export/vb_export_xdcam.go
@@ -14,7 +14,7 @@ func VBExportToXDCAM(ctx workflow.Context, params VBExportChildWorkflowParams) (
 		folder:    "XDCAM",
 		outputDir: "xdcam_output",
 		ext:       ".mxf",
-		transcode: func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path, _ bool) (paths.Path, error) {
+		transcode: func(ctx workflow.Context, params VBExportChildWorkflowParams, outputDir paths.Path) (paths.Path, error) {
 			res, err := wfutils.Execute(ctx, activities.Video.TranscodeToXDCAMActivity, activities.EncodeParams{
 				FilePath:       params.InputFile,
 				OutputDir:      outputDir,


### PR DESCRIPTION
Closes the Tier 3 audit finding *"~400 lines removable from `workflows/vb_export/`"*.

Seven of the nine destination children were the same workflow with a different transcode in the middle — log, activity options, optional `IsImage`, destination name, `RcloneWaitForFileGone`, output folder, transcode, `RcloneCopyFileWithNotifications`, `notifyExportDone`, return. `vb_export_bstage.go` and `vb_export_gfx.go` were 88 identical lines apart from five tokens.

`runVBExportChild` is that frame, and a child is now only what differs:

```go
func VBExportToBStage(ctx workflow.Context, params VBExportChildWorkflowParams) (*VBExportResult, error) {
	return runVBExportChild(ctx, params, vbExportDestination{
		destination: DestinationBStage,
		imageAware:  true,
		transcode:   proRes{interlace: false, alpha: false}.transcode,
	})
}
```

| file | before | after |
|---|---|---|
| `vb_export_bstage.go` | 88 | 26 |
| `vb_export_gfx.go` | 88 | 26 |
| `vb_export_hippo_v2.go` | 123 | 85 |
| `vb_export_hyperdeck.go` | 93 | 67 |
| `vb_export_xdcam.go` | 60 | 33 |
| `vb_export_raw_abekas.go` | 35 | 14 |
| `vb_export_caspar_cg.go` | 35 | 14 |
| `vb_export.go` | 287 | 302 |
| `child.go` | — | 131 |

Production code in the package goes **1113 → 1002 lines**. The `~400` in the finding assumed `abekas` and `dubbing` folded in as well, and predates #454 taking the HAP v1 child — one of the ten sites — with it.

**Left alone, deliberately.** `abekas` creates its output folder before analyzing, ahead of the wait, so routing it through the frame would reorder two activities in the history of an in-flight export — for about forty lines. `dubbing` shares none of the shape. Both still use the destination methods below, so nothing is described in two places.

### Nothing stringly typed left

`flow`, `folder` and `outputDir` were three bare strings repeated per child, and they had already drifted: eight `flow` values matched their `Destination` member and B-Stage's did not, so a B-Stage export announced itself as `b-stage` when it started and `bstage` when it finished. All three are now the enum:

- `destination Destination` — one name per destination, and a typo does not compile.
- `OutputDirName()` — every output dir was the destination's value plus `_output`, including `abekas` and `dubbing`, so the field is gone and the method derives it.
- `DeliveryFolder()` — not derivable (`Hyperdeck-ProRes`, `Abekas-RAW`), so a table beside the enum with a test that no destination is missing one.

### Fixed on the way through

- `VBExportResult.Title` was set by `raw-abekas`, `caspar-cg` and one branch of `abekas`, and omitted by the other six, so aggregated results had blank titles about half the time. The frame sets it for everything it runs.
- **Operator-visible:** the finish notification for B-Stage now says ``Destination: `b-stage` `` instead of ``bstage``, matching the start notification for the same export.
- The destination `switch` is now a map, so a destination that parses but has no workflow is caught by a test rather than by the default case at runtime.

### Two functions, not one flag

A destination declares `transcode` and, when image-aware, `image`. The frame picks between them, so no transcoder takes an `isImage` argument and none opens by deciding not to transcode. Nil `image` delivers the input untouched — what B-Stage and GFX did inline; Hippo names the copy-into-the-output-dir it already had.

### Verification

The new tests were run **against the pre-refactor code**. They pass there unchanged — same rclone source and destination, same `Interlace`/`Alpha`, same `_SUB_NOR` naming, same copy-without-transcode, same untouched-image delivery — failing in exactly two places, both of them the intended changes above: the empty `Title`, and the B-Stage notification naming.

`go vet`, `go test -race ./workflows/...` and `workflowcheck` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)