### PR TITLE
fix(trigger_ui): the Massive webhook fails closed

### DIFF
--- a/cmd/trigger_ui/example.env
+++ b/cmd/trigger_ui/example.env
@@ -16,3 +16,7 @@ RCLONE_USERNAME=
 RCLONE_PASSWORD=
 
 SUBTITLE_STYLES_DIR=
+
+# Authenticates the Massive.app webhook. Unset means /webhook/massive refuses
+# every request, so MASV imports stop rather than running unauthenticated.
+MASSIVE_WEBHOOK_API_KEY=

--- a/cmd/trigger_ui/main.go
+++ b/cmd/trigger_ui/main.go
@@ -513,6 +513,10 @@ func main() {
 	// MD: This is a legacy route, it should be removed in the future.
 	router.POST("/filecatalyst", server.fileCatalystWebhookHandler)
 
+	if os.Getenv(massiveWebhookKeyVar) == "" {
+		log.Printf("WARNING: %s is not set, so /webhook/massive will refuse every request", massiveWebhookKeyVar)
+	}
+
 	router.Group("/webhook").
 		POST("/massive", server.massiveWebhookHandler).
 		POST("/filecatalyst", server.fileCatalystWebhookHandler)

--- a/cmd/trigger_ui/webhook_auth_test.go
+++ b/cmd/trigger_ui/webhook_auth_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func authResult(t *testing.T, configuredKey, sentKey string) (bool, int, string) {
+	t.Helper()
+	t.Setenv(massiveWebhookKeyVar, configuredKey)
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/webhook/massive", nil)
+	if sentKey != "" {
+		ctx.Request.Header.Set("api-key", sentKey)
+	}
+
+	ok := massiveWebhookAuthorized(ctx)
+	return ok, recorder.Code, recorder.Body.String()
+}
+
+// An unset key used to mean "no key required", which left an endpoint that starts a
+// copy workflow open to anyone who could reach it.
+func TestMassiveWebhook_UnsetKeyRefuses(t *testing.T) {
+	ok, code, body := authResult(t, "", "")
+
+	require.False(t, ok)
+	assert.Equal(t, http.StatusServiceUnavailable, code)
+	assert.Contains(t, body, massiveWebhookKeyVar,
+		"the refusal names the variable, so the cause is not a guess")
+}
+
+func TestMassiveWebhook_UnsetKeyRefusesEvenWithAKeySent(t *testing.T) {
+	ok, code, _ := authResult(t, "", "some-key")
+
+	require.False(t, ok, "an attacker-supplied key must not satisfy an unset one")
+	assert.Equal(t, http.StatusServiceUnavailable, code)
+}
+
+func TestMassiveWebhook_WrongKeyIsUnauthorized(t *testing.T) {
+	ok, code, _ := authResult(t, "correct-key", "wrong-key")
+
+	require.False(t, ok)
+	assert.Equal(t, http.StatusUnauthorized, code)
+}
+
+func TestMassiveWebhook_MissingHeaderIsUnauthorized(t *testing.T) {
+	ok, code, _ := authResult(t, "correct-key", "")
+
+	require.False(t, ok)
+	assert.Equal(t, http.StatusUnauthorized, code)
+}
+
+func TestMassiveWebhook_CorrectKeyPasses(t *testing.T) {
+	ok, code, _ := authResult(t, "correct-key", "correct-key")
+
+	require.True(t, ok)
+	assert.Equal(t, http.StatusOK, code, "nothing is written when the request is allowed")
+}
+
+// A prefix of the key must not pass, which a length-insensitive compare could allow.
+func TestMassiveWebhook_PrefixDoesNotPass(t *testing.T) {
+	ok, _, _ := authResult(t, "correct-key", "correct")
+
+	require.False(t, ok)
+}

--- a/cmd/trigger_ui/workflows.go
+++ b/cmd/trigger_ui/workflows.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -42,20 +43,43 @@ type massivePayload struct {
 
 // Massive.app webhook handler
 // Expects:
-//   - Header: api-key (must match MASSIVE_WEBHOOK_API_KEY env var if set)
+//   - Header: api-key, matching MASSIVE_WEBHOOK_API_KEY
 //   - JSON body similar to:
 //     {
 //     "event_type": "package.finalized",
 //     "object": {"id": "...", "name": "...", "sender": "...", "total_files": 1}
 //     }
+const massiveWebhookKeyVar = "MASSIVE_WEBHOOK_API_KEY"
+
+// massiveWebhookAuthorized answers whether this request may start an import, and writes
+// the refusal itself when it may not.
+//
+// An unset key disables the route rather than opening it. This endpoint starts a
+// workflow that copies whatever it is pointed at out of an S3 bucket, and it is reachable
+// from the internet, so "no key configured" cannot mean "no key required" — which is what
+// it used to mean, and nothing in the deployment sets the variable.
+func massiveWebhookAuthorized(ctx *gin.Context) bool {
+	expected := os.Getenv(massiveWebhookKeyVar)
+	if expected == "" {
+		log.Printf("%s is not set: refusing a request to %s", massiveWebhookKeyVar, ctx.Request.URL.Path)
+		ctx.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "webhook disabled: " + massiveWebhookKeyVar + " is not set",
+		})
+		return false
+	}
+
+	// Constant time, so the response time does not report how much of the key was right.
+	if subtle.ConstantTimeCompare([]byte(ctx.GetHeader("api-key")), []byte(expected)) != 1 {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid api-key"})
+		return false
+	}
+
+	return true
+}
+
 func (s *TriggerServer) massiveWebhookHandler(ctx *gin.Context) {
-	// Validate API key if configured
-	expectedKey := os.Getenv("MASSIVE_WEBHOOK_API_KEY")
-	if expectedKey != "" {
-		if ctx.GetHeader("api-key") != expectedKey {
-			ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid api-key"})
-			return
-		}
+	if !massiveWebhookAuthorized(ctx) {
+		return
 	}
 	var payload massivePayload
 	if err := ctx.ShouldBindJSON(&payload); err != nil {


### PR DESCRIPTION
Closes the Tier 4 audit finding *"Fail-open webhook key"*.

`cmd/trigger_ui/workflows.go` only checked the `api-key` header **when `MASSIVE_WEBHOOK_API_KEY` was non-empty**:

```go
expectedKey := os.Getenv("MASSIVE_WEBHOOK_API_KEY")
if expectedKey != "" {
    if ctx.GetHeader("api-key") != expectedKey { ... 401 ... }
}
```

So an unset variable meant no authentication at all — on an endpoint that starts `MASVImport`, a workflow that copies whatever it is pointed at out of an S3 bucket.

**Unset looks like the default posture.** The variable is in no deployment config in this repo, it was not in `cmd/trigger_ui/example.env`, and `trigger_ui` never loads a `.env`. Whatever is true in production, nothing here would have set it.

### What changes

- **An unset key disables the route instead of opening it** — `503`, naming the variable, plus a warning at startup saying the same thing. A stopped MASV import is then traceable to its cause instead of being a mystery.
- **`subtle.ConstantTimeCompare`**, so the response time no longer reports how much of the key was right. A prefix of the key does not pass either.

### Why not "refuse to start", which the finding asked for

Because the key may well be unset in production right now, and that would take the **whole trigger UI** down on deploy — the export and ingest forms operators use, not just a webhook. Refusing the requests closes the hole with a fraction of the blast radius, and the startup warning gives the same signal to whoever is watching the logs.

Flagging it as a judgement call rather than burying it: if you would rather it hard-fail, that is a two-line change.

### Verification

Six tests, none of which existed — `cmd/trigger_ui` had no test file at all. They cover the hole directly: an unset key refuses **even when the caller supplies one**, a wrong key is 401, a missing header is 401, a correct key passes and writes nothing, and a prefix of the key does not pass.

`go build ./...`, `go vet ./...`, `go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)