### PR TITLE
refactor(workflows): decompose addMetaTags and the merge collect blocks

### DIFF
--- a/workflows/export/generate_short.go
+++ b/workflows/export/generate_short.go
@@ -44,20 +44,9 @@ func GenerateShort(ctx workflow.Context, params GenerateShortDataParams) (*Gener
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting GenerateShort")
 
-	if strings.TrimSpace(params.VXID) == "" {
-		return nil, validationError("VXID is empty")
-	}
-	if strings.TrimSpace(params.OutputDirPath) == "" {
-		return nil, validationError("OutputDirPath is empty")
-	}
-	if params.InSeconds < 0 {
-		return nil, validationError("InSeconds must be >= 0")
-	}
-	if params.OutSeconds < 0 {
-		return nil, validationError("OutSeconds must be >= 0")
-	}
-	if params.InSeconds >= params.OutSeconds {
-		return nil, validationError("InSeconds must be < OutSeconds")
+	err := validateShortParams(params)
+	if err != nil {
+		return nil, err
 	}
 
 	outputPath, err := paths.Parse(params.OutputDirPath)
@@ -134,36 +123,7 @@ func GenerateShort(ctx workflow.Context, params GenerateShortDataParams) (*Gener
 			"cannot generate a short without a video file", "NO_VIDEO_FILE", nil)
 	}
 
-	sceneResult, err := wfutils.Execute(ctx,
-		activities.Video.FFmpegGetSceneChanges,
-		clipResult.VideoFile,
-	).Result(ctx)
-	if err != nil {
-		logger.Error("Scene-detect FFmpeg failed: " + err.Error())
-		return nil, err
-	}
-
-	submitJobParams := activities.SubmitShortJobInput{
-		InputPath:    clipResult.VideoFile.Linux(),
-		OutputPath:   tempFolder.Linux(),
-		Model:        params.ModelSize,
-		Debug:        params.DebugMode,
-		SceneChanges: sceneResult,
-	}
-
-	jobResult, err := wfutils.Execute(ctx, activities.Util.SubmitShortJobActivity, submitJobParams).Result(ctx)
-	if err != nil {
-		logger.Error("Failed to submit job: " + err.Error())
-		return nil, err
-	}
-
-	logger.Info("Job submitted with ID: " + jobResult.JobID)
-
-	checkStatusParams := activities.CheckJobStatusInput{
-		JobID: jobResult.JobID,
-	}
-
-	keyframes, err := waitForShortJob(ctx, checkStatusParams)
+	sceneChanges, keyframes, err := findShortKeyframes(ctx, *clipResult.VideoFile, tempFolder, params)
 	if err != nil {
 		return nil, err
 	}
@@ -185,31 +145,16 @@ func GenerateShort(ctx workflow.Context, params GenerateShortDataParams) (*Gener
 		norwegianAudioPath = &audioPath
 	}
 
-	var cropRes activities.CropShortResult
-	err = wfutils.Execute(ctx,
-		activities.Util.CropShortActivity,
-		activities.CropShortInput{
-			InputVideoPath:  *clipResult.VideoFile,
-			OutputVideoPath: shortVideoPath,
-			//SubtitlePath:    subtitlePaths, // For now disable subtitle burn-in
-			AudioPath:    norwegianAudioPath,
-			KeyFrames:    keyframes,
-			InSeconds:    params.InSeconds,
-			OutSeconds:   params.OutSeconds,
-			SceneChanges: sceneResult,
-		}).Get(ctx, &cropRes)
+	err = cropShortVideo(ctx, cropShortRequest{
+		Video:        *clipResult.VideoFile,
+		Output:       shortVideoPath,
+		Audio:        norwegianAudioPath,
+		Keyframes:    keyframes,
+		SceneChanges: sceneChanges,
+		InSeconds:    params.InSeconds,
+		OutSeconds:   params.OutSeconds,
+	})
 	if err != nil {
-		logger.Error("CropShortActivity failed: " + err.Error())
-		return nil, err
-	}
-
-	ffmpegParams := miscworkflows.ExecuteFFmpegInput{
-		Arguments: cropRes.Arguments,
-	}
-
-	err = workflow.ExecuteChildWorkflow(ctx, miscworkflows.ExecuteFFmpeg, ffmpegParams).Get(ctx, nil)
-	if err != nil {
-		logger.Error("Failed to execute FFmpeg: " + err.Error())
 		return nil, err
 	}
 
@@ -220,6 +165,103 @@ func GenerateShort(ctx workflow.Context, params GenerateShortDataParams) (*Gener
 		AudioFiles:     clipResult.AudioFiles,
 		SubtitleFiles:  clipResult.SubtitleFiles,
 	}, nil
+}
+
+func validateShortParams(params GenerateShortDataParams) error {
+	switch {
+	case strings.TrimSpace(params.VXID) == "":
+		return validationError("VXID is empty")
+	case strings.TrimSpace(params.OutputDirPath) == "":
+		return validationError("OutputDirPath is empty")
+	case params.InSeconds < 0:
+		return validationError("InSeconds must be >= 0")
+	case params.OutSeconds < 0:
+		return validationError("OutSeconds must be >= 0")
+	case params.InSeconds >= params.OutSeconds:
+		return validationError("InSeconds must be < OutSeconds")
+	}
+
+	return nil
+}
+
+// findShortKeyframes asks the shorts service where to crop. The scene changes come
+// back too, because the crop needs them as well as the keyframes.
+func findShortKeyframes(
+	ctx workflow.Context,
+	video paths.Path,
+	tempFolder paths.Path,
+	params GenerateShortDataParams,
+) ([]float64, []activities.Keyframe, error) {
+	logger := workflow.GetLogger(ctx)
+
+	sceneChanges, err := wfutils.Execute(ctx, activities.Video.FFmpegGetSceneChanges, &video).Result(ctx)
+	if err != nil {
+		logger.Error("Scene-detect FFmpeg failed: " + err.Error())
+		return nil, nil, err
+	}
+
+	jobResult, err := wfutils.Execute(ctx, activities.Util.SubmitShortJobActivity, activities.SubmitShortJobInput{
+		InputPath:    video.Linux(),
+		OutputPath:   tempFolder.Linux(),
+		Model:        params.ModelSize,
+		Debug:        params.DebugMode,
+		SceneChanges: sceneChanges,
+	}).Result(ctx)
+	if err != nil {
+		logger.Error("Failed to submit job: " + err.Error())
+		return nil, nil, err
+	}
+
+	logger.Info("Job submitted with ID: " + jobResult.JobID)
+
+	keyframes, err := waitForShortJob(ctx, activities.CheckJobStatusInput{JobID: jobResult.JobID})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return sceneChanges, keyframes, nil
+}
+
+type cropShortRequest struct {
+	Video        paths.Path
+	Output       paths.Path
+	Audio        *paths.Path
+	Keyframes    []activities.Keyframe
+	SceneChanges []float64
+	InSeconds    float64
+	OutSeconds   float64
+}
+
+// cropShortVideo works out the ffmpeg arguments and then runs them, which is two
+// steps because the run happens in a child workflow on the transcode queue.
+func cropShortVideo(ctx workflow.Context, req cropShortRequest) error {
+	logger := workflow.GetLogger(ctx)
+
+	var cropRes activities.CropShortResult
+	err := wfutils.Execute(ctx, activities.Util.CropShortActivity, activities.CropShortInput{
+		InputVideoPath:  req.Video,
+		OutputVideoPath: req.Output,
+		// SubtitlePath is left out: subtitle burn-in is disabled for now.
+		AudioPath:    req.Audio,
+		KeyFrames:    req.Keyframes,
+		InSeconds:    req.InSeconds,
+		OutSeconds:   req.OutSeconds,
+		SceneChanges: req.SceneChanges,
+	}).Get(ctx, &cropRes)
+	if err != nil {
+		logger.Error("CropShortActivity failed: " + err.Error())
+		return err
+	}
+
+	err = workflow.ExecuteChildWorkflow(ctx, miscworkflows.ExecuteFFmpeg, miscworkflows.ExecuteFFmpegInput{
+		Arguments: cropRes.Arguments,
+	}).Get(ctx, nil)
+	if err != nil {
+		logger.Error("Failed to execute FFmpeg: " + err.Error())
+		return err
+	}
+
+	return nil
 }
 
 const (

--- a/workflows/export/generate_short_sequence_test.go
+++ b/workflows/export/generate_short_sequence_test.go
@@ -1,0 +1,79 @@
+package export
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/activities"
+	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
+	"github.com/bcc-code/bcc-media-flows/paths"
+	"github.com/bcc-code/bcc-media-flows/services/vidispine"
+	miscworkflows "github.com/bcc-code/bcc-media-flows/workflows/misc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/testsuite"
+)
+
+// TestGenerateShortActivityOrder pins the order GenerateShort works in.
+// Extracting helpers does not change a workflow's history; reordering while
+// moving code does.
+func TestGenerateShortActivityOrder(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+
+	videoFile := paths.MustParse("/mnt/temp/workflows/clip.mxf")
+
+	env.OnActivity(activities.Vidispine.GetExportDataActivity, mock.Anything, mock.Anything).
+		Return(&vidispine.ExportData{
+			Title: "A Title",
+			Clips: []*vidispine.Clip{{VideoFile: videoFile.Local()}},
+		}, nil)
+	env.OnActivity(activities.Util.CreateFolder, mock.Anything, mock.Anything).Return("", nil).Maybe()
+	env.OnWorkflow(MergeExportData, mock.Anything, mock.Anything).
+		Return(&MergeExportDataResult{
+			VideoFile:  &videoFile,
+			AudioFiles: map[string]paths.Path{"nor": paths.MustParse("/mnt/temp/workflows/nor.wav")},
+		}, nil)
+	env.OnActivity(activities.Video.FFmpegGetSceneChanges, mock.Anything, mock.Anything).
+		Return([]float64{1.0}, nil)
+	env.OnActivity(activities.Util.SubmitShortJobActivity, mock.Anything, mock.Anything).
+		Return(&activities.SubmitShortJobResult{JobID: "job-1"}, nil)
+	env.OnActivity(activities.Util.CheckJobStatusActivity, mock.Anything, mock.Anything).
+		Return(&activities.GenerateShortRequestResult{
+			Status:    "completed",
+			Keyframes: []activities.Keyframe{},
+		}, nil)
+	env.OnActivity(activities.Util.CropShortActivity, mock.Anything, mock.Anything).
+		Return(&activities.CropShortResult{Arguments: []string{"-i", "in.mxf"}}, nil)
+	env.OnWorkflow(miscworkflows.ExecuteFFmpeg, mock.Anything, mock.Anything).Return(nil)
+
+	var calls []string
+	env.SetOnActivityStartedListener(func(info *activity.Info, _ context.Context, _ converter.EncodedValues) {
+		calls = append(calls, info.ActivityType.Name)
+	})
+
+	env.ExecuteWorkflow(GenerateShort, GenerateShortDataParams{
+		VXID:          "VX-1",
+		OutputDirPath: "/mnt/isilon/Export/out",
+		InSeconds:     0,
+		OutSeconds:    10,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	assert.Equal(t, []string{
+		"GetExportDataActivity",
+		"CreateFolder",
+		"CreateFolder",
+		"FFmpegGetSceneChanges",
+		"SubmitShortJobActivity",
+		"CheckJobStatusActivity",
+		"CropShortActivity",
+	}, calls)
+
+	var _ = vsactivity.GetExportDataParams{}
+}

--- a/workflows/export/merge_export_data.go
+++ b/workflows/export/merge_export_data.go
@@ -92,38 +92,14 @@ func MergeExportData(ctx workflow.Context, params MergeExportDataParams) (*Merge
 		videoFile = &result.Path
 	}
 
-	var audioFiles = map[string]paths.Path{}
-	{
-		keys, err := wfutils.GetMapKeysSafely(ctx, audioTasks)
-		if err != nil {
-			return nil, err
-		}
-		for _, lang := range keys {
-			task := audioTasks[lang]
-			var result common.MergeResult
-			err = task.Get(ctx, &result)
-			if err != nil {
-				return nil, err
-			}
-			audioFiles[lang] = result.Path
-		}
+	audioFiles, err := collectMergedPaths(ctx, audioTasks)
+	if err != nil {
+		return nil, err
 	}
 
-	var subtitleFiles = map[string]paths.Path{}
-	{
-		keys, err := wfutils.GetMapKeysSafely(ctx, subtitleTasks)
-		if err != nil {
-			return nil, err
-		}
-		for _, lang := range keys {
-			task := subtitleTasks[lang]
-			var result common.MergeResult
-			err = task.Get(ctx, &result)
-			if err != nil {
-				return nil, err
-			}
-			subtitleFiles[lang] = result.Path
-		}
+	subtitleFiles, err := collectMergedPaths(ctx, subtitleTasks)
+	if err != nil {
+		return nil, err
 	}
 
 	jsonTranscriptResult := map[string]paths.Path{}
@@ -249,4 +225,25 @@ func exportDataToMergeInputs(data *vidispine.ExportData, tempDir, subtitlesDir p
 		SubtitleMergeInputs: subtitleMergeInputs,
 		JSONTranscriptInput: JSONTranscriptInput,
 	}
+}
+
+// collectMergedPaths waits for one merge per language and keeps where each landed.
+func collectMergedPaths(ctx workflow.Context, tasks map[string]workflow.Future) (map[string]paths.Path, error) {
+	langs, err := wfutils.GetMapKeysSafely(ctx, tasks)
+	if err != nil {
+		return nil, err
+	}
+
+	files := map[string]paths.Path{}
+	for _, lang := range langs {
+		var result common.MergeResult
+		err = tasks[lang].Get(ctx, &result)
+		if err != nil {
+			return nil, err
+		}
+
+		files[lang] = result.Path
+	}
+
+	return files, nil
 }

--- a/workflows/export/shorts.go
+++ b/workflows/export/shorts.go
@@ -247,10 +247,8 @@ func createShortInPlatform(ctx workflow.Context, short *ShortsData, styledImage 
 
 	assetID := strconv.Itoa(int(assetResult.ID))
 
-	var episodeID string
-	if short.EpisodeID != "" {
-		episodeID = short.EpisodeID
-	} else {
+	episodeID := short.EpisodeID
+	if episodeID == "" {
 		workflow.GetLogger(ctx).Warn("EpisodeID is empty", "mediabankenID", short.MBMetadata.ID, "label", short.Label)
 	}
 
@@ -280,36 +278,11 @@ func createShortInPlatform(ctx workflow.Context, short *ShortsData, styledImage 
 	}
 
 	// Tag codes will be sourced from ClickUp custom fields once those are added.
-	// The loop below already no-ops on empty values.
 	var tagCodes []string
 
-	for _, raw := range tagCodes {
-		code := strings.ToLower(strings.TrimSpace(raw))
-		if code == "" {
-			continue
-		}
-
-		tag, err := wfutils.Execute(ctx, activities.Directus.GetOrCreateTag, activities.GetOrCreateTagInput{
-			Code: code,
-			Name: code,
-		}).Result(ctx)
-
-		if err != nil {
-			return err
-		}
-
-		// Create relationship between media item and tag
-		_, err = wfutils.Execute(ctx, activities.Directus.CreateMediaItemTag, activities.CreateMediaItemTagInput{
-			MediaItemID: mediaItemResult.ID,
-			TagID:       tag.ID,
-		}).Result(ctx)
-		if err != nil {
-			workflow.GetLogger(ctx).Error("Error creating media item tag relationship",
-				"error", err,
-				"mediaItemID", mediaItemResult.ID,
-				"tagId", tag.ID,
-			)
-		}
+	err = tagMediaItem(ctx, mediaItemResult.ID, tagCodes)
+	if err != nil {
+		return err
 	}
 
 	// Create short
@@ -324,6 +297,40 @@ func createShortInPlatform(ctx workflow.Context, short *ShortsData, styledImage 
 
 	if shortResult == nil {
 		return fmt.Errorf("failed to create short: no data in response")
+	}
+
+	return nil
+}
+
+// tagMediaItem attaches each tag to the media item, creating the tag if it is new. A
+// relationship that fails to save is logged rather than returned: the short is already
+// created, and losing a tag is not worth failing the export over.
+func tagMediaItem(ctx workflow.Context, mediaItemID string, tagCodes []string) error {
+	for _, raw := range tagCodes {
+		code := strings.ToLower(strings.TrimSpace(raw))
+		if code == "" {
+			continue
+		}
+
+		tag, err := wfutils.Execute(ctx, activities.Directus.GetOrCreateTag, activities.GetOrCreateTagInput{
+			Code: code,
+			Name: code,
+		}).Result(ctx)
+		if err != nil {
+			return err
+		}
+
+		_, err = wfutils.Execute(ctx, activities.Directus.CreateMediaItemTag, activities.CreateMediaItemTagInput{
+			MediaItemID: mediaItemID,
+			TagID:       tag.ID,
+		}).Result(ctx)
+		if err != nil {
+			workflow.GetLogger(ctx).Error("Error creating media item tag relationship",
+				"error", err,
+				"mediaItemID", mediaItemID,
+				"tagId", tag.ID,
+			)
+		}
 	}
 
 	return nil

--- a/workflows/export/vx_export.go
+++ b/workflows/export/vx_export.go
@@ -69,6 +69,47 @@ type VXExportChildWorkflowParams struct {
 	ForceReplaceTranscription bool
 }
 
+// announceExportStarted reports the warnings the export data came with, then that the
+// export started. An export with no clips is announced too rather than refused: the
+// destinations decide what to do about it.
+func announceExportStarted(ctx workflow.Context, chat telegram.Chat, params VXExportParams, data *vidispine.ExportData) {
+	for _, warning := range data.Warnings {
+		wfutils.SendTelegramText(ctx, chat,
+			fmt.Sprintf("Warning during export of `%s`:\n%s", params.VXID, warning))
+	}
+
+	destinations := strings.Join(params.Destinations, ", ")
+	runID := workflow.GetInfo(ctx).OriginalRunID
+
+	if len(data.Clips) == 0 {
+		wfutils.SendTelegramText(ctx, chat,
+			fmt.Sprintf("No clips found for `%s`.\nTitle: `%s`\nDestinations: `%s`\n\nRunID: `%s`",
+				params.VXID, data.Title, destinations, runID))
+	}
+
+	wfutils.SendTelegramText(ctx, chat,
+		fmt.Sprintf("🟦 Export of `%s` started.\nTitle: `%s`\nDestinations: `%s`\n\nRunID: `%s`",
+			params.VXID, data.Title, destinations, runID))
+}
+
+func createExportFolders(ctx workflow.Context) (tempDir, outputDir, subtitlesDir paths.Path, err error) {
+	tempDir, err = wfutils.GetWorkflowTempFolder(ctx)
+	if err != nil {
+		return
+	}
+
+	outputDir = tempDir.Append("output")
+	err = wfutils.CreateFolder(ctx, outputDir)
+	if err != nil {
+		return
+	}
+
+	subtitlesDir = outputDir.Append("subtitles")
+	err = wfutils.CreateFolder(ctx, subtitlesDir)
+
+	return
+}
+
 // VXExport is the main workflow for exporting assets from vidispine
 // It will create a child workflow for each destination
 func VXExport(ctx workflow.Context, params VXExportParams) ([]wfutils.ResultOrError[VXExportResult], error) {
@@ -104,49 +145,11 @@ func VXExport(ctx workflow.Context, params VXExportParams) ([]wfutils.ResultOrEr
 		return nil, err
 	}
 
-	// Send warnings to Telegram
-	for _, warning := range data.Warnings {
-		wfutils.SendTelegramText(ctx, telegramChat,
-			fmt.Sprintf("Warning during export of `%s`:\n%s", params.VXID, warning))
-	}
-
-	if len(data.Clips) == 0 {
-		wfutils.SendTelegramText(ctx, telegramChat,
-			fmt.Sprintf("No clips found for `%s`.\nTitle: `%s`\nDestinations: `%s`\n\nRunID: `%s`",
-				params.VXID,
-				data.Title,
-				strings.Join(params.Destinations, ", "),
-				workflow.GetInfo(ctx).OriginalRunID,
-			),
-		)
-	}
-
-	wfutils.SendTelegramText(ctx,
-		telegramChat,
-		fmt.Sprintf(
-			"🟦 Export of `%s` started.\nTitle: `%s`\nDestinations: `%s`\n\nRunID: `%s`",
-			params.VXID,
-			data.Title,
-			strings.Join(params.Destinations, ", "),
-			workflow.GetInfo(ctx).OriginalRunID,
-		),
-	)
+	announceExportStarted(ctx, telegramChat, params, data)
 
 	logger.Info("Retrieved data from vidispine")
 
-	tempDir, err := wfutils.GetWorkflowTempFolder(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	outputDir := tempDir.Append("output")
-	err = wfutils.CreateFolder(ctx, outputDir)
-	if err != nil {
-		return nil, err
-	}
-
-	subtitlesOutputDir := outputDir.Append("subtitles")
-	err = wfutils.CreateFolder(ctx, subtitlesOutputDir)
+	tempDir, outputDir, subtitlesOutputDir, err := createExportFolders(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/workflows/export/vx_export_bmm.go
+++ b/workflows/export/vx_export_bmm.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bcc-code/bcc-media-flows/languages"
+	"github.com/bcc-code/bcc-media-flows/paths"
 	"github.com/bcc-code/bcc-media-flows/services/telegram"
 
 	pcommon "github.com/bcc-code/bcc-media-platform/backend/common"
@@ -71,8 +72,6 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 
 	wfutils.SendTelegramText(ctx, telegram.ChatBMM, fmt.Sprintf("🟦 Exporting to BMM - `%s`", params.ExportData.Title))
 
-	normalizedFutures := map[string]workflow.Future{}
-
 	langs, err := wfutils.GetMapKeysSafely(ctx, params.MergeResult.AudioFiles)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get audio file keys: %w", err)
@@ -84,89 +83,19 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 		return nil, fmt.Errorf("failed to create output folder: %w", err)
 	}
 
-	// Normalize audio
-	for _, lang := range langs {
-		audio := params.MergeResult.AudioFiles[lang]
-		future := wfutils.Execute(ctx, activities.Audio.NormalizeAudioActivity, activities.NormalizeAudioParams{
-			FilePath:              audio,
-			TargetLUFS:            targetLufs,
-			PerformOutputAnalysis: true,
-			OutputPath:            params.TempDir,
-		})
-		normalizedFutures[lang] = future.Future
+	normalizedResults, err := normalizeAudioPerLanguage(ctx, params, langs)
+	if err != nil {
+		return nil, err
 	}
 
-	normalizedResults := map[string]activities.NormalizeAudioResult{}
-	for _, lang := range langs {
-		future := normalizedFutures[lang]
-		normalizedRes := activities.NormalizeAudioResult{}
-		err := future.Get(ctx, &normalizedRes)
-		if err != nil {
-			return nil, fmt.Errorf("failed to normalize audio for language %s: %w", lang, err)
-		}
-
-		logger.Debug("Normalized audio for language", lang, normalizedRes)
-		normalizedResults[lang] = normalizedRes
-		params.MergeResult.AudioFiles[lang] = normalizedRes.FilePath
+	audioResults, err := encodeAudioPerLanguage(ctx, params, langs, normalizedResults)
+	if err != nil {
+		return nil, err
 	}
 
-	// Encode to AAC and MP3
-	encodingFutures := map[string][]workflow.Future{}
-	for _, lang := range langs {
-		audio := normalizedResults[lang]
-		var encodings []workflow.Future
-		for _, bitrate := range aacBitrates {
-			f := wfutils.Execute(ctx, activities.Audio.TranscodeToAudioAac, common.AudioInput{
-				Path:            audio.FilePath,
-				DestinationPath: params.OutputDir,
-				Bitrate:         bitrate,
-			})
-			encodings = append(encodings, f.Future)
-		}
-
-		for _, bitrate := range mp3Bitrates {
-			f := wfutils.Execute(ctx, activities.Audio.TranscodeToAudioMP3, common.AudioInput{
-				Path:            audio.FilePath,
-				DestinationPath: params.OutputDir,
-				Bitrate:         bitrate,
-				ForceCBR:        true,
-			})
-			encodings = append(encodings, f.Future)
-		}
-
-		encodingFutures[lang] = encodings
-	}
-
-	audioResults := map[string][]common.AudioResult{}
-	for _, lang := range langs {
-		futures := encodingFutures[lang]
-		var encodings []common.AudioResult
-		for _, future := range futures {
-			var res common.AudioResult
-			err := future.Get(ctx, &res)
-			if err != nil {
-				return nil, fmt.Errorf("failed to transcode audio for language %s: %w", lang, err)
-			}
-			encodings = append(encodings, res)
-		}
-
-		audioResults[lang] = encodings
-	}
-
-	{
-		// Move the transcription files to the output folder
-		keys, err := wfutils.GetMapKeysSafely(ctx, params.MergeResult.JSONTranscript)
-		if err != nil {
-			return nil, err
-		}
-		for _, lang := range keys {
-			p := params.MergeResult.JSONTranscript[lang]
-
-			err = wfutils.MoveFile(ctx, p, params.OutputDir.Append(p.Base()), rclone.PriorityNormal)
-			if err != nil {
-				return nil, err
-			}
-		}
+	err = moveTranscriptsToOutput(ctx, params)
+	if err != nil {
+		return nil, err
 	}
 
 	var chapters []asset.TimedMetadata
@@ -214,6 +143,106 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	}, nil
 }
 
+// normalizeAudioPerLanguage schedules every language before waiting on any of them, so
+// they normalize in parallel. It rewrites params.MergeResult.AudioFiles to the
+// normalized copies, which the map being shared makes visible to the caller.
+func normalizeAudioPerLanguage(ctx workflow.Context, params VXExportChildWorkflowParams, langs []string) (map[string]activities.NormalizeAudioResult, error) {
+	logger := workflow.GetLogger(ctx)
+
+	futures := map[string]workflow.Future{}
+	for _, lang := range langs {
+		futures[lang] = wfutils.Execute(ctx, activities.Audio.NormalizeAudioActivity, activities.NormalizeAudioParams{
+			FilePath:              params.MergeResult.AudioFiles[lang],
+			TargetLUFS:            targetLufs,
+			PerformOutputAnalysis: true,
+			OutputPath:            params.TempDir,
+		}).Future
+	}
+
+	results := map[string]activities.NormalizeAudioResult{}
+	for _, lang := range langs {
+		result := activities.NormalizeAudioResult{}
+		err := futures[lang].Get(ctx, &result)
+		if err != nil {
+			return nil, fmt.Errorf("failed to normalize audio for language %s: %w", lang, err)
+		}
+
+		logger.Debug("Normalized audio for language", lang, result)
+		results[lang] = result
+		params.MergeResult.AudioFiles[lang] = result.FilePath
+	}
+
+	return results, nil
+}
+
+func encodeAudioPerLanguage(
+	ctx workflow.Context,
+	params VXExportChildWorkflowParams,
+	langs []string,
+	normalized map[string]activities.NormalizeAudioResult,
+) (map[string][]common.AudioResult, error) {
+	futures := map[string][]workflow.Future{}
+	for _, lang := range langs {
+		audio := normalized[lang]
+
+		var encodings []workflow.Future
+		for _, bitrate := range aacBitrates {
+			encodings = append(encodings, wfutils.Execute(ctx, activities.Audio.TranscodeToAudioAac, common.AudioInput{
+				Path:            audio.FilePath,
+				DestinationPath: params.OutputDir,
+				Bitrate:         bitrate,
+			}).Future)
+		}
+
+		for _, bitrate := range mp3Bitrates {
+			encodings = append(encodings, wfutils.Execute(ctx, activities.Audio.TranscodeToAudioMP3, common.AudioInput{
+				Path:            audio.FilePath,
+				DestinationPath: params.OutputDir,
+				Bitrate:         bitrate,
+				ForceCBR:        true,
+			}).Future)
+		}
+
+		futures[lang] = encodings
+	}
+
+	results := map[string][]common.AudioResult{}
+	for _, lang := range langs {
+		var encodings []common.AudioResult
+		for _, future := range futures[lang] {
+			var res common.AudioResult
+			err := future.Get(ctx, &res)
+			if err != nil {
+				return nil, fmt.Errorf("failed to transcode audio for language %s: %w", lang, err)
+			}
+
+			encodings = append(encodings, res)
+		}
+
+		results[lang] = encodings
+	}
+
+	return results, nil
+}
+
+func moveTranscriptsToOutput(ctx workflow.Context, params VXExportChildWorkflowParams) error {
+	langs, err := wfutils.GetMapKeysSafely(ctx, params.MergeResult.JSONTranscript)
+	if err != nil {
+		return err
+	}
+
+	for _, lang := range langs {
+		transcript := params.MergeResult.JSONTranscript[lang]
+
+		err = wfutils.MoveFile(ctx, transcript, params.OutputDir.Append(transcript.Base()), rclone.PriorityNormal)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func makeBMMJSON(
 	ctx workflow.Context,
 	params VXExportChildWorkflowParams,
@@ -225,6 +254,7 @@ func makeBMMJSON(
 
 	// Prepare data for the JSON file
 	jsonData := prepareBMMData(ctx, audioResults, normalizedResults)
+	var err error
 	jsonData.Length = int(params.MergeResult.Duration)
 	jsonData.MediabankenID = fmt.Sprintf("%s-%s", params.ParentParams.VXID, HashTitle(params.ExportData.Title))
 	jsonData.ImportDate = params.ExportData.ImportDate
@@ -236,55 +266,18 @@ func makeBMMJSON(
 	}
 	jsonData.TrackID = params.ExportData.BmmTrackID
 
-	langs, _ := wfutils.GetMapKeysSafely(ctx, params.MergeResult.JSONTranscript)
-	for _, lang := range langs {
-		bmmTextLang := lang
-
-		// The text languages are mapped with two letter codes so we need to convert to code
-		// in order to be uniform with the audio languages
-		if val, ok := languages.LanguagesByISOTwoLetter[lang]; ok {
-			bmmTextLang = val.ISO6391
-		}
-
-		// skip broken transcriptions
-		if _, skip := brokenTranscription[bmmTextLang]; skip {
-			continue
-		}
-
-		transcript := params.MergeResult.JSONTranscript[lang]
-		jsonData.TranscriptionFiles[bmmTextLang] = transcript.Base()
+	jsonData.TranscriptionFiles, err = bmmTranscriptionFiles(ctx, params.MergeResult.JSONTranscript)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(chapters) > 0 {
-		chapter := chapters[0]
-		for _, p := range chapter.Persons {
-			if !lo.Contains(jsonData.PersonsAppearing, p) {
-				jsonData.PersonsAppearing = append(jsonData.PersonsAppearing, p)
-			}
-		}
-
-		d := workflow.Now(ctx).Truncate(time.Hour * 6)
+		recordedBase := workflow.Now(ctx).Truncate(time.Hour * 6)
 		if params.ExportData.ImportDate != nil {
-			d = *params.ExportData.ImportDate
-		}
-		chaperRecordedAt := d.Add(time.Duration(chapter.Timestamp * float64(time.Second)))
-		jsonData.RecordedAt = &chaperRecordedAt
-
-		jsonData.StartsAt = chapter.Timestamp
-		jsonData.Type = chapter.ContentType
-
-		if chapter.SongNumber != "" && chapter.SongCollection != "" {
-			jsonData.SongCollection = &chapter.SongCollection
-			jsonData.SongNumber = &chapter.SongNumber
+			recordedBase = *params.ExportData.ImportDate
 		}
 
-		if chapter.ContentType == pcommon.ContentTypeSong.Value && chapter.SongCollection == "" {
-			jsonData.Title = chapter.Title
-		}
-
-		if len(jsonData.PersonsAppearing) == 0 && jsonData.SongNumber == nil && jsonData.Title == "" {
-			jsonData.Title = chapter.Title
-		}
+		applyChapterToBMMData(&jsonData, chapters[0], recordedBase)
 	}
 
 	if len(jsonData.PersonsAppearing) == 0 && jsonData.SongNumber == nil && jsonData.Title == "" {
@@ -293,6 +286,58 @@ func makeBMMJSON(
 	}
 
 	return wfutils.MarshalJson(ctx, jsonData)
+}
+
+// bmmTranscriptionFiles keys the transcripts by the same language codes as the audio,
+// which BMM needs, and drops the ones known to be broken.
+func bmmTranscriptionFiles(ctx workflow.Context, transcripts map[string]paths.Path) (map[string]string, error) {
+	langs, err := wfutils.GetMapKeysSafely(ctx, transcripts)
+	if err != nil {
+		return nil, err
+	}
+
+	files := map[string]string{}
+	for _, lang := range langs {
+		bmmLang := lang
+		if val, ok := languages.LanguagesByISOTwoLetter[lang]; ok {
+			bmmLang = val.ISO6391
+		}
+
+		if _, skip := brokenTranscription[bmmLang]; skip {
+			continue
+		}
+
+		files[bmmLang] = transcripts[lang].Base()
+	}
+
+	return files, nil
+}
+
+func applyChapterToBMMData(data *BMMData, chapter asset.TimedMetadata, recordedBase time.Time) {
+	for _, p := range chapter.Persons {
+		if !lo.Contains(data.PersonsAppearing, p) {
+			data.PersonsAppearing = append(data.PersonsAppearing, p)
+		}
+	}
+
+	recordedAt := recordedBase.Add(time.Duration(chapter.Timestamp * float64(time.Second)))
+	data.RecordedAt = &recordedAt
+
+	data.StartsAt = chapter.Timestamp
+	data.Type = chapter.ContentType
+
+	if chapter.SongNumber != "" && chapter.SongCollection != "" {
+		data.SongCollection = &chapter.SongCollection
+		data.SongNumber = &chapter.SongNumber
+	}
+
+	if chapter.ContentType == pcommon.ContentTypeSong.Value && chapter.SongCollection == "" {
+		data.Title = chapter.Title
+	}
+
+	if len(data.PersonsAppearing) == 0 && data.SongNumber == nil && data.Title == "" {
+		data.Title = chapter.Title
+	}
 }
 
 type BMMData struct {

--- a/workflows/export/vx_export_bmm.go
+++ b/workflows/export/vx_export_bmm.go
@@ -254,11 +254,9 @@ func makeBMMJSON(
 
 	// Prepare data for the JSON file
 	jsonData := prepareBMMData(ctx, audioResults, normalizedResults)
-	var err error
 	jsonData.Length = int(params.MergeResult.Duration)
 	jsonData.MediabankenID = fmt.Sprintf("%s-%s", params.ParentParams.VXID, HashTitle(params.ExportData.Title))
 	jsonData.ImportDate = params.ExportData.ImportDate
-	jsonData.TranscriptionFiles = map[string]string{}
 	jsonData.ForceReplaceTranscription = params.ForceReplaceTranscription
 
 	if params.ExportData.BmmTitle != nil && *params.ExportData.BmmTitle != "" {
@@ -266,10 +264,7 @@ func makeBMMJSON(
 	}
 	jsonData.TrackID = params.ExportData.BmmTrackID
 
-	jsonData.TranscriptionFiles, err = bmmTranscriptionFiles(ctx, params.MergeResult.JSONTranscript)
-	if err != nil {
-		return nil, err
-	}
+	jsonData.TranscriptionFiles = bmmTranscriptionFiles(ctx, params.MergeResult.JSONTranscript)
 
 	if len(chapters) > 0 {
 		recordedBase := workflow.Now(ctx).Truncate(time.Hour * 6)
@@ -290,11 +285,11 @@ func makeBMMJSON(
 
 // bmmTranscriptionFiles keys the transcripts by the same language codes as the audio,
 // which BMM needs, and drops the ones known to be broken.
-func bmmTranscriptionFiles(ctx workflow.Context, transcripts map[string]paths.Path) (map[string]string, error) {
-	langs, err := wfutils.GetMapKeysSafely(ctx, transcripts)
-	if err != nil {
-		return nil, err
-	}
+//
+// Nothing here fails the export. A missing transcription costs a transcription and
+// nothing else, and an episode without one is still an episode people can listen to.
+func bmmTranscriptionFiles(ctx workflow.Context, transcripts map[string]paths.Path) map[string]string {
+	langs, _ := wfutils.GetMapKeysSafely(ctx, transcripts)
 
 	files := map[string]string{}
 	for _, lang := range langs {
@@ -310,7 +305,7 @@ func bmmTranscriptionFiles(ctx workflow.Context, transcripts map[string]paths.Pa
 		files[bmmLang] = transcripts[lang].Base()
 	}
 
-	return files, nil
+	return files
 }
 
 func applyChapterToBMMData(data *BMMData, chapter asset.TimedMetadata, recordedBase time.Time) {

--- a/workflows/export/vx_export_bmm_sequence_test.go
+++ b/workflows/export/vx_export_bmm_sequence_test.go
@@ -1,0 +1,100 @@
+package export
+
+import (
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/activities"
+	platform_activities "github.com/bcc-code/bcc-media-flows/activities/platform"
+	"github.com/bcc-code/bcc-media-flows/common"
+	"github.com/bcc-code/bcc-media-flows/paths"
+	"github.com/bcc-code/bcc-media-platform/backend/asset"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/testsuite"
+)
+
+// BMMSequenceTestSuite records the order VXExportToBMM schedules its activities in.
+// Extracting helpers does not change a workflow's history, but reordering while
+// moving code does, and that breaks replay for anything in flight.
+type BMMSequenceTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+}
+
+func (s *BMMSequenceTestSuite) Test_ActivityOrder() {
+	env := s.NewTestWorkflowEnvironment()
+
+	var calls []string
+	record := func(name string) func(mock.Arguments) {
+		return func(mock.Arguments) { calls = append(calls, name) }
+	}
+
+	env.OnActivity(activities.Util.SendTelegramMessage, mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+	env.OnActivity(activities.Util.CreateFolder, mock.Anything, mock.Anything).
+		Run(record("CreateFolder")).Return(nil, nil)
+	env.OnActivity(activities.Audio.NormalizeAudioActivity, mock.Anything, mock.Anything).
+		Run(record("Normalize")).Return(&activities.NormalizeAudioResult{
+		FilePath: paths.MustParse("/mnt/temp/normalized.wav"),
+	}, nil)
+	env.OnActivity(activities.Audio.TranscodeToAudioAac, mock.Anything, mock.Anything).
+		Run(record("Aac")).Return(&common.AudioResult{
+		OutputPath: paths.MustParse("/mnt/temp/out.aac"),
+		Format:     "aac",
+	}, nil)
+	env.OnActivity(activities.Audio.TranscodeToAudioMP3, mock.Anything, mock.Anything).
+		Run(record("Mp3")).Return(&common.AudioResult{
+		OutputPath: paths.MustParse("/mnt/temp/out.mp3"),
+		Format:     "mp3",
+	}, nil)
+	env.OnActivity(activities.Util.MoveFile, mock.Anything, mock.Anything).
+		Run(record("MoveTranscript")).Return(nil, nil)
+	env.OnActivity(activities.Util.RcloneWaitForJob, mock.Anything, mock.Anything).Maybe().Return(true, nil)
+	env.OnActivity(activities.Platform.GetTimedMetadataChaptersActivity, mock.Anything, mock.Anything).
+		Run(record("Chapters")).Return([]asset.TimedMetadata{}, nil)
+	env.OnActivity(activities.Util.WriteFile, mock.Anything, mock.Anything).
+		Run(record("WriteJSON")).Return(nil, nil)
+	env.OnActivity(activities.Util.RcloneCopyDir, mock.Anything, mock.Anything).
+		Run(record("CopyDir")).Return(1, nil)
+	env.OnActivity(activities.Util.TriggerBMMImport, mock.Anything, mock.Anything).
+		Run(record("TriggerImport")).Return(true, nil)
+
+	params := VXExportChildWorkflowParams{
+		ParentParams:      VXExportParams{VXID: "VX-1"},
+		ExportDestination: AssetExportDestinationBMM,
+		TempDir:           paths.MustParse("/mnt/temp/workflows"),
+		OutputDir:         paths.MustParse("/mnt/temp/workflows/output"),
+		MergeResult: MergeExportDataResult{
+			AudioFiles:     map[string]paths.Path{"nor": paths.MustParse("/mnt/temp/nor.wav")},
+			JSONTranscript: map[string]paths.Path{"no": paths.MustParse("/mnt/temp/no.json")},
+		},
+	}
+
+	env.ExecuteWorkflow(VXExportToBMM, params)
+	require.True(s.T(), env.IsWorkflowCompleted())
+	require.NoError(s.T(), env.GetWorkflowError())
+
+	encodes := len(aacBitrates) + len(mp3Bitrates)
+	require.Len(s.T(), calls, 2+encodes+5)
+
+	// The encodes are scheduled together and run in whatever order the worker gets
+	// to them, so only their phase and their number are fixed.
+	assert.Equal(s.T(), []string{"CreateFolder", "Normalize"}, calls[:2],
+		"the output folder exists before anything writes into it")
+
+	batch := calls[2 : 2+encodes]
+	assert.Equal(s.T(), len(aacBitrates), lo.Count(batch, "Aac"))
+	assert.Equal(s.T(), len(mp3Bitrates), lo.Count(batch, "Mp3"))
+
+	assert.Equal(s.T(), []string{
+		"MoveTranscript", "Chapters", "WriteJSON", "CopyDir", "TriggerImport",
+	}, calls[2+encodes:], "everything after the encodes is strictly sequential")
+}
+
+func TestBMMSequence(t *testing.T) {
+	suite.Run(t, new(BMMSequenceTestSuite))
+}
+
+var _ = platform_activities.GetTimedMetadataChaptersParams{}

--- a/workflows/export/vx_export_vod.go
+++ b/workflows/export/vx_export_vod.go
@@ -42,25 +42,9 @@ func VXExportToVOD(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 		}).Future
 	}
 
-	{
-		keys, err := wfutils.GetMapKeysSafely(ctx, params.MergeResult.SubtitleFiles)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, key := range keys {
-
-			if key == "und" && !params.ParentParams.SubsAllowAI {
-				// Skip AI generated if not allowed
-				continue
-			}
-
-			subtitle := params.MergeResult.SubtitleFiles[key]
-			err = wfutils.CopyFile(ctx, subtitle, params.OutputDir.Append(subtitle.Base()))
-			if err != nil {
-				return nil, err
-			}
-		}
+	err := copySubtitlesToOutput(ctx, params)
+	if err != nil {
+		return nil, err
 	}
 
 	audioFiles, err := prepareAudioFiles(ctx, params.MergeResult, params.TempDir, true, params.ParentParams.IgnoreSilence)
@@ -78,57 +62,9 @@ func VXExportToVOD(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 		wm = &path
 	}
 
-	// Determine base video source: if none from merge, generate using vizualizer
-	var baseVideo paths.Path
-	primaryMediaType := "video"
-	if params.MergeResult.VideoFile == nil {
-		primaryMediaType = "audio"
-		// pick an audio to visualize: prefer original language, else any available
-		chosenLang := params.ExportData.OriginalLanguage
-		if chosenLang == "" || audioFiles[chosenLang].Path == "" {
-			if len(audioKeys) == 0 {
-				return nil, fmt.Errorf("no audio available to generate visualization video")
-			}
-			chosenLang = audioKeys[0]
-		}
-		audioPath := audioFiles[chosenLang]
-
-		// decide render size based on the largest requested resolution
-		maxW, maxH := 1920, 1080
-		for _, r := range params.ParentParams.Resolutions {
-			if r.Width*r.Height > maxW*maxH {
-				maxW, maxH = r.Width, r.Height
-			}
-		}
-
-		outPath := params.TempDir.Append("viz_source.mp4")
-
-		// submit job
-		jobID, err := wfutils.Execute(ctx, activities.Vizualizer.SubmitVisualization, activities.SubmitVisualizationArgs{
-			AudioPath:    audioPath,
-			OutputPath:   outPath,
-			Width:        maxW,
-			Height:       maxH,
-			FPS:          50,
-			IncludeAudio: false,
-		}).Result(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("submit vizualizer job: %w", err)
-		}
-
-		// wait for completion
-		_, err = wfutils.Execute(ctx, activities.Vizualizer.WaitForVisualization, activities.WaitForVisualizationArgs{
-			JobID:        jobID,
-			PollInterval: 5 * time.Second,
-			Timeout:      2 * time.Hour,
-		}).Result(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("vizualizer job failed: %w", err)
-		}
-
-		baseVideo = outPath
-	} else {
-		baseVideo = *params.MergeResult.VideoFile
+	baseVideo, primaryMediaType, err := baseVideoForVOD(ctx, params, audioFiles, audioKeys)
+	if err != nil {
+		return nil, err
 	}
 
 	service := &vxExportVodService{
@@ -202,6 +138,84 @@ func VXExportToVOD(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 		params.OutputDir,
 		primaryMediaType,
 	)
+}
+
+func copySubtitlesToOutput(ctx workflow.Context, params VXExportChildWorkflowParams) error {
+	langs, err := wfutils.GetMapKeysSafely(ctx, params.MergeResult.SubtitleFiles)
+	if err != nil {
+		return err
+	}
+
+	for _, lang := range langs {
+		if lang == "und" && !params.ParentParams.SubsAllowAI {
+			// "und" is the AI generated one.
+			continue
+		}
+
+		subtitle := params.MergeResult.SubtitleFiles[lang]
+		err = wfutils.CopyFile(ctx, subtitle, params.OutputDir.Append(subtitle.Base()))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// baseVideoForVOD is the video every rendition is derived from, and what kind of media
+// this export really is. An audio-only export has no video, so one is rendered from the
+// audio instead.
+func baseVideoForVOD(
+	ctx workflow.Context,
+	params VXExportChildWorkflowParams,
+	audioFiles map[string]paths.Path,
+	audioKeys []string,
+) (paths.Path, string, error) {
+	if params.MergeResult.VideoFile != nil {
+		return *params.MergeResult.VideoFile, "video", nil
+	}
+
+	// Prefer the original language, else whatever there is.
+	lang := params.ExportData.OriginalLanguage
+	if lang == "" || audioFiles[lang].Path == "" {
+		if len(audioKeys) == 0 {
+			return paths.Path{}, "", fmt.Errorf("no audio available to generate visualization video")
+		}
+		lang = audioKeys[0]
+	}
+
+	// Render at the largest resolution asked for, so every rendition downscales.
+	width, height := 1920, 1080
+	for _, r := range params.ParentParams.Resolutions {
+		if r.Width*r.Height > width*height {
+			width, height = r.Width, r.Height
+		}
+	}
+
+	outPath := params.TempDir.Append("viz_source.mp4")
+
+	jobID, err := wfutils.Execute(ctx, activities.Vizualizer.SubmitVisualization, activities.SubmitVisualizationArgs{
+		AudioPath:    audioFiles[lang],
+		OutputPath:   outPath,
+		Width:        width,
+		Height:       height,
+		FPS:          50,
+		IncludeAudio: false,
+	}).Result(ctx)
+	if err != nil {
+		return paths.Path{}, "", fmt.Errorf("submit vizualizer job: %w", err)
+	}
+
+	_, err = wfutils.Execute(ctx, activities.Vizualizer.WaitForVisualization, activities.WaitForVisualizationArgs{
+		JobID:        jobID,
+		PollInterval: 5 * time.Second,
+		Timeout:      2 * time.Hour,
+	}).Result(ctx)
+	if err != nil {
+		return paths.Path{}, "", fmt.Errorf("vizualizer job failed: %w", err)
+	}
+
+	return outPath, "audio", nil
 }
 
 func prepareAudioFiles(ctx workflow.Context, mergeResult MergeExportDataResult, tempDir paths.Path, normalizeAudio, ignoreSilence bool) (map[string]paths.Path, error) {

--- a/workflows/ingest/incremental_ingest.go
+++ b/workflows/ingest/incremental_ingest.go
@@ -183,20 +183,7 @@ func doIncremental(ctx workflow.Context, params IncrementalParams) error {
 
 	if len(importAudioFuture) > 0 {
 		wfutils.SendTelegramText(ctx, telegram.ChatOther, "🟩 Audio import finished")
-
-		audioFiles, err := wfutils.Execute(ctx, activities.Vidispine.GetRelatedAudioFiles, videoVXID).Result(ctx)
-		if err != nil {
-			wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟥 Audio/video sync skipped for %s, failed to get related audio files: %v", videoVXID, err))
-		} else if _, ok := audioFiles["nor"]; ok {
-			err = workflow.ExecuteChildWorkflow(ctx, IngestSyncFix, IngestSyncFixParams{
-				VXID: videoVXID,
-			}).Get(ctx, nil)
-			if err != nil {
-				wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟥 Audio/video sync failed for %s: %v", videoVXID, err))
-			}
-		} else {
-			wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟧 Audio/video sync skipped for %s: nor audio not found", videoVXID))
-		}
+		syncAudioToVideo(ctx, videoVXID)
 	}
 
 	err = transcribeFuture.Get(ctx, nil)
@@ -211,6 +198,32 @@ func doIncremental(ctx workflow.Context, params IncrementalParams) error {
 	_ = fixDurationFuture.Get(ctx, nil)
 
 	return nil
+}
+
+// syncAudioToVideo lines the reaper audio up with the video. Every failure here is
+// reported and swallowed: the ingest itself has succeeded by this point, and a sync
+// that did not happen is something an operator fixes rather than a reason to fail.
+func syncAudioToVideo(ctx workflow.Context, videoVXID string) {
+	audioFiles, err := wfutils.Execute(ctx, activities.Vidispine.GetRelatedAudioFiles, videoVXID).Result(ctx)
+	if err != nil {
+		wfutils.SendTelegramText(ctx, telegram.ChatOther,
+			fmt.Sprintf("🟥 Audio/video sync skipped for %s, failed to get related audio files: %v", videoVXID, err))
+		return
+	}
+
+	if _, ok := audioFiles["nor"]; !ok {
+		wfutils.SendTelegramText(ctx, telegram.ChatOther,
+			fmt.Sprintf("🟧 Audio/video sync skipped for %s: nor audio not found", videoVXID))
+		return
+	}
+
+	err = workflow.ExecuteChildWorkflow(ctx, IngestSyncFix, IngestSyncFixParams{
+		VXID: videoVXID,
+	}).Get(ctx, nil)
+	if err != nil {
+		wfutils.SendTelegramText(ctx, telegram.ChatOther,
+			fmt.Sprintf("🟥 Audio/video sync failed for %s: %v", videoVXID, err))
+	}
 }
 
 func createGrowingPlaceholder(ctx workflow.Context, in paths.Path) (string, error) {

--- a/workflows/ingest/incremental_ingest.go
+++ b/workflows/ingest/incremental_ingest.go
@@ -89,36 +89,14 @@ func doIncremental(ctx workflow.Context, params IncrementalParams) error {
 	expectedFilename := in.Base()
 	logger.Info(fmt.Sprintf("Waiting for signal with filename: %s", expectedFilename))
 
-	// Create placeholder in Vidispine
-	var assetResult vsactivity.CreatePlaceholderResult
-	err = wfutils.Execute(ctx, activities.Vidispine.CreatePlaceholderActivity, vsactivity.CreatePlaceholderParams{
-		Title: in.Base(),
-	}).Get(ctx, &assetResult)
+	videoVXID, err := createGrowingPlaceholder(ctx, in)
 	if err != nil {
 		return err
 	}
-	wfutils.UpsertVXID(ctx, assetResult.AssetID)
 
-	err = wfutils.SetVidispineMeta(ctx, assetResult.AssetID, vscommon.FieldIngested.Value, workflow.Now(ctx).Format(time.RFC3339))
-	if err != nil {
-		logger.Error("%w", err)
-	}
+	reaperSessionID := startReaperSession(ctx, params.ReaperSessionID)
 
-	videoVXID := assetResult.AssetID
-
-	// REAPER: Start recording
-	reaperSessionID := params.ReaperSessionID
-
-	if reaperSessionID == "" {
-		err = wfutils.Execute(ctx, activities.Live.StartReaper, nil).Get(ctx, &reaperSessionID)
-		if err != nil {
-			wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟦 Unable to start reaper. Start it manually and notify Matjaz!\n\n```%s```", err.Error()))
-		}
-	} else {
-		wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟦 ASSUMING REAPER SESSION: %s", reaperSessionID))
-	}
-
-	wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟦 Starting live ingest: https://vault.bcc.media/item/%s", assetResult.AssetID))
+	wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟦 Starting live ingest: https://vault.bcc.media/item/%s", videoVXID))
 
 	var jobResult vsactivity.FileJobResult
 	err = wfutils.Execute(ctx, activities.Vidispine.AddFileToPlaceholder, vsactivity.AddFileToPlaceholderParams{
@@ -130,127 +108,15 @@ func doIncremental(ctx workflow.Context, params IncrementalParams) error {
 		return err
 	}
 
-	previewPath, err := wfutils.GetWorkflowAuxOutputFolder(ctx)
-	if err != nil {
-		logger.Error("%w", err)
-	}
+	previewPath, stopPreview := startGrowingPreview(ctx, rawPath, videoVXID)
 
-	previewTempPath, err := wfutils.GetWorkflowTempFolder(ctx)
-	if err != nil {
-		logger.Error("%w", err)
-	}
-	previewTempPath.Append("preview")
+	copyUntilTransferred(ctx, in, rawPath, signalChan, expectedFilename)
 
-	previewPath = previewPath.Append(rawPath.Base()).SetExt("mp4")
-
-	var previewFuture wfutils.Task[any]
-	previewCtx, stopPreviewFunc := workflow.WithCancel(ctx)
-	previewActivityOpts := wfutils.GetDefaultActivityOptions()
-	previewActivityOpts.StartToCloseTimeout = time.Hour * 8
-	previewCtx = workflow.WithActivityOptions(previewCtx, previewActivityOpts)
-
-	workflow.Go(ctx, func(ctx workflow.Context) {
-		_ = workflow.Sleep(ctx, 1*time.Minute)
-		previewFuture = wfutils.Execute(previewCtx, activities.Video.TranscodeGrowingPreview, activities.TranscodeGrowingPreviewParams{
-			OriginalFilePath:    rawPath,
-			DestinationFilePath: previewPath,
-			TempFolderPath:      previewTempPath,
-		})
-
-		_ = workflow.Sleep(ctx, 2*time.Minute)
-		lowresImportJob, importErr := wfutils.Execute(ctx, activities.Vidispine.ImportFileAsShapeActivity, vsactivity.ImportFileAsShapeParams{
-			AssetID:  videoVXID,
-			FilePath: previewPath,
-			ShapeTag: "lowres_watermarked",
-			Growing:  true,
-			Replace:  false,
-		}).Result(ctx)
-		if importErr != nil {
-			// Named separately from the enclosing function's err so the failure cannot
-			// be hidden by a later check reading the wrong variable.
-			logger.Error("Failed to import growing preview as lowres shape", "error", importErr)
-		}
-
-		if previewErr := previewFuture.Wait(ctx); previewErr != nil {
-			logger.Error("Growing preview transcode failed", "error", previewErr)
-		}
-
-		// Only close a file the import actually produced. A failed import leaves
-		// lowresImportJob nil, and dereferencing it panics the workflow task — which
-		// Temporal then retries indefinitely.
-		if lowresImportJob == nil {
-			return
-		}
-
-		if closeErr := wfutils.Execute(ctx, activities.Vidispine.CloseFile, vsactivity.CloseFileParams{
-			FileID: lowresImportJob.FileID,
-		}).Wait(ctx); closeErr != nil {
-			logger.Error("Failed to close growing lowres file", "error", closeErr)
-		}
-	})
-
-	signalReceived := false
-
-	// Initialize slice to store transfer samples
-	samples := []transferSample{}
-
-	// alertState tracks whether we are currently in alert mode
-	alert := &alertState{}
-
-	// Keep copying the file until we receive a signal or the copy process completes naturally
-	maxCopyAttempts := 1000 // Limit total number of attempts
-
-	for copyAttempt := 0; copyAttempt < maxCopyAttempts; copyAttempt++ {
-		logger.Info(fmt.Sprintf("Starting copy attempt %d", copyAttempt+1))
-
-		copyFuture := wfutils.Execute(ctx, activities.Live.RsyncIncrementalCopy, activities.RsyncIncrementalCopyInput{
-			In:  in,
-			Out: rawPath,
-		})
-
-		copyResult, err := copyFuture.Result(ctx)
-		if err != nil {
-			logger.Error("Copy operation failed", "error", err)
-		} else {
-			sample := transferSample{time: workflow.Now(ctx), bytes: copyResult.Size}
-			samples = append(samples, sample)
-
-			// Use the function to calculate rate and prune samples
-			rate, pruned := CalculateRollingTransferRate(samples, workflow.Now(ctx), windowDuration)
-			samples = pruned
-			checkTransferRateAndAlert(ctx, rate, pruned, alert)
-		}
-
-		// Waiting on the signal and the timer together is what makes the signal
-		// act on arrival. A signal sent while the copy above was running is
-		// already queued on the channel, so this returns without sleeping at all.
-		signalReceived = waitForTransferSignal(ctx, signalChan, expectedFilename, copyRetryInterval)
-
-		if signalReceived {
-			logger.Info("Received signal, breaking out of copy loop")
-			break
-		}
-	}
-
-	// The copy at the top of the loop ran before the signal, so whatever was
-	// written to the source in between is not here yet.
-	if signalReceived {
-		logger.Info("Copying once more now that the source is complete")
-		if _, copyErr := wfutils.Execute(ctx, activities.Live.RsyncIncrementalCopy, activities.RsyncIncrementalCopyInput{
-			In:  in,
-			Out: rawPath,
-		}).Result(ctx); copyErr != nil {
-			logger.Error("Final copy failed", "error", copyErr)
-			wfutils.SendTelegramText(ctx, telegram.ChatOther,
-				fmt.Sprintf("🟥 The final copy of %s failed, the ingested file may be short: %v", in.Base(), copyErr))
-		}
-	}
-
-	wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟦 Video ingest ended: https://vault.bcc.media/item/%s\n\nImporting reaper files.", assetResult.AssetID))
+	wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟦 Video ingest ended: https://vault.bcc.media/item/%s\n\nImporting reaper files.", videoVXID))
 
 	waitForPreviewToCatchUp(ctx, rawPath, previewPath)
 
-	stopPreviewFunc()
+	stopPreview()
 
 	reaperResult, err := listReaperFiles(ctx, reaperSessionID, videoVXID)
 	if err != nil {
@@ -345,6 +211,167 @@ func doIncremental(ctx workflow.Context, params IncrementalParams) error {
 	_ = fixDurationFuture.Get(ctx, nil)
 
 	return nil
+}
+
+func createGrowingPlaceholder(ctx workflow.Context, in paths.Path) (string, error) {
+	logger := workflow.GetLogger(ctx)
+
+	var assetResult vsactivity.CreatePlaceholderResult
+	err := wfutils.Execute(ctx, activities.Vidispine.CreatePlaceholderActivity, vsactivity.CreatePlaceholderParams{
+		Title: in.Base(),
+	}).Get(ctx, &assetResult)
+	if err != nil {
+		return "", err
+	}
+
+	wfutils.UpsertVXID(ctx, assetResult.AssetID)
+
+	err = wfutils.SetVidispineMeta(ctx, assetResult.AssetID, vscommon.FieldIngested.Value, workflow.Now(ctx).Format(time.RFC3339))
+	if err != nil {
+		logger.Error("%w", err)
+	}
+
+	return assetResult.AssetID, nil
+}
+
+// startReaperSession returns the session to take audio from. A failure to start one is
+// reported and not fatal: the video ingest is worth finishing without the audio.
+func startReaperSession(ctx workflow.Context, existing string) string {
+	if existing != "" {
+		wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟦 ASSUMING REAPER SESSION: %s", existing))
+		return existing
+	}
+
+	sessionID := ""
+	err := wfutils.Execute(ctx, activities.Live.StartReaper, nil).Get(ctx, &sessionID)
+	if err != nil {
+		wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟦 Unable to start reaper. Start it manually and notify Matjaz!\n\n```%s```", err.Error()))
+	}
+
+	return sessionID
+}
+
+// startGrowingPreview transcodes a preview alongside the ingest and imports it as the
+// lowres shape, so the item is watchable while the source is still arriving. It returns
+// where the preview is written and the cancel that stops the transcode.
+func startGrowingPreview(ctx workflow.Context, rawPath paths.Path, videoVXID string) (paths.Path, func()) {
+	logger := workflow.GetLogger(ctx)
+
+	previewPath, err := wfutils.GetWorkflowAuxOutputFolder(ctx)
+	if err != nil {
+		logger.Error("%w", err)
+	}
+
+	previewTempPath, err := wfutils.GetWorkflowTempFolder(ctx)
+	if err != nil {
+		logger.Error("%w", err)
+	}
+	previewTempPath.Append("preview")
+
+	previewPath = previewPath.Append(rawPath.Base()).SetExt("mp4")
+
+	var previewFuture wfutils.Task[any]
+	previewCtx, stopPreview := workflow.WithCancel(ctx)
+	previewActivityOpts := wfutils.GetDefaultActivityOptions()
+	previewActivityOpts.StartToCloseTimeout = time.Hour * 8
+	previewCtx = workflow.WithActivityOptions(previewCtx, previewActivityOpts)
+
+	workflow.Go(ctx, func(ctx workflow.Context) {
+		_ = workflow.Sleep(ctx, 1*time.Minute)
+		previewFuture = wfutils.Execute(previewCtx, activities.Video.TranscodeGrowingPreview, activities.TranscodeGrowingPreviewParams{
+			OriginalFilePath:    rawPath,
+			DestinationFilePath: previewPath,
+			TempFolderPath:      previewTempPath,
+		})
+
+		_ = workflow.Sleep(ctx, 2*time.Minute)
+		lowresImportJob, importErr := wfutils.Execute(ctx, activities.Vidispine.ImportFileAsShapeActivity, vsactivity.ImportFileAsShapeParams{
+			AssetID:  videoVXID,
+			FilePath: previewPath,
+			ShapeTag: "lowres_watermarked",
+			Growing:  true,
+			Replace:  false,
+		}).Result(ctx)
+		if importErr != nil {
+			// Named separately from the enclosing function's err so the failure cannot
+			// be hidden by a later check reading the wrong variable.
+			logger.Error("Failed to import growing preview as lowres shape", "error", importErr)
+		}
+
+		if previewErr := previewFuture.Wait(ctx); previewErr != nil {
+			logger.Error("Growing preview transcode failed", "error", previewErr)
+		}
+
+		// Only close a file the import actually produced. A failed import leaves
+		// lowresImportJob nil, and dereferencing it panics the workflow task — which
+		// Temporal then retries indefinitely.
+		if lowresImportJob == nil {
+			return
+		}
+
+		if closeErr := wfutils.Execute(ctx, activities.Vidispine.CloseFile, vsactivity.CloseFileParams{
+			FileID: lowresImportJob.FileID,
+		}).Wait(ctx); closeErr != nil {
+			logger.Error("Failed to close growing lowres file", "error", closeErr)
+		}
+	})
+
+	return previewPath, stopPreview
+}
+
+// copyUntilTransferred copies the growing source until the watcher signals that the
+// transfer finished, then copies once more: the last copy ran before the signal, so
+// whatever was written in between is not here yet.
+func copyUntilTransferred(ctx workflow.Context, in, rawPath paths.Path, signalChan workflow.ReceiveChannel, expectedFilename string) {
+	logger := workflow.GetLogger(ctx)
+
+	samples := []transferSample{}
+	alert := &alertState{}
+	signalReceived := false
+
+	const maxCopyAttempts = 1000
+
+	for copyAttempt := 0; copyAttempt < maxCopyAttempts; copyAttempt++ {
+		logger.Info(fmt.Sprintf("Starting copy attempt %d", copyAttempt+1))
+
+		copyResult, err := wfutils.Execute(ctx, activities.Live.RsyncIncrementalCopy, activities.RsyncIncrementalCopyInput{
+			In:  in,
+			Out: rawPath,
+		}).Result(ctx)
+		if err != nil {
+			logger.Error("Copy operation failed", "error", err)
+		} else {
+			samples = append(samples, transferSample{time: workflow.Now(ctx), bytes: copyResult.Size})
+
+			rate, pruned := CalculateRollingTransferRate(samples, workflow.Now(ctx), windowDuration)
+			samples = pruned
+			checkTransferRateAndAlert(ctx, rate, pruned, alert)
+		}
+
+		// Waiting on the signal and the timer together is what makes the signal
+		// act on arrival. A signal sent while the copy above was running is
+		// already queued on the channel, so this returns without sleeping at all.
+		signalReceived = waitForTransferSignal(ctx, signalChan, expectedFilename, copyRetryInterval)
+
+		if signalReceived {
+			logger.Info("Received signal, breaking out of copy loop")
+			break
+		}
+	}
+
+	if !signalReceived {
+		return
+	}
+
+	logger.Info("Copying once more now that the source is complete")
+	if _, copyErr := wfutils.Execute(ctx, activities.Live.RsyncIncrementalCopy, activities.RsyncIncrementalCopyInput{
+		In:  in,
+		Out: rawPath,
+	}).Result(ctx); copyErr != nil {
+		logger.Error("Final copy failed", "error", copyErr)
+		wfutils.SendTelegramText(ctx, telegram.ChatOther,
+			fmt.Sprintf("🟥 The final copy of %s failed, the ingested file may be short: %v", in.Base(), copyErr))
+	}
 }
 
 const (

--- a/workflows/ingest/incremental_sequence_test.go
+++ b/workflows/ingest/incremental_sequence_test.go
@@ -1,0 +1,55 @@
+package ingestworkflows
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/activities"
+	"github.com/bcc-code/bcc-media-flows/services/ffmpeg"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
+)
+
+// mainPath are the activities only doIncremental itself schedules. The preview
+// coroutine runs alongside it, so anything it touches — TranscodeGrowingPreview,
+// ImportFileAsShape, CloseFile — interleaves unpredictably and is left out.
+var mainPath = []string{
+	"CreatePlaceholderActivity",
+	"AddFileToPlaceholder",
+	"RsyncIncrementalCopy",
+	"ListReaperFiles",
+	"CreateThumbnailsActivity",
+}
+
+// TestIncrementalMainPathOrder pins the order the ingest does its work in.
+// Extracting helpers does not change a workflow's history; reordering while
+// moving code does, and that breaks replay for an ingest already running.
+func TestIncrementalMainPathOrder(t *testing.T) {
+	env := newIncrementalEnv(t)
+
+	var calls []string
+	env.OnActivity(activities.Audio.AnalyzeFile, mock.Anything, mock.Anything).
+		Return(&ffmpeg.StreamInfo{TotalSeconds: incrementalTestDurationSeconds}, nil).Maybe()
+
+	env.SetOnActivityStartedListener(func(info *activity.Info, _ context.Context, _ converter.EncodedValues) {
+		calls = append(calls, info.ActivityType.Name)
+	})
+
+	runIncremental(t, env)
+
+	got := lo.Filter(calls, func(name string, _ int) bool {
+		return lo.Contains(mainPath, name)
+	})
+
+	assert.Equal(t, []string{
+		"CreatePlaceholderActivity",
+		"AddFileToPlaceholder",
+		"RsyncIncrementalCopy",
+		"RsyncIncrementalCopy",
+		"ListReaperFiles",
+		"CreateThumbnailsActivity",
+	}, got)
+}

--- a/workflows/ingest/masters.go
+++ b/workflows/ingest/masters.go
@@ -251,100 +251,94 @@ func SetUploadJobID(ctx workflow.Context, assetID string, jobID string) error {
 }
 
 func addMetaTags(ctx workflow.Context, assetID string, metadata *ingest.Metadata) error {
-	err := SetUploadedBy(ctx, assetID, metadata.JobProperty.SenderEmail)
+	job := metadata.JobProperty
+
+	err := SetUploadedBy(ctx, assetID, job.SenderEmail)
 	if err != nil {
 		return err
 	}
 
-	err = SetUploadJobID(ctx, assetID, strconv.Itoa(metadata.JobProperty.JobID))
+	err = SetUploadJobID(ctx, assetID, strconv.Itoa(job.JobID))
 	if err != nil {
 		return err
 	}
 
-	if metadata.JobProperty.PersonsAppearing != "" {
-		for _, person := range strings.Split(metadata.JobProperty.PersonsAppearing, ",") {
-			person = strings.TrimSpace(person)
-			if person == "" {
-				continue
-			}
-			err = wfutils.AddVidispineMetaValue(ctx, assetID, vscommon.FieldPersonsAppearing.Value, person)
-			if err != nil {
-				return err
-			}
-		}
+	err = addMetaValues(ctx, assetID, vscommon.FieldPersonsAppearing.Value, job.PersonsAppearing)
+	if err != nil {
+		return err
 	}
 
-	if metadata.JobProperty.Tags != "" {
-		for _, tag := range strings.Split(metadata.JobProperty.Tags, ",") {
-			tag = strings.TrimSpace(tag)
-			if tag == "" {
-				continue
-			}
-			err = wfutils.AddVidispineMetaValue(ctx, assetID, vscommon.FieldGeneralTags.Value, tag)
-			if err != nil {
-				return err
-			}
-		}
+	err = addMetaValues(ctx, assetID, vscommon.FieldGeneralTags.Value, job.Tags)
+	if err != nil {
+		return err
 	}
 
-	if metadata.JobProperty.Language != "" {
-		err = wfutils.SetVidispineMeta(ctx, assetID, vscommon.FieldLanguagesRecorded.Value, metadata.JobProperty.Language)
-		if err != nil {
-			return err
-		}
+	program := programName(job.ProgramID)
+
+	title := job.EpisodeTitle
+	if title != "" && program != "" {
+		title = fmt.Sprintf("%s | %s", program, title)
 	}
 
-	program := ""
-	if metadata.JobProperty.ProgramID != "" {
-		// XML ProgramIDs are formatted "<code> - <program name>"; take the name.
-		// JSON ingest forms provide the program directly with no separator.
-		parts := strings.Split(metadata.JobProperty.ProgramID, " - ")
-		if len(parts) > 1 {
-			program = parts[1]
-		} else {
-			program = parts[0]
-		}
-		if program != "" {
-			err = wfutils.SetVidispineMeta(ctx, assetID, vscommon.FieldProgram.Value, program)
-			if err != nil {
-				return err
-			}
-		}
+	fields := []struct {
+		field string
+		value string
+	}{
+		{vscommon.FieldLanguagesRecorded.Value, job.Language},
+		{vscommon.FieldProgram.Value, program},
+		{vscommon.FieldSeason.Value, job.Season},
+		{vscommon.FieldEpisode.Value, job.Episode},
+		{vscommon.FieldTitle.Value, title},
+		{vscommon.FieldEpisodeDescription.Value, job.EpisodeDescription},
 	}
 
-	if metadata.JobProperty.Season != "" {
-		err = wfutils.SetVidispineMeta(ctx, assetID, vscommon.FieldSeason.Value, metadata.JobProperty.Season)
-		if err != nil {
-			return err
-		}
-	}
-
-	if metadata.JobProperty.Episode != "" {
-		err = wfutils.SetVidispineMeta(ctx, assetID, vscommon.FieldEpisode.Value, metadata.JobProperty.Episode)
-		if err != nil {
-			return err
-		}
-	}
-
-	if metadata.JobProperty.EpisodeTitle != "" {
-		title := metadata.JobProperty.EpisodeTitle
-
-		if program != "" {
-			title = fmt.Sprintf("%s | %s", program, title)
+	for _, f := range fields {
+		if f.value == "" {
+			continue
 		}
 
-		err = wfutils.SetVidispineMeta(ctx, assetID, vscommon.FieldTitle.Value, title)
-		if err != nil {
-			return err
-		}
-	}
-
-	if metadata.JobProperty.EpisodeDescription != "" {
-		err = wfutils.SetVidispineMeta(ctx, assetID, vscommon.FieldEpisodeDescription.Value, metadata.JobProperty.EpisodeDescription)
+		err = wfutils.SetVidispineMeta(ctx, assetID, f.field, f.value)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// addMetaValues adds one value per comma-separated entry, skipping the blanks a
+// trailing or doubled comma leaves behind.
+func addMetaValues(ctx workflow.Context, assetID, field, commaSeparated string) error {
+	if commaSeparated == "" {
+		return nil
+	}
+
+	for _, value := range strings.Split(commaSeparated, ",") {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+
+		err := wfutils.AddVidispineMetaValue(ctx, assetID, field, value)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// programName takes the name out of an XML ProgramID, formatted
+// "<code> - <program name>". JSON ingest forms provide the program directly.
+func programName(programID string) string {
+	if programID == "" {
+		return ""
+	}
+
+	parts := strings.Split(programID, " - ")
+	if len(parts) > 1 {
+		return parts[1]
+	}
+
+	return parts[0]
 }

--- a/workflows/ingest/masters_metatags_test.go
+++ b/workflows/ingest/masters_metatags_test.go
@@ -1,0 +1,126 @@
+package ingestworkflows
+
+import (
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/activities"
+	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
+	"github.com/bcc-code/bcc-media-flows/services/ingest"
+	"github.com/bcc-code/bcc-media-flows/services/vidispine/vscommon"
+	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+type AddMetaTagsTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+}
+
+type metaCall struct {
+	Op    string
+	Key   string
+	Value string
+}
+
+func addMetaTagsWorkflow(ctx workflow.Context, metadata *ingest.Metadata) error {
+	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
+	return addMetaTags(ctx, "VX-1", metadata)
+}
+
+func (s *AddMetaTagsTestSuite) run(metadata *ingest.Metadata) []metaCall {
+	env := s.NewTestWorkflowEnvironment()
+
+	var calls []metaCall
+	record := func(op string) func(mock.Arguments) {
+		return func(args mock.Arguments) {
+			params := args.Get(1).(vsactivity.VXMetadataFieldParams)
+			calls = append(calls, metaCall{Op: op, Key: params.Key, Value: params.Value})
+		}
+	}
+
+	env.OnActivity(activities.Vidispine.SetVXMetadataFieldActivity, mock.Anything, mock.Anything).
+		Run(record("set")).Return(nil, nil)
+	env.OnActivity(activities.Vidispine.AddToVXMetadataFieldActivity, mock.Anything, mock.Anything).
+		Run(record("add")).Return(nil, nil)
+
+	env.ExecuteWorkflow(addMetaTagsWorkflow, metadata)
+	require.True(s.T(), env.IsWorkflowCompleted())
+	require.NoError(s.T(), env.GetWorkflowError())
+
+	return calls
+}
+
+func fullMetadata() *ingest.Metadata {
+	return &ingest.Metadata{
+		JobProperty: ingest.JobProperty{
+			SenderEmail:        "someone@bcc.media",
+			JobID:              42,
+			PersonsAppearing:   "Ada, Grace ,, Alan",
+			Tags:               "news, sport",
+			Language:           "nor",
+			ProgramID:          "BTV - Brunstad TV",
+			Season:             "3",
+			Episode:            "7",
+			EpisodeTitle:       "The Title",
+			EpisodeDescription: "A description",
+		},
+	}
+}
+
+func (s *AddMetaTagsTestSuite) Test_CallOrderAndValues() {
+	calls := s.run(fullMetadata())
+
+	assert.Equal(s.T(), []metaCall{
+		{Op: "set", Key: vscommon.FieldUploadedBy.Value, Value: "someone@bcc.media"},
+		{Op: "set", Key: vscommon.FieldUploadJob.Value, Value: "42"},
+		{Op: "add", Key: vscommon.FieldPersonsAppearing.Value, Value: "Ada"},
+		{Op: "add", Key: vscommon.FieldPersonsAppearing.Value, Value: "Grace"},
+		{Op: "add", Key: vscommon.FieldPersonsAppearing.Value, Value: "Alan"},
+		{Op: "add", Key: vscommon.FieldGeneralTags.Value, Value: "news"},
+		{Op: "add", Key: vscommon.FieldGeneralTags.Value, Value: "sport"},
+		{Op: "set", Key: vscommon.FieldLanguagesRecorded.Value, Value: "nor"},
+		{Op: "set", Key: vscommon.FieldProgram.Value, Value: "Brunstad TV"},
+		{Op: "set", Key: vscommon.FieldSeason.Value, Value: "3"},
+		{Op: "set", Key: vscommon.FieldEpisode.Value, Value: "7"},
+		{Op: "set", Key: vscommon.FieldTitle.Value, Value: "Brunstad TV | The Title"},
+		{Op: "set", Key: vscommon.FieldEpisodeDescription.Value, Value: "A description"},
+	}, calls)
+}
+
+func (s *AddMetaTagsTestSuite) Test_EmptyFieldsAreSkipped() {
+	metadata := &ingest.Metadata{
+		JobProperty: ingest.JobProperty{SenderEmail: "a@b.c", JobID: 1},
+	}
+
+	calls := s.run(metadata)
+
+	s.Len(calls, 2, "only the two unconditional calls")
+}
+
+func (s *AddMetaTagsTestSuite) Test_ProgramIDWithoutSeparatorIsTakenWhole() {
+	metadata := fullMetadata()
+	metadata.JobProperty.ProgramID = "Brunstad TV"
+
+	calls := s.run(metadata)
+
+	s.Contains(calls, metaCall{Op: "set", Key: vscommon.FieldProgram.Value, Value: "Brunstad TV"})
+	s.Contains(calls, metaCall{Op: "set", Key: vscommon.FieldTitle.Value, Value: "Brunstad TV | The Title"})
+}
+
+func (s *AddMetaTagsTestSuite) Test_TitleIsNotPrefixedWithoutAProgram() {
+	metadata := fullMetadata()
+	metadata.JobProperty.ProgramID = ""
+
+	calls := s.run(metadata)
+
+	s.Contains(calls, metaCall{Op: "set", Key: vscommon.FieldTitle.Value, Value: "The Title"})
+}
+
+func TestAddMetaTagsTestSuite(t *testing.T) {
+	suite.Run(t, new(AddMetaTagsTestSuite))
+}

--- a/workflows/ingest/sync_fix.go
+++ b/workflows/ingest/sync_fix.go
@@ -42,62 +42,9 @@ func IngestSyncFix(ctx workflow.Context, params IngestSyncFixParams) error {
 	}
 
 	if params.Adjustment == 0 {
-		wfutils.SendTelegramText(ctx, telegram.ChatVOD, fmt.Sprintf("🟦 `%s`\n\nCalculating automatic adjustments to audio files.", params.VXID))
-		// Attempt to calculate the adjustment automatically
-		shapes, err := wfutils.Execute(ctx, activities.Vidispine.GetShapes, vsactivity.VXOnlyParam{
-			VXID: params.VXID,
-		}).Result(ctx)
-
+		params.Adjustment, err = calculateAudioAdjustment(ctx, params.VXID, audioPaths)
 		if err != nil {
 			return err
-		}
-
-		originalShape := shapes.GetShape("original")
-		if originalShape == nil {
-			return fmt.Errorf("original shape not found")
-		}
-
-		if len(originalShape.AudioComponent) == 0 {
-			return fmt.Errorf("original shape has no audio")
-		}
-
-		originalPath, err := paths.Parse(originalShape.GetPath())
-		if err != nil {
-			return err
-		}
-
-		tempFolder, err := wfutils.GetWorkflowTempFolder(ctx)
-		if err != nil {
-			return err
-		}
-		prepareResult, err := wfutils.Execute(ctx, activities.Audio.PrepareForTranscription, common.AudioInput{
-			Path:            originalPath,
-			DestinationPath: tempFolder,
-		}).Result(ctx)
-		if err != nil {
-			return err
-		}
-
-		if prepareResult.HasAudio {
-			reaperAudioPath := ""
-			if p, ok := audioPaths["nor"]; ok {
-				reaperAudioPath = p.Linux()
-			} else {
-				return fmt.Errorf("nor audio not found")
-			}
-
-			diff, err := wfutils.Execute(ctx, activities.Util.GetAudioDiff, activities.GetAudioDiffParams{
-				ReferenceFile: prepareResult.OutputPath.Linux(),
-				TargetFile:    reaperAudioPath,
-			}).Result(ctx)
-
-			if err != nil {
-				return err
-			}
-
-			params.Adjustment = diff.Difference
-
-			wfutils.SendTelegramText(ctx, telegram.ChatVOD, fmt.Sprintf("🟦 `%s`\n\nAutomatic adjustment calculated: %dms", params.VXID, params.Adjustment))
 		}
 	}
 
@@ -173,4 +120,67 @@ func IngestSyncFix(ctx workflow.Context, params IngestSyncFixParams) error {
 	wfutils.SendTelegramText(ctx, telegram.ChatVOD, fmt.Sprintf("🟩 `%s`\n\nAdjustments applied to audio files.", params.VXID))
 
 	return nil
+}
+
+// calculateAudioAdjustment measures how far the reaper audio drifts from the audio in
+// the original video, so the copies can be shifted by it. A video with no audio to
+// compare against is not an error: the adjustment stays zero and the operator is told
+// nothing was calculated.
+func calculateAudioAdjustment(ctx workflow.Context, vxID string, audioPaths map[string]paths.Path) (int, error) {
+	wfutils.SendTelegramText(ctx, telegram.ChatVOD, fmt.Sprintf("🟦 `%s`\n\nCalculating automatic adjustments to audio files.", vxID))
+
+	shapes, err := wfutils.Execute(ctx, activities.Vidispine.GetShapes, vsactivity.VXOnlyParam{
+		VXID: vxID,
+	}).Result(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	originalShape := shapes.GetShape("original")
+	if originalShape == nil {
+		return 0, fmt.Errorf("original shape not found")
+	}
+
+	if len(originalShape.AudioComponent) == 0 {
+		return 0, fmt.Errorf("original shape has no audio")
+	}
+
+	originalPath, err := paths.Parse(originalShape.GetPath())
+	if err != nil {
+		return 0, err
+	}
+
+	tempFolder, err := wfutils.GetWorkflowTempFolder(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	prepareResult, err := wfutils.Execute(ctx, activities.Audio.PrepareForTranscription, common.AudioInput{
+		Path:            originalPath,
+		DestinationPath: tempFolder,
+	}).Result(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	if !prepareResult.HasAudio {
+		return 0, nil
+	}
+
+	reaperAudio, ok := audioPaths["nor"]
+	if !ok {
+		return 0, fmt.Errorf("nor audio not found")
+	}
+
+	diff, err := wfutils.Execute(ctx, activities.Util.GetAudioDiff, activities.GetAudioDiffParams{
+		ReferenceFile: prepareResult.OutputPath.Linux(),
+		TargetFile:    reaperAudio.Linux(),
+	}).Result(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	wfutils.SendTelegramText(ctx, telegram.ChatVOD, fmt.Sprintf("🟦 `%s`\n\nAutomatic adjustment calculated: %dms", vxID, diff.Difference))
+
+	return diff.Difference, nil
 }

--- a/workflows/misc/masv_import.go
+++ b/workflows/misc/masv_import.go
@@ -92,117 +92,25 @@ func MASVImport(ctx workflow.Context, params MASVImportParams) error {
 		return err
 	}
 
-	var metaFileInfo *rclone.RcloneFile
-	for i := 0; i < 60; i++ {
-
-		files, err := wfutils.RcloneListFiles(ctx, srcFolder)
-		if err != nil {
-			return err
-		}
-
-		for _, file := range files {
-
-			if !strings.HasSuffix(file.Name, "transfer-manifest.json") {
-				continue
-			}
-
-			metaFileInfo = &file
-			break
-		}
-
-		if metaFileInfo != nil {
-			break
-		}
-
-		err = workflow.Sleep(ctx, 30*time.Second)
-	}
-
-	if metaFileInfo == nil {
-		return fmt.Errorf("could not find metadata file for package %s", params.ID)
-	}
-
-	metaRemotePath, err := paths.Parse("s3prod:/" + metaFileInfo.Path)
+	masvMeta, err := waitForTransferManifest(ctx, srcFolder, tmpRoot, params.ID)
 	if err != nil {
 		return err
 	}
 
-	metaFilePath := tmpRoot.Append("manifest.json")
-	err = wfutils.CopyFile(ctx, metaRemotePath, metaFilePath)
+	filesToCopy, church, err := stagePackageFiles(ctx, masvMeta, tmpRoot)
 	if err != nil {
 		return err
 	}
 
-	metaBytes, err := wfutils.ReadFile(ctx, metaFilePath)
+	outputDestination := paths.MustParse("/mnt/isilon/Input/FromMASV").Append(church).Append(params.ID)
+
+	transcodeJobs, err := deliverPackageFiles(ctx, filesToCopy, outputDestination)
 	if err != nil {
 		return err
 	}
 
-	masvMeta := &MASVMetadata{}
-	err = json.Unmarshal(metaBytes, masvMeta)
-	if err != nil {
-		return err
-	}
-
-	var transcodeJobs []wfutils.Task[*activities.EncodeResult]
-	church := "unknown"
-	filesToCopy := []paths.Path{}
-	for _, f := range masvMeta.Package.Files {
-		parsedPath, err := paths.Parse(fmt.Sprintf("s3prod:/massiveio-bccm/%s/%s", f.Path, f.Name))
-		if err != nil {
-			return err
-		}
-
-		err = wfutils.RcloneWaitForFileExists(ctx, parsedPath, 30)
-		if err != nil {
-			return err
-		}
-
-		tempFilePath := tmpRoot.Append(parsedPath.Base())
-		err = wfutils.RcloneCopyFile(ctx, parsedPath, tempFilePath, rclone.PriorityNormal)
-		if err != nil {
-			return err
-		}
-
-		if strings.HasSuffix(tempFilePath.Base(), "metadata.json") {
-			metaBytes, err := wfutils.ReadFile(ctx, tempFilePath)
-			if err != nil {
-				return err
-			}
-
-			metadata := &Metadata{}
-			err = json.Unmarshal(metaBytes, metadata)
-			if err != nil {
-				return err
-			}
-
-			// Sanitize church: keep only a-Z, A-Z, 0-9 and '-' ; replace others with '_'
-			church = churchSanitizer.ReplaceAllString(metadata.Church, "_")
-		}
-
-		filesToCopy = append(filesToCopy, tempFilePath)
-	}
-
-	for _, tempFilePath := range filesToCopy {
-		outputDestination := paths.MustParse("/mnt/isilon/Input/FromMASV").Append(church).Append(params.ID)
-		if lo.Contains([]string{".mov", ".avi", ".mxf", ".mp4"}, tempFilePath.Ext()) {
-			// Transcode to ProRes
-			job := wfutils.Execute(ctx, activities.Video.TranscodeToProResActivity, activities.EncodeParams{
-				FilePath:  tempFilePath,
-				OutputDir: outputDestination,
-			})
-			transcodeJobs = append(transcodeJobs, job)
-			err = wfutils.RcloneCopyFile(ctx, tempFilePath, outputDestination.Append("originals").Append(tempFilePath.Base()), rclone.PriorityNormal)
-		} else {
-			err = wfutils.RcloneCopyFile(ctx, tempFilePath, outputDestination.Append(tempFilePath.Base()), rclone.PriorityNormal)
-		}
-
-		if err != nil {
-			return err
-		}
-	}
-
-	for _, j := range transcodeJobs {
-		err := j.Wait(ctx)
+	for _, job := range transcodeJobs {
+		err = job.Wait(ctx)
 		if err != nil {
 			return err
 		}
@@ -212,4 +120,127 @@ func MASVImport(ctx workflow.Context, params MASVImportParams) error {
 	wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("✅ Copied MASV package '%s' to %s", params.Name, dst.Rclone()))
 
 	return nil
+}
+
+// waitForTransferManifest polls the upload folder for up to half an hour: MASV reports
+// the package finalized before the manifest has necessarily landed.
+func waitForTransferManifest(ctx workflow.Context, srcFolder, tmpRoot paths.Path, packageID string) (*MASVMetadata, error) {
+	var manifest *rclone.RcloneFile
+
+	for i := 0; i < 60 && manifest == nil; i++ {
+		files, err := wfutils.RcloneListFiles(ctx, srcFolder)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, file := range files {
+			if strings.HasSuffix(file.Name, "transfer-manifest.json") {
+				manifest = &file
+				break
+			}
+		}
+
+		if manifest == nil {
+			_ = workflow.Sleep(ctx, 30*time.Second)
+		}
+	}
+
+	if manifest == nil {
+		return nil, fmt.Errorf("could not find metadata file for package %s", packageID)
+	}
+
+	remotePath, err := paths.Parse("s3prod:/" + manifest.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	localPath := tmpRoot.Append("manifest.json")
+	err = wfutils.CopyFile(ctx, remotePath, localPath)
+	if err != nil {
+		return nil, err
+	}
+
+	contents, err := wfutils.ReadFile(ctx, localPath)
+	if err != nil {
+		return nil, err
+	}
+
+	masvMeta := &MASVMetadata{}
+	err = json.Unmarshal(contents, masvMeta)
+	if err != nil {
+		return nil, err
+	}
+
+	return masvMeta, nil
+}
+
+// stagePackageFiles copies the package into temp storage and reads the church out of
+// its metadata.json, which is what the delivery folder is named after.
+func stagePackageFiles(ctx workflow.Context, masvMeta *MASVMetadata, tmpRoot paths.Path) ([]paths.Path, string, error) {
+	church := "unknown"
+	var staged []paths.Path
+
+	for _, f := range masvMeta.Package.Files {
+		remotePath, err := paths.Parse(fmt.Sprintf("s3prod:/massiveio-bccm/%s/%s", f.Path, f.Name))
+		if err != nil {
+			return nil, "", err
+		}
+
+		err = wfutils.RcloneWaitForFileExists(ctx, remotePath, 30)
+		if err != nil {
+			return nil, "", err
+		}
+
+		tempFilePath := tmpRoot.Append(remotePath.Base())
+		err = wfutils.RcloneCopyFile(ctx, remotePath, tempFilePath, rclone.PriorityNormal)
+		if err != nil {
+			return nil, "", err
+		}
+
+		if strings.HasSuffix(tempFilePath.Base(), "metadata.json") {
+			contents, err := wfutils.ReadFile(ctx, tempFilePath)
+			if err != nil {
+				return nil, "", err
+			}
+
+			metadata := &Metadata{}
+			err = json.Unmarshal(contents, metadata)
+			if err != nil {
+				return nil, "", err
+			}
+
+			church = churchSanitizer.ReplaceAllString(metadata.Church, "_")
+		}
+
+		staged = append(staged, tempFilePath)
+	}
+
+	return staged, church, nil
+}
+
+// deliverPackageFiles copies each staged file to its destination, and for the video
+// ones also starts a ProRes transcode, whose jobs the caller waits on.
+func deliverPackageFiles(ctx workflow.Context, files []paths.Path, destination paths.Path) ([]wfutils.Task[*activities.EncodeResult], error) {
+	var transcodeJobs []wfutils.Task[*activities.EncodeResult]
+
+	for _, file := range files {
+		var err error
+
+		if lo.Contains([]string{".mov", ".avi", ".mxf", ".mp4"}, file.Ext()) {
+			transcodeJobs = append(transcodeJobs, wfutils.Execute(ctx, activities.Video.TranscodeToProResActivity, activities.EncodeParams{
+				FilePath:  file,
+				OutputDir: destination,
+			}))
+
+			err = wfutils.RcloneCopyFile(ctx, file, destination.Append("originals").Append(file.Base()), rclone.PriorityNormal)
+		} else {
+			err = wfutils.RcloneCopyFile(ctx, file, destination.Append(file.Base()), rclone.PriorityNormal)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return transcodeJobs, nil
 }


### PR DESCRIPTION
Closes the Tier 3 audit finding *"Functions over 100 lines that decompose naturally"* — **all eleven**, each at its own seams, each with the ordering checked.

Rebased onto `master` now that #464 and #465 are merged.

| Function | Before | After |
|---|---|---|
| `doIncremental` | **295** | **134** |
| `GenerateShort` | 203 | 127 |
| `VXExportToVOD` | 176 | 112 |
| `VXExport` | 168 | 130 |
| `IngestSyncFix` | 153 | 106 |
| `VXExportToBMM` | 151 | **78** |
| `MASVImport` | 150 | **59** |
| `MergeExportData` | 133 | 109 |
| `makeBMMJSON` | 111 | **44** |
| `createShortInPlatform` | 100 | 72 |
| `addMetaTags` | 97 | 55 |

**Six are still over a hundred lines.** That is where their seams are; splitting further would mean inventing seams to hit a number. The finding asked for the ones that decompose *naturally*, and this is how far that goes.

### Ordering is the risk, so ordering is what the tests check

Extracting a helper does not change a workflow's history. **Reordering while moving code does**, and that breaks replay for anything in flight. Three of these workflows had no end-to-end test at all, so:

- `TestAddMetaTagsTestSuite` — the exact `SetVXMetadataField` / `AddToVXMetadataField` sequence, keys and values included.
- `TestIncrementalMainPathOrder` — **written and run against the 295-line `doIncremental` first**, so the order it pins is the old one.
- `TestGenerateShortActivityOrder` — same method, pinned against the 203-line version.
- `TestBMMSequence` — new; `VXExportToBMM` had nothing.

**Writing the BMM one caught a mistake in the test, not the code.** The first version asserted a total ordering over all eleven activities and passed here — then failed against the pre-refactor code with `Aac, Mp3, Aac` instead of `Aac, Aac, Mp3`. Both are correct: those encodes are *scheduled* together and the test environment *executes* them in any order, so a total ordering was never a real property and the test would have gone flaky in CI. It now pins what is actually deterministic — the phase boundaries, and the count of encodes between them — and passes against the old code, five runs each way. Same reasoning made `TestIncrementalMainPathOrder` filter out everything the preview coroutine touches.

### One thing fixed rather than moved

`MergeExportData` loses the collect-results block the finding flagged as written twice (`collectMergedPaths`).

**Not** changed, after review: `bmmTranscriptionFiles` still discards the error from `GetMapKeysSafely`. An intermediate commit propagated it, which turned a missing transcription into a failed export — the wrong trade. A transcription that did not make it costs a transcription and nothing else, and an episode without one is still an episode people can listen to. The bare `_` now carries that reasoning so it does not read as an oversight.

### Noticed, not touched

Functions over 90 lines that this finding never listed, some now larger than entries that were: `ExtractAudioFromMU1MU2` (155), `VBExport` (137), `BmmTrackMetadata` (120), `TranscribeVX` (117), `MergeAndImportSubtitlesFromCSV` (117), `BmmIngestUpload` (117). Worth their own entry rather than being swept in here.

### Verification

`go build ./...`, `go vet ./...`, `go test ./...` and `workflowcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
