### PR TITLE
chore: drop the dead Notion link above the language table

### DIFF
--- a/language_config.go
+++ b/language_config.go
@@ -138,7 +138,6 @@ func (l LanguageList) Less(i, j int) bool {
 	return l[i].LanguageNumber < l[j].LanguageNumber
 }
 
-// Master: https://www.notion.so/bccmedia/Language-codes-222bc3bd6240428a93d03a84761ab57b?pvs=4
 var languages = LanguageList{
 	{
 		LanguageNumber:     0,


### PR DESCRIPTION
`language_config.go:141` cited a Notion page as the master copy of the language codes. That page no longer exists, so the comment pointed at nothing — and the table in this file is the master now.

This also settles the Tier 3 audit finding *"language_config.go should be data, not Go"*, which argued the table should move to an embedded `languages.json`/`.csv` **because** its authoritative source lived elsewhere and was hand-transcribed. With no external source, that argument is gone: the Go literal is the source, it is type-checked, and moving it to a data file would trade compile-time checking for runtime parsing to no benefit. The finding is dismissed rather than done.

The second half of that entry — moving both root files into a `languages/` package, since `package bccmflows` at the module root forces a `bccmflows "github.com/bcc-code/bcc-media-flows"` alias in 15 files — stands on its own and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)