### PR TITLE
refactor(languages): move the root package into languages/

### DIFF
--- a/activities/vidispine/meta.go
+++ b/activities/vidispine/meta.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	bccmflows "github.com/bcc-code/bcc-media-flows"
+	"github.com/bcc-code/bcc-media-flows/languages"
 	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsapi"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vscommon"
@@ -187,7 +187,7 @@ func (a Activities) UpdateAssetRelations(ctx context.Context, params VXOnlyParam
 		// Get the last three characters of the title, as it should be a language code
 		title = title[len(title)-3:]
 
-		if l, ok := bccmflows.LanguagesByISO[strings.ToLower(title)]; ok {
+		if l, ok := languages.LanguagesByISO[strings.ToLower(title)]; ok {
 			err := vsClient.SetItemMetadataField(
 				vsapi.ItemMetadataFieldParams{
 					ItemID:  vxID,

--- a/cmd/trigger_ui/main.go
+++ b/cmd/trigger_ui/main.go
@@ -21,7 +21,7 @@ import (
 
 	"os"
 
-	bccmflows "github.com/bcc-code/bcc-media-flows"
+	"github.com/bcc-code/bcc-media-flows/languages"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsapi"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vscommon"
@@ -82,7 +82,7 @@ func renderErrorPage(ctx *gin.Context, httpStatus int, err error) {
 type TriggerServer struct {
 	vidispine vidispine.Client
 	wfClient  client.Client
-	languages map[string]bccmflows.Language
+	languages map[string]languages.Language
 	database  *sql.DB
 }
 
@@ -114,7 +114,7 @@ type TriggerGETParams struct {
 	Title                   string
 	AssetExportDestinations []string
 	Filenames               []string
-	Languages               map[string]bccmflows.Language
+	Languages               map[string]languages.Language
 	SelectedLanguages       []string
 	SelectedAudioSource     string
 	AudioSources            []string
@@ -474,7 +474,7 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
-	lang := bccmflows.LanguagesByISO
+	lang := languages.LanguagesByISO
 
 	router.LoadHTMLGlob("./templates/*")
 

--- a/languages/config.go
+++ b/languages/config.go
@@ -1,4 +1,4 @@
-package bccmflows
+package languages
 
 type Language struct {
 	LanguageNumber     int
@@ -32,14 +32,14 @@ var (
 )
 
 func init() {
-	LanguagesByNumber = languages.ByNumber()
-	LanguagesByISO = languages.ByISO6391()
-	LanguagesByMU1 = languages.ByMU1()
-	LanguagesByMU2 = languages.ByMU2()
-	LanguagesByReaper = languages.ByReaperChan()
-	LanguagesByISOTwoLetter = languages.ByISO6392TwoLetter()
-	LanguageBySoftron = languages.BySoftron()
-	LanguageByBMM = languages.ByBMMCode()
+	LanguagesByNumber = all.ByNumber()
+	LanguagesByISO = all.ByISO6391()
+	LanguagesByMU1 = all.ByMU1()
+	LanguagesByMU2 = all.ByMU2()
+	LanguagesByReaper = all.ByReaperChan()
+	LanguagesByISOTwoLetter = all.ByISO6392TwoLetter()
+	LanguageBySoftron = all.BySoftron()
+	LanguageByBMM = all.ByBMMCode()
 }
 
 func (l LanguageList) BySoftron() map[int]Language {
@@ -138,7 +138,7 @@ func (l LanguageList) Less(i, j int) bool {
 	return l[i].LanguageNumber < l[j].LanguageNumber
 }
 
-var languages = LanguageList{
+var all = LanguageList{
 	{
 		LanguageNumber:     0,
 		LanguageName:       "Norsk",

--- a/languages/parser.go
+++ b/languages/parser.go
@@ -1,4 +1,4 @@
-package bccmflows
+package languages
 
 import "github.com/ansel1/merry/v2"
 

--- a/services/transcode/mux.go
+++ b/services/transcode/mux.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/bcc-code/bcc-media-flows/paths"
 
-	bccmflows "github.com/bcc-code/bcc-media-flows"
 	"github.com/bcc-code/bcc-media-flows/common"
+	"github.com/bcc-code/bcc-media-flows/languages"
 	"github.com/bcc-code/bcc-media-flows/services/ffmpeg"
 	"github.com/bcc-code/bcc-media-flows/utils"
 	"github.com/samber/lo"
@@ -22,9 +22,9 @@ type languageFile struct {
 
 // Order and respect the global language ordering.
 func languageFilesForPaths(paths map[string]paths.Path) []languageFile {
-	languages := utils.LanguageKeysToOrderedLanguages(lo.Keys(paths))
+	langs := utils.LanguageKeysToOrderedLanguages(lo.Keys(paths))
 
-	return lo.Map(languages, func(lang bccmflows.Language, _ int) languageFile {
+	return lo.Map(langs, func(lang languages.Language, _ int) languageFile {
 		return languageFile{
 			Path:     paths[lang.ISO6391],
 			Language: lang.ISO6391,

--- a/services/transcode/preview.go
+++ b/services/transcode/preview.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	bccmflows "github.com/bcc-code/bcc-media-flows"
 	"github.com/bcc-code/bcc-media-flows/environment"
+	"github.com/bcc-code/bcc-media-flows/languages"
 	"github.com/bcc-code/bcc-media-flows/services/ffmpeg"
 )
 
@@ -105,7 +105,7 @@ func prepareAudioPreview(isMU1, isMU2 bool, fileInfo *ffmpeg.FFProbeResult, inpu
 
 	if len(audioStreams) == 16 {
 		if isMU1 {
-			for i, l := range bccmflows.LanguagesByMU1 {
+			for i, l := range languages.LanguagesByMU1 {
 				if l.MU1ChannelStart != i {
 					continue // skip duplicated languages
 				}
@@ -123,7 +123,7 @@ func prepareAudioPreview(isMU1, isMU2 bool, fileInfo *ffmpeg.FFProbeResult, inpu
 				fileMap[l.ISO6391] = fileName
 			}
 		} else if isMU2 {
-			for i, l := range bccmflows.LanguagesByMU2 {
+			for i, l := range languages.LanguagesByMU2 {
 				if l.MU2ChannelStart != i {
 					continue // skip duplicated languages
 				}
@@ -144,7 +144,7 @@ func prepareAudioPreview(isMU1, isMU2 bool, fileInfo *ffmpeg.FFProbeResult, inpu
 		}
 
 	} else if len(audioStreams) == 1 && audioStreams[0].Channels == 64 {
-		for i, l := range bccmflows.LanguageBySoftron {
+		for i, l := range languages.LanguageBySoftron {
 			fileName := filepath.Join(outputDir, fmt.Sprintf("%d.%s.aac", i, l.ISO6391))
 			filterParts = append(filterParts, fmt.Sprintf("[0:%d]pan=stereo|c0=c%d|c1=c%d[a%d]", audioStreams[0].Index, l.SoftronStartCh, l.SoftronStartCh+1, i))
 			audioMap = append(audioMap, "-map", fmt.Sprintf("[a%d]", i), fileName)

--- a/services/vidispine/export.go
+++ b/services/vidispine/export.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	bccmflows "github.com/bcc-code/bcc-media-flows"
 	"github.com/bcc-code/bcc-media-flows/common"
 	"github.com/bcc-code/bcc-media-flows/environment"
+	"github.com/bcc-code/bcc-media-flows/languages"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsapi"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vscommon"
 	mapset "github.com/deckarep/golang-set/v2"
@@ -90,7 +90,7 @@ func GetRelatedAudioPaths(client Client, vxID string) (map[string]string, error)
 	}
 
 	var result = map[string]string{}
-	for _, lang := range bccmflows.LanguagesByISO {
+	for _, lang := range languages.LanguagesByISO {
 		relatedField := lang.RelatedMBFieldID
 		if relatedField == "" {
 			continue
@@ -144,7 +144,7 @@ func enrichClipWithRelatedAudios(client Client, clip *Clip, oLanguagesToExport [
 		}
 
 		// Figure out which field holds the related id
-		relatedField := bccmflows.LanguagesByISO[lang].RelatedMBFieldID
+		relatedField := languages.LanguagesByISO[lang].RelatedMBFieldID
 		if relatedField == "" {
 			return errors.New("No related field for language " + lang + ". This indicates missing support in Vidispine")
 		}
@@ -278,7 +278,7 @@ func enrichClipWithEmbeddedAudio(client Client, clip *Clip, languagesToExport []
 		// This is a softron file
 
 		for _, lang := range languagesToExport {
-			if langInfo, ok := bccmflows.LanguagesByISO[lang]; ok {
+			if langInfo, ok := languages.LanguagesByISO[lang]; ok {
 				clip.AudioFiles[lang] = &AudioFile{
 					File: shape.GetPath(),
 					Streams: []common.AudioStream{
@@ -377,7 +377,7 @@ func enrichClipWithEmbeddedAudio(client Client, clip *Clip, languagesToExport []
 	// We have an actual 16 channel audio file, so we need to figure out which channels to use
 	// and assign them to the correct language
 	for _, lang := range languagesToExport {
-		if l, ok := bccmflows.LanguagesByISO[lang]; ok {
+		if l, ok := languages.LanguagesByISO[lang]; ok {
 			var streams []common.AudioStream
 			for i := 0; i < l.MU1ChannelCount; i++ {
 				streams = append(streams, common.AudioStream{
@@ -392,7 +392,7 @@ func enrichClipWithEmbeddedAudio(client Client, clip *Clip, languagesToExport []
 				Streams: streams,
 			}
 		} else if lang != "" {
-			return nil, errors.New("No language " + lang + " found in bccmflows.LanguagesByISO")
+			return nil, errors.New("No language " + lang + " found in languages.LanguagesByISO")
 		}
 	}
 
@@ -561,7 +561,7 @@ func addSubtitlesAndTranscriptionsToClips(client Client, clips []*Clip, allowAI 
 			return err
 		}
 
-		for langCode := range bccmflows.LanguagesByISO {
+		for langCode := range languages.LanguagesByISO {
 			// There are also videos with .txt subs... we should support those at some point
 			shape := clipShapes.GetShape(fmt.Sprintf("sub_%s_srt", langCode))
 			if shape == nil || shape.GetPath() == "" {

--- a/utils/languages.go
+++ b/utils/languages.go
@@ -1,15 +1,15 @@
 package utils
 
 import (
-	bccmflows "github.com/bcc-code/bcc-media-flows"
+	"github.com/bcc-code/bcc-media-flows/languages"
 	"github.com/samber/lo"
 	"sort"
 )
 
-func LanguageKeysToOrderedLanguages(keys []string) bccmflows.LanguageList {
+func LanguageKeysToOrderedLanguages(keys []string) languages.LanguageList {
 	// Do we want this to fail the job if key doesn't exist? Will panic.
-	languages := bccmflows.LanguageList(lo.Map(keys, func(key string, _ int) bccmflows.Language {
-		return bccmflows.LanguagesByISO[key]
+	languages := languages.LanguageList(lo.Map(keys, func(key string, _ int) languages.Language {
+		return languages.LanguagesByISO[key]
 	}))
 
 	// Sort languages by priority

--- a/workflows/export/mux_files.go
+++ b/workflows/export/mux_files.go
@@ -7,10 +7,10 @@ import (
 	"github.com/bcc-code/bcc-media-flows/paths"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 
-	bccmflows "github.com/bcc-code/bcc-media-flows"
 	"github.com/bcc-code/bcc-media-flows/activities"
 	"github.com/bcc-code/bcc-media-flows/common"
 	"github.com/bcc-code/bcc-media-flows/common/smil"
+	"github.com/bcc-code/bcc-media-flows/languages"
 	"github.com/bcc-code/bcc-media-flows/utils"
 	"go.temporal.io/sdk/workflow"
 )
@@ -46,11 +46,11 @@ func createTranslatedFile(ctx workflow.Context, language string, videoPath, outp
 
 type ResolutionWithLanguages struct {
 	Resolution resolutionString
-	Languages  []bccmflows.Language
+	Languages  []languages.Language
 }
 
 func assignLanguagesToResolutions(audioKeys []string, resolutions []utils.Resolution) []ResolutionWithLanguages {
-	languages := utils.LanguageKeysToOrderedLanguages(audioKeys)
+	langs := utils.LanguageKeysToOrderedLanguages(audioKeys)
 
 	sortedResolutions := sortResolutionsForVODStreaming(resolutions)
 
@@ -58,14 +58,14 @@ func assignLanguagesToResolutions(audioKeys []string, resolutions []utils.Resolu
 	for i, r := range sortedResolutions {
 		qualities[i] = ResolutionWithLanguages{
 			Resolution: resolutionToString(r),
-			Languages:  []bccmflows.Language{},
+			Languages:  []languages.Language{},
 		}
 
 		// 9 is the limit of audio streams AWS will accept on one file
 		// https://eu-north-1.console.aws.amazon.com/servicequotas/home/services/mediapackage/quotas/L-81A8E99B
-		for len(languages) > 0 && len(qualities[i].Languages) < 8 {
-			qualities[i].Languages = append(qualities[i].Languages, languages[0])
-			languages = languages[1:]
+		for len(langs) > 0 && len(qualities[i].Languages) < 8 {
+			qualities[i].Languages = append(qualities[i].Languages, langs[0])
+			langs = langs[1:]
 		}
 	}
 
@@ -90,9 +90,9 @@ func sortResolutionsForVODStreaming(resolutions []utils.Resolution) []utils.Reso
 	return sortedResolutions
 }
 
-func createStreamFile(ctx workflow.Context, languages []bccmflows.Language, videoFile, outputPath paths.Path, audioFiles map[string]paths.Path) workflow.Future {
+func createStreamFile(ctx workflow.Context, langs []languages.Language, videoFile, outputPath paths.Path, audioFiles map[string]paths.Path) workflow.Future {
 	audioFilePaths := map[string]paths.Path{}
-	for _, lang := range languages {
+	for _, lang := range langs {
 		audioFilePaths[lang.ISO6391] = audioFiles[lang.ISO6391]
 	}
 

--- a/workflows/export/vx_export_bmm.go
+++ b/workflows/export/vx_export_bmm.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	bccmflows "github.com/bcc-code/bcc-media-flows"
+	"github.com/bcc-code/bcc-media-flows/languages"
 	"github.com/bcc-code/bcc-media-flows/services/telegram"
 
 	pcommon "github.com/bcc-code/bcc-media-platform/backend/common"
@@ -242,7 +242,7 @@ func makeBMMJSON(
 
 		// The text languages are mapped with two letter codes so we need to convert to code
 		// in order to be uniform with the audio languages
-		if val, ok := bccmflows.LanguagesByISOTwoLetter[lang]; ok {
+		if val, ok := languages.LanguagesByISOTwoLetter[lang]; ok {
 			bmmTextLang = val.ISO6391
 		}
 

--- a/workflows/export/vx_export_vod.go
+++ b/workflows/export/vx_export_vod.go
@@ -13,10 +13,10 @@ import (
 	platform_activities "github.com/bcc-code/bcc-media-flows/activities/platform"
 	"github.com/bcc-code/bcc-media-flows/services/rclone"
 
-	bccmflows "github.com/bcc-code/bcc-media-flows"
 	"github.com/bcc-code/bcc-media-flows/activities"
 	"github.com/bcc-code/bcc-media-flows/common"
 	"github.com/bcc-code/bcc-media-flows/common/smil"
+	"github.com/bcc-code/bcc-media-flows/languages"
 	"github.com/bcc-code/bcc-media-flows/paths"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"github.com/bcc-code/bcc-media-platform/backend/asset"
@@ -387,7 +387,7 @@ func (v *vxExportVodService) handleFileWorkflowFuture(ctx workflow.Context, lang
 		v.errs = append(v.errs, err)
 		return
 	}
-	code := bccmflows.LanguagesByISO[lang].ISO6392TwoLetter
+	code := languages.LanguagesByISO[lang].ISO6392TwoLetter
 	if code == "" {
 		code = lang
 	}
@@ -415,10 +415,10 @@ func (v *vxExportVodService) handleStreamWorkflowFuture(ctx workflow.Context, re
 	v.smilVideos[resolutionWithLanguages.Resolution] = smil.Video{
 		Src:          result.Path.Base(),
 		IncludeAudio: fmt.Sprintf("%t", len(fileLanguages) > 0),
-		SystemLanguage: strings.Join(lo.Map(fileLanguages, func(i bccmflows.Language, _ int) string {
+		SystemLanguage: strings.Join(lo.Map(fileLanguages, func(i languages.Language, _ int) string {
 			return i.ISO6391
 		}), ","),
-		AudioName: strings.Join(lo.Map(fileLanguages, func(i bccmflows.Language, _ int) string {
+		AudioName: strings.Join(lo.Map(fileLanguages, func(i languages.Language, _ int) string {
 			return i.LanguageNameSystem
 		}), ","),
 	}

--- a/workflows/ingest/import_audio_from_reaper.go
+++ b/workflows/ingest/import_audio_from_reaper.go
@@ -9,11 +9,11 @@ import (
 	"github.com/bcc-code/bcc-media-flows/services/telegram"
 	miscworkflows "github.com/bcc-code/bcc-media-flows/workflows/misc"
 
-	bccmflows "github.com/bcc-code/bcc-media-flows"
 	"github.com/bcc-code/bcc-media-flows/activities"
 	"github.com/bcc-code/bcc-media-flows/activities/cantemo"
 	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
 	"github.com/bcc-code/bcc-media-flows/common"
+	"github.com/bcc-code/bcc-media-flows/languages"
 	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vscommon"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
@@ -98,7 +98,7 @@ func RelateAudioToVideo(ctx workflow.Context, params RelateAudioToVideoParams) e
 		err = wfutils.Execute(ctx, activities.Vidispine.SetVXMetadataFieldActivity, vsactivity.VXMetadataFieldParams{
 			ItemID:  params.VideoVXID,
 			GroupID: "System",
-			Key:     bccmflows.LanguagesByISO[lang].RelatedMBFieldID,
+			Key:     languages.LanguagesByISO[lang].RelatedMBFieldID,
 			Value:   assetResult.AssetID,
 		}).Get(ctx, nil)
 		if err != nil {
@@ -179,7 +179,7 @@ func doImportAudioFileFromReaper(ctx workflow.Context, params ImportAudioFileFro
 	}
 
 	if isSilent {
-		wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟧 File %s is silent, skipping", bccmflows.LanguagesByReaper[reaperTrackNumber].LanguageName))
+		wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟧 File %s is silent, skipping", languages.LanguagesByReaper[reaperTrackNumber].LanguageName))
 
 		// This is not a fail, so we should not send an error
 		return nil
@@ -196,7 +196,7 @@ func doImportAudioFileFromReaper(ctx workflow.Context, params ImportAudioFileFro
 		return err
 	}
 
-	lang := bccmflows.LanguagesByReaper[reaperTrackNumber]
+	lang := languages.LanguagesByReaper[reaperTrackNumber]
 
 	// Generate a filename with the language code
 	outPath := outputFolder.Append(fmt.Sprintf("%s-%s.wav", params.BaseName, strings.ToUpper(lang.ISO6391)))

--- a/workflows/ingest/mu1_mu2_extract.go
+++ b/workflows/ingest/mu1_mu2_extract.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"time"
 
-	bccmflows "github.com/bcc-code/bcc-media-flows"
 	"github.com/bcc-code/bcc-media-flows/activities"
 	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
+	"github.com/bcc-code/bcc-media-flows/languages"
 	"github.com/bcc-code/bcc-media-flows/paths"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"go.temporal.io/sdk/workflow"
@@ -116,7 +116,7 @@ func ExtractAudioFromMU1MU2(ctx workflow.Context, input ExtractAudioFromMU1MU2In
 			})
 
 			futures = append(futures, f.Future)
-			filesToImport[bccmflows.LanguagesByMU2[key].ISO6391] = outputFile
+			filesToImport[languages.LanguagesByMU2[key].ISO6391] = outputFile
 		}
 	} else if sampleOffset > 0 {
 		for _, key := range keys {
@@ -130,7 +130,7 @@ func ExtractAudioFromMU1MU2(ctx workflow.Context, input ExtractAudioFromMU1MU2In
 			})
 
 			futures = append(futures, f.Future)
-			filesToImport[bccmflows.LanguagesByMU2[key].ISO6391] = outputFile
+			filesToImport[languages.LanguagesByMU2[key].ISO6391] = outputFile
 		}
 	} else {
 		return fmt.Errorf("no offset - this is extremely unlikely to happen, please check the input files - STOPPING WORKFLOW")
@@ -150,7 +150,7 @@ func ExtractAudioFromMU1MU2(ctx workflow.Context, input ExtractAudioFromMU1MU2In
 			Destination: destinationFile,
 		})
 		futures = append(futures, f.Future)
-		filesToImport[bccmflows.LanguagesByMU1[i].ISO6391] = destinationFile
+		filesToImport[languages.LanguagesByMU1[i].ISO6391] = destinationFile
 	}
 
 	errors := ""

--- a/workflows/misc/transcode_preview-vx.go
+++ b/workflows/misc/transcode_preview-vx.go
@@ -3,7 +3,7 @@ package miscworkflows
 import (
 	"errors"
 	"fmt"
-	bccmflows "github.com/bcc-code/bcc-media-flows"
+	"github.com/bcc-code/bcc-media-flows/languages"
 	"github.com/samber/lo"
 	"path/filepath"
 	"strings"
@@ -96,7 +96,7 @@ func TranscodePreviewVX(
 
 	for _, l := range audioLangs {
 		p := previewResponse.AudioPreviewFiles[l]
-		tag := bccmflows.LanguagesByISO[l].MBPreviewTag
+		tag := languages.LanguagesByISO[l].MBPreviewTag
 		if tag == "" {
 			logger.Info("Skipping audio preview with empty MBPreviewTag", "language", l)
 			continue

--- a/workflows/vb_export/vb_export_dubbing.go
+++ b/workflows/vb_export/vb_export_dubbing.go
@@ -3,10 +3,10 @@ package vb_export
 import (
 	"fmt"
 
-	bccmflows "github.com/bcc-code/bcc-media-flows"
 	"github.com/bcc-code/bcc-media-flows/activities"
 	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
 	"github.com/bcc-code/bcc-media-flows/common"
+	"github.com/bcc-code/bcc-media-flows/languages"
 	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/services/rclone"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vscommon"
@@ -109,7 +109,7 @@ func postTranscodeAudio(ctx workflow.Context, originalFile paths.Path, destinati
 		//Naming: wav with trackNumber_languageCode at the end of the name e.g. BIST_S01_E07_MAS_NORmov_1_nor
 
 		dubbReaperChannel := 99
-		if l, ok := bccmflows.LanguagesByISO[lang]; ok {
+		if l, ok := languages.LanguagesByISO[lang]; ok {
 			dubbReaperChannel = l.ReaperChannel
 		}
 


### PR DESCRIPTION
Closes what was left of the Tier 3 audit finding *"language_config.go should be data, not Go"* — the half that never depended on the Notion premise.

> **Stacked on #464** — based on `refactor/common-layering`, review that one first. Both touch `services/vidispine/export.go`.

`package bccmflows` sat at the module root, so its import path ended in `bcc-media-flows` while the package was called `bccmflows`. Go cannot infer that, which is why **all 13 importers** carried:

```go
bccmflows "github.com/bcc-code/bcc-media-flows"
```

The root package was also one import away from a cycle: it is imported by `utils`, `services/*`, `workflows/*` and `activities/*`, and stayed acyclic only because it imported nothing but `merry`. `paths → environment` already exists, so a root → `paths` import would have closed it.

The two files are now `languages/config.go` and `languages/parser.go`. The package name matches the last path element, so the alias is gone — and there is nothing left at the module root to import at all.

### Two renames came with it

- The package-level `LanguageList` was called `languages`, which now reads as the package name. It is `all`.
- Five importers had a local variable named `languages` that would shadow the package. Two of them needed it (`services/transcode/mux.go`, `workflows/export/mux_files.go`) and now use `langs`, which is what the neighbouring code already called it.

### No behaviour change

Same types, same exported names, same `init()`. Nothing moved between packages except the file location, so no payload, no registration and no workflow history is affected.

### Verification

`go build ./...`, `go vet ./...`, `go test ./...` and `workflowcheck` clean. `grep -rn bccmflows --include='*.go' .` returns nothing, and `ls *.go` at the root returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)