### PR TITLE
refactor(bootstrap): one place for the startup every entrypoint repeats

### DIFF
--- a/analytics/service.go
+++ b/analytics/service.go
@@ -2,7 +2,7 @@ package analytics
 
 import (
 	"fmt"
-	"os"
+	"github.com/bcc-code/bcc-media-flows/internal/bootstrap"
 	"sync"
 	"time"
 
@@ -72,10 +72,7 @@ func (s *Service) ActivityStarted(activityName string, queue string, parentWorkf
 		return
 	}
 
-	identity := os.Getenv("IDENTITY")
-	if identity == "" {
-		identity = "worker"
-	}
+	identity := bootstrap.Identity()
 
 	properties := map[string]interface{}{
 		"activityName":   activityName,

--- a/cmd/bmm-trigger/main.go
+++ b/cmd/bmm-trigger/main.go
@@ -5,17 +5,17 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"github.com/bcc-code/bcc-media-flows/internal/bootstrap"
 	"os"
 	"strconv"
 
 	"github.com/bcc-code/bcc-media-flows/services/bmm"
 	ingestworkflows "github.com/bcc-code/bcc-media-flows/workflows/ingest"
-	"github.com/joho/godotenv"
 	"go.temporal.io/sdk/client"
 )
 
 func main() {
-	_ = godotenv.Load(".env")
+	bootstrap.LoadEnv()
 
 	trackID := flag.Int("track-id", 0, "BMM track ID to load from RavenDB (mutually exclusive with --album-id and --playlist-id)")
 	albumID := flag.Int("album-id", 0, "BMM album (ParentId) to load tracks for (mutually exclusive with --track-id and --playlist-id)")

--- a/cmd/fakerclone/main.go
+++ b/cmd/fakerclone/main.go
@@ -1,12 +1,11 @@
 package main
 
 import (
-	"fmt"
+	"github.com/bcc-code/bcc-media-flows/internal/bootstrap"
 	"github.com/bcc-code/bcc-media-flows/services/rclone"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gin-gonic/gin"
 	"net/http"
-	"os"
 	"time"
 )
 
@@ -123,13 +122,7 @@ func main() {
 	router.POST("/operations/movefile", operationsCopyFileHandler)
 	router.POST("/sync/copy", operationsCopyFileHandler)
 
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8084"
-	}
-
-	fmt.Printf("Started on port %s", port)
-	err := router.Run(fmt.Sprintf(":%s", port))
+	err := bootstrap.Serve(router, "8084")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/httpin/main.go
+++ b/cmd/httpin/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
+	"github.com/bcc-code/bcc-media-flows/internal/bootstrap"
 	"net/http"
-	"os"
 	"strconv"
 
 	"github.com/bcc-code/bcc-media-flows/utils"
@@ -42,11 +42,7 @@ func getClient() (client.Client, error) {
 }
 
 func getQueue() string {
-	queue := os.Getenv("QUEUE")
-	if queue == "" {
-		queue = environment.QueueWorker
-	}
-	return queue
+	return environment.GetQueue()
 }
 
 func triggerHandler(ctx *gin.Context) {
@@ -260,10 +256,7 @@ func triggerHandler(ctx *gin.Context) {
 
 func main() {
 	var err error
-	temporalClient, err = client.Dial(client.Options{
-		HostPort:  os.Getenv("TEMPORAL_HOST_PORT"),
-		Namespace: os.Getenv("TEMPORAL_NAMESPACE"),
-	})
+	temporalClient, err = bootstrap.TemporalClient()
 	if err != nil {
 		panic(err)
 	}
@@ -279,10 +272,5 @@ func main() {
 
 	r.POST("/ingest/json", jsonIngestHandler)
 
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080" // Default port if not specified
-	}
-
-	_ = r.Run(":" + port)
+	_ = bootstrap.Serve(r, "8080")
 }

--- a/cmd/trigger_ui/main.go
+++ b/cmd/trigger_ui/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	"github.com/bcc-code/bcc-media-flows/internal/bootstrap"
 	"log"
 	"net/http"
 	"path/filepath"
@@ -32,18 +33,11 @@ import (
 )
 
 func getTemporalClient() (client.Client, error) {
-	return client.Dial(client.Options{
-		HostPort:  os.Getenv("TEMPORAL_HOST_PORT"),
-		Namespace: os.Getenv("TEMPORAL_NAMESPACE"),
-	})
+	return bootstrap.TemporalClient()
 }
 
 func getQueue() string {
-	queue := os.Getenv("QUEUE")
-	if queue == "" {
-		queue = environment.QueueWorker
-	}
-	return queue
+	return environment.GetQueue()
 }
 
 var overlaysDir = os.Getenv("OVERLAYS_DIR")
@@ -562,13 +556,7 @@ func main() {
 		ctx.HTML(http.StatusOK, "index.gohtml", nil)
 	})
 
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8083"
-	}
-
-	fmt.Printf("Started on port %s", port)
-	err = router.Run(fmt.Sprintf(":%s", port))
+	err = bootstrap.Serve(router, "8083")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/bcc-code/bcc-media-flows/internal/bootstrap"
 	"log"
 	"os"
 	"os/exec"
@@ -17,7 +18,6 @@ import (
 	"github.com/bcc-code/bcc-media-flows/services/vizualizer"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	miscworkflows "github.com/bcc-code/bcc-media-flows/workflows/misc"
-	"github.com/joho/godotenv"
 
 	"github.com/bcc-code/bcc-media-flows/services/rclone"
 	"github.com/bcc-code/bcc-media-flows/workflows"
@@ -65,12 +65,11 @@ func GetAnalyticsService() *analytics.Service {
 var Version = "development"
 
 func main() {
-	err := godotenv.Load(".env")
-	if err == nil {
+	if bootstrap.LoadEnv() {
 		fmt.Println("Env file loaded")
 	}
 
-	err = update(Version)
+	err := update(Version)
 	if err != nil {
 		panic(err)
 	}
@@ -85,11 +84,7 @@ func main() {
 		}
 	}()
 
-	c, err := client.Dial(client.Options{
-		HostPort:  os.Getenv("TEMPORAL_HOST_PORT"),
-		Namespace: os.Getenv("TEMPORAL_NAMESPACE"),
-	})
-
+	c, err := bootstrap.TemporalClient()
 	if err != nil {
 		panic(err)
 	}
@@ -107,10 +102,7 @@ func main() {
 		Verbose:   false,
 	})
 
-	identity := os.Getenv("IDENTITY")
-	if identity == "" {
-		identity = "worker"
-	}
+	identity := bootstrap.Identity()
 
 	activityCountString := os.Getenv("ACTIVITY_COUNT")
 	if activityCountString == "" {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -1,0 +1,50 @@
+// Package bootstrap holds the startup steps every cmd/ entrypoint repeats:
+// loading .env, dialing Temporal, naming itself, and serving HTTP.
+package bootstrap
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gin-gonic/gin"
+	"github.com/joho/godotenv"
+	"go.temporal.io/sdk/client"
+)
+
+// LoadEnv reads .env into the environment. A missing file is not an error: in
+// production the values come from the deployment rather than a file.
+func LoadEnv() bool {
+	return godotenv.Load(".env") == nil
+}
+
+// TemporalClient dials the server named by TEMPORAL_HOST_PORT.
+func TemporalClient() (client.Client, error) {
+	host := os.Getenv("TEMPORAL_HOST_PORT")
+	if host == "" {
+		return nil, fmt.Errorf("TEMPORAL_HOST_PORT is required")
+	}
+
+	return client.Dial(client.Options{
+		HostPort:  host,
+		Namespace: os.Getenv("TEMPORAL_NAMESPACE"),
+	})
+}
+
+// Identity names this process in analytics and worker registration.
+func Identity() string {
+	if identity := os.Getenv("IDENTITY"); identity != "" {
+		return identity
+	}
+	return "worker"
+}
+
+// Serve runs router on PORT, or on defaultPort when PORT is unset.
+func Serve(router *gin.Engine, defaultPort string) error {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = defaultPort
+	}
+
+	fmt.Printf("Started on port %s\n", port)
+	return router.Run(":" + port)
+}

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -1,0 +1,25 @@
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdentity(t *testing.T) {
+	t.Setenv("IDENTITY", "")
+	assert.Equal(t, "worker", Identity())
+
+	t.Setenv("IDENTITY", "transcode-01")
+	assert.Equal(t, "transcode-01", Identity())
+}
+
+func TestTemporalClient_RequiresAHost(t *testing.T) {
+	t.Setenv("TEMPORAL_HOST_PORT", "")
+
+	_, err := TemporalClient()
+
+	require.Error(t, err, "dialing an empty host fails later and less clearly")
+	assert.Contains(t, err.Error(), "TEMPORAL_HOST_PORT")
+}

--- a/services/bmm/trigger.go
+++ b/services/bmm/trigger.go
@@ -3,6 +3,7 @@ package bmm
 import (
 	"context"
 	"fmt"
+	"github.com/bcc-code/bcc-media-flows/internal/bootstrap"
 	"os"
 
 	"github.com/bcc-code/bcc-media-flows/environment"
@@ -12,14 +13,7 @@ import (
 )
 
 func NewTemporalClient() (client.Client, error) {
-	host := os.Getenv("TEMPORAL_HOST_PORT")
-	if host == "" {
-		return nil, fmt.Errorf("TEMPORAL_HOST_PORT is required")
-	}
-	return client.Dial(client.Options{
-		HostPort:  host,
-		Namespace: os.Getenv("TEMPORAL_NAMESPACE"),
-	})
+	return bootstrap.TemporalClient()
 }
 
 func queueFromEnv() string {


### PR DESCRIPTION
Closes the Tier 3 audit finding *"One internal/bootstrap package for the four cmd/ entrypoints"*.

> **Stacked on #460** — based on `refactor/inline-helpers`, review that one first. The diff shown here is only this change.

`internal/bootstrap` now holds what `cmd/worker`, `cmd/httpin`, `cmd/trigger_ui`, `cmd/fakerclone`, `cmd/bmm-trigger` and `services/bmm` each had their own copy of.

| Concern | Was | Now |
|---|---|---|
| Temporal `client.Dial` | 4 copies | `bootstrap.TemporalClient()` |
| `PORT` + `Run` + error handling | 3 copies, 3 defaults, 2 error behaviours | `bootstrap.Serve(router, default)` |
| `IDENTITY` or `"worker"` | 2 copies | `bootstrap.Identity()` |
| `godotenv.Load(".env")` | 2 copies | `bootstrap.LoadEnv()` |
| `getQueue()` re-implementing `environment.GetQueue()` | 2 copies | the real one |

`TemporalClient` requires `TEMPORAL_HOST_PORT`, which only `services/bmm` checked — the other three dialed an empty host and failed further from the cause. The port defaults are unchanged (8080 / 8083 / 8084) and stay at the call sites, since they are what tells you which service you are reading.

### Three rows that look like duplication and are not

- **`services/bmm.queueFromEnv`.** `cmd/bmm-trigger` loads `.env`, and `environment` reads `QUEUE` into a package variable at **init**, before `main` runs — so the two disagree whenever `.env` sets it. That is the init-time env finding in Tier 5, and it should be fixed there rather than papered over by a call swap here.
- **The two `getTriggeredBy`.** Same name, opposite semantics: `httpin` takes a **request parameter**, `trigger_ui` reads a **proxy header**. Merging them would either make the UI trust a query parameter or make `httpin` ignore one its callers send. The `httpin` half is the attacker-controlled audit trail in Tier 4 and belongs with that finding.
- **`getFunctionName`.** No longer duplicated — the `httpin` copy left with the dynamic trigger RPC in #450.

### Not included

The server timeouts, size limits, graceful shutdown and `gin.ReleaseMode` the finding mentions as coming along for the ride. Those change how three services behave under load and in error — `httpin` handlers can block on a workflow, so a `WriteTimeout` is a real decision, not a freebie. Now that `Serve` exists they are one function to change instead of three, and they can land as the Tier 4 entry they belong to.

### Verification

`go build ./...`, `go vet ./...` and `go test ./...` clean. Two tests on the new package: `Identity` falls back to `worker`, and `TemporalClient` refuses an empty host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)