### PR TITLE
refactor: build clients at boot and inject them into the activities

### DIFF
--- a/activities/cantemo/files.go
+++ b/activities/cantemo/files.go
@@ -18,8 +18,8 @@ type GetFilesParams struct {
 	Query    string
 }
 
-func GetFiles(_ context.Context, params GetFilesParams) (*cantemo.GetFilesResult, error) {
-	return GetClient().GetFiles(
+func (a Activities) GetFiles(_ context.Context, params GetFilesParams) (*cantemo.GetFilesResult, error) {
+	return a.Client.GetFiles(
 		params.Path,
 		params.State,
 		strings.Join(params.Storages, ","),
@@ -36,16 +36,16 @@ type RenameFileParams struct {
 	NewPath           string
 }
 
-func RenameFile(_ context.Context, params *RenameFileParams) (string, error) {
+func (a Activities) RenameFile(_ context.Context, params *RenameFileParams) (string, error) {
 	if params.SourceStorage == params.DestinatinStorage {
-		return GetClient().RenameFile(params.ItemID, params.ShapeID, params.SourceStorage, params.DestinatinStorage, params.NewPath)
+		return a.Client.RenameFile(params.ItemID, params.ShapeID, params.SourceStorage, params.DestinatinStorage, params.NewPath)
 	}
 
-	return GetClient().MoveFile(params.ItemID, params.ShapeID, params.SourceStorage, params.DestinatinStorage, params.NewPath)
+	return a.Client.MoveFile(params.ItemID, params.ShapeID, params.SourceStorage, params.DestinatinStorage, params.NewPath)
 }
 
-func MoveFileWait(ctx context.Context, params *RenameFileParams) (any, error) {
-	taskID, err := RenameFile(ctx, params)
+func (a Activities) MoveFileWait(ctx context.Context, params *RenameFileParams) (any, error) {
+	taskID, err := a.RenameFile(ctx, params)
 
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func MoveFileWait(ctx context.Context, params *RenameFileParams) (any, error) {
 	status := "STARTED"
 
 	for status == "STARTED" {
-		taskStatus, err := GetTaskInfo(ctx, GetTaskInfoParams{
+		taskStatus, err := a.GetTaskInfo(ctx, GetTaskInfoParams{
 			TaskID: taskID,
 		})
 

--- a/activities/cantemo/items.go
+++ b/activities/cantemo/items.go
@@ -9,6 +9,6 @@ type GetFormatsParams struct {
 	ItemID string
 }
 
-func GetFormats(_ context.Context, params GetFormatsParams) ([]cantemo.Format, error) {
-	return GetClient().GetFormats(params.ItemID)
+func (a Activities) GetFormats(_ context.Context, params GetFormatsParams) ([]cantemo.Format, error) {
+	return a.Client.GetFormats(params.ItemID)
 }

--- a/activities/cantemo/relations.go
+++ b/activities/cantemo/relations.go
@@ -2,7 +2,6 @@ package cantemo
 
 import (
 	"context"
-	"github.com/bcc-code/bcc-media-flows/environment"
 
 	"github.com/bcc-code/bcc-media-flows/services/cantemo"
 )
@@ -12,10 +11,13 @@ type AddRelationParams struct {
 	Child  string
 }
 
-func GetClient() *cantemo.Client {
-	return cantemo.NewClient(environment.Get().Cantemo)
+type Activities struct {
+	Client *cantemo.Client
 }
 
-func AddRelation(ctx context.Context, params AddRelationParams) (any, error) {
-	return nil, GetClient().AddRelation(params.Parent, params.Child)
+// Cantemo is replaced at boot with a client built from the configuration.
+var Cantemo = &Activities{}
+
+func (a Activities) AddRelation(ctx context.Context, params AddRelationParams) (any, error) {
+	return nil, a.Client.AddRelation(params.Parent, params.Child)
 }

--- a/activities/cantemo/relations.go
+++ b/activities/cantemo/relations.go
@@ -13,7 +13,7 @@ type AddRelationParams struct {
 }
 
 func GetClient() *cantemo.Client {
-	return cantemo.NewFromConfig(environment.Get().Cantemo)
+	return cantemo.NewClient(environment.Get().Cantemo)
 }
 
 func AddRelation(ctx context.Context, params AddRelationParams) (any, error) {

--- a/activities/cantemo/tasks.go
+++ b/activities/cantemo/tasks.go
@@ -9,6 +9,6 @@ type GetTaskInfoParams struct {
 	TaskID string
 }
 
-func GetTaskInfo(_ context.Context, params GetTaskInfoParams) (*cantemo.Task, error) {
-	return GetClient().GetTask(params.TaskID)
+func (a Activities) GetTaskInfo(_ context.Context, params GetTaskInfoParams) (*cantemo.Task, error) {
+	return a.Client.GetTask(params.TaskID)
 }

--- a/activities/platform/chapters.go
+++ b/activities/platform/chapters.go
@@ -5,8 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	cantemoactivities "github.com/bcc-code/bcc-media-flows/activities/cantemo"
-	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
 	"github.com/bcc-code/bcc-media-flows/services/cantemo"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsapi"
@@ -17,9 +15,13 @@ import (
 	"go.temporal.io/sdk/activity"
 )
 
-type Activities struct{}
+type Activities struct {
+	Vidispine vidispine.Client
+	Cantemo   *cantemo.Client
+}
 
-var PlatformActivities = Activities{}
+// PlatformActivities is replaced at boot with clients built from the configuration.
+var PlatformActivities = &Activities{}
 
 type GetTimedMetadataChaptersParams struct {
 	Clips []*vidispine.Clip
@@ -30,10 +32,7 @@ func (a Activities) GetTimedMetadataChaptersActivity(ctx context.Context, params
 	activity.RecordHeartbeat(ctx, "GetTimedMetadataChaptersActivity")
 	log.Info("Starting GetTimedMetadataChaptersActivity")
 
-	vsClient := vsactivity.GetClient()
-	cantemoClient := cantemoactivities.GetClient()
-
-	return GetTimedMetadataChapters(vsClient, cantemoClient, params.Clips)
+	return GetTimedMetadataChapters(a.Vidispine, a.Cantemo, params.Clips)
 }
 
 func GetTimedMetadataChapters(vsClient vidispine.Client, cantemoClient *cantemo.Client, clips []*vidispine.Clip) ([]asset.TimedMetadata, error) {

--- a/activities/queues.go
+++ b/activities/queues.go
@@ -1,6 +1,9 @@
 package activities
 
 import (
+	cantemoactivities "github.com/bcc-code/bcc-media-flows/activities/cantemo"
+	"github.com/bcc-code/bcc-media-flows/services/subtrans"
+	"github.com/bcc-code/bcc-media-flows/services/vidispine"
 	"reflect"
 	"runtime"
 	"strings"
@@ -27,15 +30,21 @@ type VideoActivities struct{}
 
 var Video = VideoActivities{}
 
-type UtilActivities struct{}
+type UtilActivities struct {
+	Vidispine vidispine.Client
+	Subtrans  *subtrans.Client
+}
 
-var Util = UtilActivities{}
+// Util is replaced at boot with clients built from the configuration.
+var Util = &UtilActivities{}
 
 type LiveActivities struct{}
 
 var Live = LiveActivities{}
 
 var Vidispine = vsactivity.Vidispine
+
+var Cantemo = cantemoactivities.Cantemo
 
 var Platform = platform_activities.PlatformActivities
 

--- a/activities/subtrans.go
+++ b/activities/subtrans.go
@@ -35,8 +35,7 @@ type GetSubtransIDOutput struct {
 func (ua UtilActivities) GetSubtransIDActivity(_ context.Context, input GetSubtransIDInput) (*GetSubtransIDOutput, error) {
 	out := &GetSubtransIDOutput{}
 
-	vsClient := ua.Vidispine
-	subtransID, err := vidispine.GetSubtransID(vsClient, input.VXID)
+	subtransID, err := vidispine.GetSubtransID(ua.Vidispine, input.VXID)
 	if err != nil {
 		return out, err
 	}
@@ -47,7 +46,7 @@ func (ua UtilActivities) GetSubtransIDActivity(_ context.Context, input GetSubtr
 	}
 
 	// We do not have a story ID saved, so we try to find it using the file name
-	meta, err := vsClient.GetMetadata(input.VXID)
+	meta, err := ua.Vidispine.GetMetadata(input.VXID)
 	if err != nil {
 		return nil, err
 	}

--- a/activities/subtrans.go
+++ b/activities/subtrans.go
@@ -74,7 +74,7 @@ func (ua UtilActivities) GetSubtransIDActivity(_ context.Context, input GetSubtr
 	// Join back together
 	fileName = strings.Join(fileNameSplit, ".")
 
-	stClient := subtrans.NewFromConfig(environment.Get().Subtrans)
+	stClient := subtrans.NewClient(environment.Get().Subtrans)
 
 	res, err := stClient.SearchByName(fileName)
 	if err != nil {
@@ -97,7 +97,7 @@ func (ua UtilActivities) GetSubtransIDActivity(_ context.Context, input GetSubtr
 }
 
 func (ua UtilActivities) GetSubtitlesActivity(_ context.Context, params GetSubtitlesInput) (map[string]paths.Path, error) {
-	client := subtrans.NewFromConfig(environment.Get().Subtrans)
+	client := subtrans.NewClient(environment.Get().Subtrans)
 
 	info, err := os.Stat(params.DestinationFolder.Local())
 	if os.IsNotExist(err) {

--- a/activities/subtrans.go
+++ b/activities/subtrans.go
@@ -3,16 +3,13 @@ package activities
 import (
 	"context"
 	"fmt"
-	"github.com/bcc-code/bcc-media-flows/environment"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 
-	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
 	"github.com/bcc-code/bcc-media-flows/paths"
 
-	"github.com/bcc-code/bcc-media-flows/services/subtrans"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vscommon"
 	"go.temporal.io/sdk/temporal"
@@ -38,7 +35,7 @@ type GetSubtransIDOutput struct {
 func (ua UtilActivities) GetSubtransIDActivity(_ context.Context, input GetSubtransIDInput) (*GetSubtransIDOutput, error) {
 	out := &GetSubtransIDOutput{}
 
-	vsClient := vsactivity.GetClient()
+	vsClient := ua.Vidispine
 	subtransID, err := vidispine.GetSubtransID(vsClient, input.VXID)
 	if err != nil {
 		return out, err
@@ -74,7 +71,7 @@ func (ua UtilActivities) GetSubtransIDActivity(_ context.Context, input GetSubtr
 	// Join back together
 	fileName = strings.Join(fileNameSplit, ".")
 
-	stClient := subtrans.NewClient(environment.Get().Subtrans)
+	stClient := ua.Subtrans
 
 	res, err := stClient.SearchByName(fileName)
 	if err != nil {
@@ -97,7 +94,7 @@ func (ua UtilActivities) GetSubtransIDActivity(_ context.Context, input GetSubtr
 }
 
 func (ua UtilActivities) GetSubtitlesActivity(_ context.Context, params GetSubtitlesInput) (map[string]paths.Path, error) {
-	client := subtrans.NewClient(environment.Get().Subtrans)
+	client := ua.Subtrans
 
 	info, err := os.Stat(params.DestinationFolder.Local())
 	if os.IsNotExist(err) {

--- a/activities/vidispine/client.go
+++ b/activities/vidispine/client.go
@@ -18,7 +18,7 @@ type Activities struct{}
 var Vidispine = Activities{}
 
 func GetClient() vidispine.Client {
-	return vsapi.NewFromConfig(environment.Get().Vidispine)
+	return vsapi.NewClient(environment.Get().Vidispine)
 }
 
 type WaitForJobCompletionParams struct {

--- a/activities/vidispine/client.go
+++ b/activities/vidispine/client.go
@@ -33,15 +33,13 @@ func (a Activities) WaitForJobCompletion(ctx context.Context, params WaitForJobC
 	logger := activity.GetLogger(ctx)
 	logger.Info("Starting WaitForJobCompletionActivity")
 
-	vsClient := a.Client
-
 	sleepTime := time.Second * 30
 	if params.SleepTime > 0 {
 		sleepTime = time.Second * time.Duration(params.SleepTime)
 	}
 
 	for {
-		job, err := vsClient.GetJob(params.JobID)
+		job, err := a.Client.GetJob(params.JobID)
 		if err != nil {
 			return nil, err
 		}
@@ -66,10 +64,8 @@ func (a Activities) JobCompleteOrErr(ctx context.Context, params WaitForJobCompl
 	logger := activity.GetLogger(ctx)
 	logger.Info("Starting WaitForJobCompletionActivity")
 
-	vsClient := a.Client
-
 	for {
-		job, err := vsClient.GetJob(params.JobID)
+		job, err := a.Client.GetJob(params.JobID)
 		if err != nil {
 			return false, temporal.NewNonRetryableApplicationError("couldn't complete job", "JOB_FAILED", err)
 		}
@@ -93,8 +89,7 @@ func (a Activities) FindJob(ctx context.Context, params FindJobParams) (*vsapi.J
 	logger := activity.GetLogger(ctx)
 	logger.Info("Starting FindJob")
 
-	vsClient := a.Client
-	res, err := vsClient.FindJob(params.ItemID, params.JobType)
+	res, err := a.Client.FindJob(params.ItemID, params.JobType)
 
 	return res, err
 }

--- a/activities/vidispine/client.go
+++ b/activities/vidispine/client.go
@@ -3,7 +3,6 @@ package vsactivity
 import (
 	"context"
 	"fmt"
-	"github.com/bcc-code/bcc-media-flows/environment"
 	"time"
 
 	"go.temporal.io/sdk/activity"
@@ -13,13 +12,12 @@ import (
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsapi"
 )
 
-type Activities struct{}
-
-var Vidispine = Activities{}
-
-func GetClient() vidispine.Client {
-	return vsapi.NewClient(environment.Get().Vidispine)
+type Activities struct {
+	Client vidispine.Client
 }
+
+// Vidispine is replaced at boot with a client built from the configuration.
+var Vidispine = &Activities{}
 
 type WaitForJobCompletionParams struct {
 	JobID     string
@@ -35,7 +33,7 @@ func (a Activities) WaitForJobCompletion(ctx context.Context, params WaitForJobC
 	logger := activity.GetLogger(ctx)
 	logger.Info("Starting WaitForJobCompletionActivity")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	sleepTime := time.Second * 30
 	if params.SleepTime > 0 {
@@ -68,7 +66,7 @@ func (a Activities) JobCompleteOrErr(ctx context.Context, params WaitForJobCompl
 	logger := activity.GetLogger(ctx)
 	logger.Info("Starting WaitForJobCompletionActivity")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	for {
 		job, err := vsClient.GetJob(params.JobID)
@@ -95,7 +93,7 @@ func (a Activities) FindJob(ctx context.Context, params FindJobParams) (*vsapi.J
 	logger := activity.GetLogger(ctx)
 	logger.Info("Starting FindJob")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 	res, err := vsClient.FindJob(params.ItemID, params.JobType)
 
 	return res, err

--- a/activities/vidispine/export.go
+++ b/activities/vidispine/export.go
@@ -23,7 +23,7 @@ func (a Activities) GetExportDataActivity(ctx context.Context, params GetExportD
 	activity.RecordHeartbeat(ctx, "GetExportDataActivity")
 	log.Info("Starting GetExportDataActivity")
 
-	client := GetClient()
+	client := a.Client
 
 	audioSource := vidispine.ExportAudioSources.Parse(params.AudioSource)
 	if params.AudioSource != "" && audioSource == nil {
@@ -43,7 +43,7 @@ func (a Activities) GetRelatedAudioFiles(ctx context.Context, vxID string) (map[
 	activity.RecordHeartbeat(ctx, "GetRelatedAudioFiles")
 	log.Info("Starting GetRelatedAudioFiles")
 
-	client := GetClient()
+	client := a.Client
 
 	audios, err := vidispine.GetRelatedAudioPaths(client, vxID)
 

--- a/activities/vidispine/export.go
+++ b/activities/vidispine/export.go
@@ -23,14 +23,12 @@ func (a Activities) GetExportDataActivity(ctx context.Context, params GetExportD
 	activity.RecordHeartbeat(ctx, "GetExportDataActivity")
 	log.Info("Starting GetExportDataActivity")
 
-	client := a.Client
-
 	audioSource := vidispine.ExportAudioSources.Parse(params.AudioSource)
 	if params.AudioSource != "" && audioSource == nil {
 		return nil, fmt.Errorf("invalid audioSource: %s", params.AudioSource)
 	}
 
-	data, err := vidispine.GetDataForExport(client, params.VXID, params.Languages, audioSource, params.Subclip, params.SubsAllowAI)
+	data, err := vidispine.GetDataForExport(a.Client, params.VXID, params.Languages, audioSource, params.Subclip, params.SubsAllowAI)
 	if err != nil {
 		return nil, err
 	}
@@ -43,9 +41,7 @@ func (a Activities) GetRelatedAudioFiles(ctx context.Context, vxID string) (map[
 	activity.RecordHeartbeat(ctx, "GetRelatedAudioFiles")
 	log.Info("Starting GetRelatedAudioFiles")
 
-	client := a.Client
-
-	audios, err := vidispine.GetRelatedAudioPaths(client, vxID)
+	audios, err := vidispine.GetRelatedAudioPaths(a.Client, vxID)
 
 	if err != nil {
 		return nil, err

--- a/activities/vidispine/files.go
+++ b/activities/vidispine/files.go
@@ -28,7 +28,7 @@ func (a Activities) ImportFileAsShapeActivity(ctx context.Context, params Import
 	log := activity.GetLogger(ctx)
 	log.Info("Starting ImportFileAsShapeActivity")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	fileState := vsapi.FileStateClosed
 	if params.Growing {
@@ -79,7 +79,7 @@ func (a Activities) ImportFileAsSidecarActivity(ctx context.Context, params Impo
 	log := activity.GetLogger(ctx)
 	log.Info("Starting ImportSubtitleAsSidecarParams")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	jobID, err := vsClient.AddSidecarToItem(params.AssetID, params.FilePath.Local(), params.Language)
 	return &ImportFileAsSidecarResult{
@@ -99,7 +99,7 @@ func (a Activities) CreatePlaceholderActivity(ctx context.Context, params Create
 	log := activity.GetLogger(ctx)
 	log.Info("Starting CreatePlaceholderActivity")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	id, err := vsClient.CreatePlaceholder(vsapi.PlaceholderTypeRaw, params.Title)
 	if err != nil {
@@ -129,7 +129,7 @@ func (a Activities) CreateThumbnailsActivity(ctx context.Context, params CreateT
 	log := activity.GetLogger(ctx)
 	log.Info("Starting CreateThumbnailsActivity")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	if params.Width == 0 {
 		params.Width = 320
@@ -153,7 +153,7 @@ func (a Activities) AddFileToPlaceholder(ctx context.Context, params AddFileToPl
 	logger := activity.GetLogger(ctx)
 	logger.Info("Starting AddFileToPlaceholder")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	fileID, err := vsClient.RegisterFile(params.FilePath.Local(), vsapi.FileStateOpen)
 	if err != nil {
@@ -186,7 +186,7 @@ func (a Activities) CloseFile(ctx context.Context, params CloseFileParams) (any,
 	logger := activity.GetLogger(ctx)
 	logger.Info("Starting CloseFile")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	return nil, vsClient.UpdateFileState(params.FileID, vsapi.FileStateClosed)
 }
@@ -211,7 +211,7 @@ func (a Activities) WaitForFileVisibleInStorageActivity(ctx context.Context, par
 		storageID = vsapi.DefaultStorageID
 	}
 
-	vsClient := GetClient()
+	vsClient := a.Client
 	for {
 		exists, err := vsClient.FileExistsInStorage(storageID, params.FilePath.Local())
 		if err != nil {

--- a/activities/vidispine/files.go
+++ b/activities/vidispine/files.go
@@ -28,26 +28,24 @@ func (a Activities) ImportFileAsShapeActivity(ctx context.Context, params Import
 	log := activity.GetLogger(ctx)
 	log.Info("Starting ImportFileAsShapeActivity")
 
-	vsClient := a.Client
-
 	fileState := vsapi.FileStateClosed
 	if params.Growing {
 		fileState = vsapi.FileStateOpen
 	}
 
-	fileID, err := vsClient.RegisterFile(params.FilePath.Local(), fileState)
+	fileID, err := a.Client.RegisterFile(params.FilePath.Local(), fileState)
 	if err != nil {
 		return nil, err
 	}
 
 	if params.Replace {
-		s, err := vsClient.GetShapes(params.AssetID)
+		s, err := a.Client.GetShapes(params.AssetID)
 		if err != nil {
 			return nil, err
 		}
 
 		if shape := s.GetShape(params.ShapeTag); shape != nil {
-			err = vsClient.DeleteShape(params.AssetID, shape.ID)
+			err = a.Client.DeleteShape(params.AssetID, shape.ID)
 			if err != nil {
 				return nil, err
 			}
@@ -55,7 +53,7 @@ func (a Activities) ImportFileAsShapeActivity(ctx context.Context, params Import
 		}
 	}
 
-	res, err := vsClient.AddShapeToItem(params.ShapeTag, params.AssetID, fileID)
+	res, err := a.Client.AddShapeToItem(params.ShapeTag, params.AssetID, fileID)
 	if err != nil && errors.Is(err, vsapi.ErrShapeTagNotFound) {
 		err = temporal.NewNonRetryableApplicationError(err.Error(), "VS_SHAPE_TAG_NOT_FOUND", err)
 	}
@@ -79,9 +77,7 @@ func (a Activities) ImportFileAsSidecarActivity(ctx context.Context, params Impo
 	log := activity.GetLogger(ctx)
 	log.Info("Starting ImportSubtitleAsSidecarParams")
 
-	vsClient := a.Client
-
-	jobID, err := vsClient.AddSidecarToItem(params.AssetID, params.FilePath.Local(), params.Language)
+	jobID, err := a.Client.AddSidecarToItem(params.AssetID, params.FilePath.Local(), params.Language)
 	return &ImportFileAsSidecarResult{
 		JobID: jobID,
 	}, err
@@ -99,9 +95,7 @@ func (a Activities) CreatePlaceholderActivity(ctx context.Context, params Create
 	log := activity.GetLogger(ctx)
 	log.Info("Starting CreatePlaceholderActivity")
 
-	vsClient := a.Client
-
-	id, err := vsClient.CreatePlaceholder(vsapi.PlaceholderTypeRaw, params.Title)
+	id, err := a.Client.CreatePlaceholder(vsapi.PlaceholderTypeRaw, params.Title)
 	if err != nil {
 		return nil, err
 	}
@@ -129,14 +123,12 @@ func (a Activities) CreateThumbnailsActivity(ctx context.Context, params CreateT
 	log := activity.GetLogger(ctx)
 	log.Info("Starting CreateThumbnailsActivity")
 
-	vsClient := a.Client
-
 	if params.Width == 0 {
 		params.Width = 320
 		params.Height = 180
 	}
 
-	res, err := vsClient.CreateThumbnails(params.AssetID, params.Width, params.Height)
+	res, err := a.Client.CreateThumbnails(params.AssetID, params.Width, params.Height)
 	return &JobResult{
 		JobID: res,
 	}, err
@@ -153,9 +145,7 @@ func (a Activities) AddFileToPlaceholder(ctx context.Context, params AddFileToPl
 	logger := activity.GetLogger(ctx)
 	logger.Info("Starting AddFileToPlaceholder")
 
-	vsClient := a.Client
-
-	fileID, err := vsClient.RegisterFile(params.FilePath.Local(), vsapi.FileStateOpen)
+	fileID, err := a.Client.RegisterFile(params.FilePath.Local(), vsapi.FileStateOpen)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +157,7 @@ func (a Activities) AddFileToPlaceholder(ctx context.Context, params AddFileToPl
 		fileState = vsapi.FileStateClosed
 	}
 
-	jobID, err := vsClient.AddFileToPlaceholder(params.AssetID, fileID, params.Tag, fileState)
+	jobID, err := a.Client.AddFileToPlaceholder(params.AssetID, fileID, params.Tag, fileState)
 	if err != nil {
 		return nil, err
 	}
@@ -186,9 +176,7 @@ func (a Activities) CloseFile(ctx context.Context, params CloseFileParams) (any,
 	logger := activity.GetLogger(ctx)
 	logger.Info("Starting CloseFile")
 
-	vsClient := a.Client
-
-	return nil, vsClient.UpdateFileState(params.FileID, vsapi.FileStateClosed)
+	return nil, a.Client.UpdateFileState(params.FileID, vsapi.FileStateClosed)
 }
 
 type WaitForFileVisibleInStorageParams struct {
@@ -211,9 +199,8 @@ func (a Activities) WaitForFileVisibleInStorageActivity(ctx context.Context, par
 		storageID = vsapi.DefaultStorageID
 	}
 
-	vsClient := a.Client
 	for {
-		exists, err := vsClient.FileExistsInStorage(storageID, params.FilePath.Local())
+		exists, err := a.Client.FileExistsInStorage(storageID, params.FilePath.Local())
 		if err != nil {
 			return nil, err
 		}

--- a/activities/vidispine/items.go
+++ b/activities/vidispine/items.go
@@ -16,7 +16,7 @@ func (a Activities) DeleteItems(ctx context.Context, params DeleteItemsParams) (
 	log := activity.GetLogger(ctx)
 	log.Info("Starting DeleteItems")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	return nil, vsClient.DeleteItems(ctx, params.VXIDs, params.DeleteFiles)
 }
@@ -30,7 +30,7 @@ func (a Activities) GetItemsInCollection(ctx context.Context, params GetItemsInC
 	log := activity.GetLogger(ctx)
 	log.Info("Starting GetItemsInCollection")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 	res, err := vsClient.GetItemsInCollection(params.CollectionID, params.Limit)
 	if err != nil {
 		return nil, err

--- a/activities/vidispine/items.go
+++ b/activities/vidispine/items.go
@@ -16,9 +16,7 @@ func (a Activities) DeleteItems(ctx context.Context, params DeleteItemsParams) (
 	log := activity.GetLogger(ctx)
 	log.Info("Starting DeleteItems")
 
-	vsClient := a.Client
-
-	return nil, vsClient.DeleteItems(ctx, params.VXIDs, params.DeleteFiles)
+	return nil, a.Client.DeleteItems(ctx, params.VXIDs, params.DeleteFiles)
 }
 
 type GetItemsInCollectionParams struct {
@@ -30,8 +28,7 @@ func (a Activities) GetItemsInCollection(ctx context.Context, params GetItemsInC
 	log := activity.GetLogger(ctx)
 	log.Info("Starting GetItemsInCollection")
 
-	vsClient := a.Client
-	res, err := vsClient.GetItemsInCollection(params.CollectionID, params.Limit)
+	res, err := a.Client.GetItemsInCollection(params.CollectionID, params.Limit)
 	if err != nil {
 		return nil, err
 	}

--- a/activities/vidispine/meta.go
+++ b/activities/vidispine/meta.go
@@ -30,9 +30,7 @@ func (a Activities) GetFileFromVXActivity(ctx context.Context, params GetFileFro
 	log := activity.GetLogger(ctx)
 	log.Info("Starting GetFileFromVXActivity")
 
-	vsClient := a.Client
-
-	shapes, err := vsClient.GetShapes(params.VXID)
+	shapes, err := a.Client.GetShapes(params.VXID)
 	if err != nil {
 		return nil, err
 	}
@@ -54,8 +52,7 @@ func (a Activities) GetFileFromVXActivity(ctx context.Context, params GetFileFro
 }
 
 func (a Activities) GetVXMetadata(_ context.Context, params VXOnlyParam) (*vsapi.MetadataResult, error) {
-	vsClient := a.Client
-	data, err := vsClient.GetMetadata(params.VXID)
+	data, err := a.Client.GetMetadata(params.VXID)
 	return data, err
 }
 
@@ -65,12 +62,11 @@ type GetVXMetadataFieldsParams struct {
 }
 
 func (a Activities) GetVXMetadataFields(_ context.Context, params GetVXMetadataFieldsParams) (*vsapi.MetadataResult, error) {
-	vsClient := a.Client
 	fields := make([]string, len(params.Fields))
 	for i, f := range params.Fields {
 		fields[i] = f.Value
 	}
-	return vsClient.GetMetadataFields(params.VXID, fields)
+	return a.Client.GetMetadataFields(params.VXID, fields)
 }
 
 type VXMetadataFieldParams = vsapi.ItemMetadataFieldParams
@@ -82,9 +78,7 @@ func (a Activities) SetVXMetadataFieldActivity(ctx context.Context, params vsapi
 	log := activity.GetLogger(ctx)
 	log.Info("Starting SetVXMetadataFieldActivity")
 
-	vsClient := a.Client
-
-	err := vsClient.SetItemMetadataField(params)
+	err := a.Client.SetItemMetadataField(params)
 	return nil, err
 }
 
@@ -92,9 +86,7 @@ func (a Activities) AddToVXMetadataFieldActivity(ctx context.Context, params vsa
 	log := activity.GetLogger(ctx)
 	log.Info("Starting SetVXMetadataFieldActivity")
 
-	vsClient := a.Client
-
-	err := vsClient.AddToItemMetadataField(params)
+	err := a.Client.AddToItemMetadataField(params)
 	return nil, err
 }
 
@@ -106,27 +98,21 @@ func (a Activities) GetResolutions(ctx context.Context, params GetResolutionsPar
 	log := activity.GetLogger(ctx)
 	log.Info("Starting GetResolutions")
 
-	vsClient := a.Client
-
-	return vsClient.GetResolutions(params.VXID)
+	return a.Client.GetResolutions(params.VXID)
 }
 
 func (a Activities) GetRelations(ctx context.Context, assetID string) ([]vsapi.Relation, error) {
 	log := activity.GetLogger(ctx)
 	log.Info("Starting GetRelations")
 
-	vsClient := a.Client
-
-	return vsClient.GetRelations(assetID)
+	return a.Client.GetRelations(assetID)
 }
 
 func (a Activities) GetTrashedItems(ctx context.Context, _ any) ([]string, error) {
 	log := activity.GetLogger(ctx)
 	log.Info("Starting GetTrashedItems")
 
-	vsClient := a.Client
-
-	return vsClient.GetTrash()
+	return a.Client.GetTrash()
 }
 
 type SearchByMetadataFieldParams struct {
@@ -148,9 +134,7 @@ func (a Activities) UpdateAssetRelations(ctx context.Context, params VXOnlyParam
 	log := activity.GetLogger(ctx)
 	log.Info("Starting UpdateAssetRelations")
 
-	vsClient := a.Client
-
-	relations, err := vsClient.GetRelations(vxID)
+	relations, err := a.Client.GetRelations(vxID)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +146,7 @@ func (a Activities) UpdateAssetRelations(ctx context.Context, params VXOnlyParam
 			other = relation.Direction.Target
 		}
 
-		meta, err := vsClient.GetMetadata(other)
+		meta, err := a.Client.GetMetadata(other)
 		if err != nil {
 			return nil, err
 		}
@@ -188,7 +172,7 @@ func (a Activities) UpdateAssetRelations(ctx context.Context, params VXOnlyParam
 		title = title[len(title)-3:]
 
 		if l, ok := languages.LanguagesByISO[strings.ToLower(title)]; ok {
-			err := vsClient.SetItemMetadataField(
+			err := a.Client.SetItemMetadataField(
 				vsapi.ItemMetadataFieldParams{
 					ItemID:  vxID,
 					GroupID: "System",
@@ -209,7 +193,5 @@ func (a Activities) GetShapes(ctx context.Context, params VXOnlyParam) (*vsapi.S
 	log := activity.GetLogger(ctx)
 	log.Info("Starting GetShapes")
 
-	vsClient := a.Client
-
-	return vsClient.GetShapes(params.VXID)
+	return a.Client.GetShapes(params.VXID)
 }

--- a/activities/vidispine/meta.go
+++ b/activities/vidispine/meta.go
@@ -30,7 +30,7 @@ func (a Activities) GetFileFromVXActivity(ctx context.Context, params GetFileFro
 	log := activity.GetLogger(ctx)
 	log.Info("Starting GetFileFromVXActivity")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	shapes, err := vsClient.GetShapes(params.VXID)
 	if err != nil {
@@ -54,7 +54,7 @@ func (a Activities) GetFileFromVXActivity(ctx context.Context, params GetFileFro
 }
 
 func (a Activities) GetVXMetadata(_ context.Context, params VXOnlyParam) (*vsapi.MetadataResult, error) {
-	vsClient := GetClient()
+	vsClient := a.Client
 	data, err := vsClient.GetMetadata(params.VXID)
 	return data, err
 }
@@ -65,7 +65,7 @@ type GetVXMetadataFieldsParams struct {
 }
 
 func (a Activities) GetVXMetadataFields(_ context.Context, params GetVXMetadataFieldsParams) (*vsapi.MetadataResult, error) {
-	vsClient := GetClient()
+	vsClient := a.Client
 	fields := make([]string, len(params.Fields))
 	for i, f := range params.Fields {
 		fields[i] = f.Value
@@ -82,7 +82,7 @@ func (a Activities) SetVXMetadataFieldActivity(ctx context.Context, params vsapi
 	log := activity.GetLogger(ctx)
 	log.Info("Starting SetVXMetadataFieldActivity")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	err := vsClient.SetItemMetadataField(params)
 	return nil, err
@@ -92,7 +92,7 @@ func (a Activities) AddToVXMetadataFieldActivity(ctx context.Context, params vsa
 	log := activity.GetLogger(ctx)
 	log.Info("Starting SetVXMetadataFieldActivity")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	err := vsClient.AddToItemMetadataField(params)
 	return nil, err
@@ -102,11 +102,11 @@ type GetResolutionsParams struct {
 	VXID string
 }
 
-func GetResolutions(ctx context.Context, params GetResolutionsParams) ([]vsapi.Resolution, error) {
+func (a Activities) GetResolutions(ctx context.Context, params GetResolutionsParams) ([]vsapi.Resolution, error) {
 	log := activity.GetLogger(ctx)
 	log.Info("Starting GetResolutions")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	return vsClient.GetResolutions(params.VXID)
 }
@@ -115,7 +115,7 @@ func (a Activities) GetRelations(ctx context.Context, assetID string) ([]vsapi.R
 	log := activity.GetLogger(ctx)
 	log.Info("Starting GetRelations")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	return vsClient.GetRelations(assetID)
 }
@@ -124,7 +124,7 @@ func (a Activities) GetTrashedItems(ctx context.Context, _ any) ([]string, error
 	log := activity.GetLogger(ctx)
 	log.Info("Starting GetTrashedItems")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	return vsClient.GetTrash()
 }
@@ -138,7 +138,7 @@ func (a Activities) SearchItemsByMetadataField(ctx context.Context, params Searc
 	log := activity.GetLogger(ctx)
 	log.Info("Starting SearchItemsByMetadataField", "name", params.Name, "value", params.Value)
 
-	return GetClient().SearchByMetadataField(params.Name, params.Value)
+	return a.Client.SearchByMetadataField(params.Name, params.Value)
 }
 
 // UpdateAssetRelations attempts to find languages of related audio files and update the metadata
@@ -148,7 +148,7 @@ func (a Activities) UpdateAssetRelations(ctx context.Context, params VXOnlyParam
 	log := activity.GetLogger(ctx)
 	log.Info("Starting UpdateAssetRelations")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	relations, err := vsClient.GetRelations(vxID)
 	if err != nil {
@@ -209,7 +209,7 @@ func (a Activities) GetShapes(ctx context.Context, params VXOnlyParam) (*vsapi.S
 	log := activity.GetLogger(ctx)
 	log.Info("Starting GetShapes")
 
-	vsClient := GetClient()
+	vsClient := a.Client
 
 	return vsClient.GetShapes(params.VXID)
 }

--- a/activities/vizualizer_test.go
+++ b/activities/vizualizer_test.go
@@ -15,6 +15,10 @@ import (
 	"go.temporal.io/sdk/testsuite"
 )
 
+type vizConfig struct{ baseURL string }
+
+func (c vizConfig) Vizualizer() string { return c.baseURL }
+
 // vizualizerStub answers status polls with "processing" until the given number
 // of polls have happened, then "completed".
 func vizualizerStub(t *testing.T, pollsBeforeDone int) (*vizualizer.Client, *atomic.Int32) {
@@ -32,7 +36,7 @@ func vizualizerStub(t *testing.T, pollsBeforeDone int) (*vizualizer.Client, *ato
 	}))
 	t.Cleanup(server.Close)
 
-	client, err := vizualizer.NewClient(server.URL)
+	client, err := vizualizer.NewClient(vizConfig{server.URL})
 	require.NoError(t, err)
 	return client, &polls
 }

--- a/cmd/trigger_ui/main.go
+++ b/cmd/trigger_ui/main.go
@@ -472,7 +472,7 @@ func main() {
 
 	router := gin.Default()
 
-	vsapiClient := vsapi.NewFromConfig(environment.Get().Vidispine)
+	vsapiClient := vsapi.NewClient(environment.Get().Vidispine)
 	wfClient, err := getTemporalClient()
 	if err != nil {
 		panic(err.Error())

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -148,13 +148,13 @@ func main() {
 func registerWorker(c client.Client, queue string, options worker.Options) {
 	w := worker.New(c, queue, options)
 
-	directusClient := directus.NewFromConfig(environment.Get().Directus)
+	directusClient := directus.NewClient(environment.Get().Directus)
 	activities.Directus = &activities.DirectusActivities{
 		Client:         directusClient,
 		ShortsFolderID: environment.Get().Directus.ShortsFolderID(),
 	}
 
-	clickUpClient, err := clickup.NewFromConfig(environment.Get().ClickUp)
+	clickUpClient, err := clickup.NewClient(environment.Get().ClickUp)
 	if err != nil {
 		log.Printf("Error creating ClickUp client: %v", err)
 	}
@@ -162,7 +162,7 @@ func registerWorker(c client.Client, queue string, options worker.Options) {
 		Client: clickUpClient,
 	}
 
-	vizClient, err := vizualizer.NewFromConfig(environment.Get().Services)
+	vizClient, err := vizualizer.NewClient(environment.Get().Services)
 	if err != nil {
 		log.Printf("Error creating vizualizer client: %v", err)
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/bcc-code/bcc-media-flows/internal/bootstrap"
+	cantemo "github.com/bcc-code/bcc-media-flows/services/cantemo"
+	"github.com/bcc-code/bcc-media-flows/services/subtrans"
+	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsapi"
 	"log"
 	"os"
 	"os/exec"
@@ -22,7 +25,6 @@ import (
 	"github.com/bcc-code/bcc-media-flows/workflows"
 
 	"github.com/bcc-code/bcc-media-flows/activities"
-	"github.com/bcc-code/bcc-media-flows/activities/cantemo"
 	"github.com/bcc-code/bcc-media-flows/environment"
 	"github.com/teamwork/reload"
 	"go.temporal.io/sdk/activity"
@@ -34,11 +36,15 @@ import (
 	selfupdate "github.com/creativeprojects/go-selfupdate"
 )
 
-var utilActivities = []any{
-	cantemo.AddRelation,
-	cantemo.RenameFile,
-	cantemo.MoveFileWait,
-	cantemo.GetTaskInfo,
+// utilActivities is a function, not a var: a method value captures the receiver, and
+// at package-init time the clients are not built yet.
+func utilActivities() []any {
+	return []any{
+		activities.Cantemo.AddRelation,
+		activities.Cantemo.RenameFile,
+		activities.Cantemo.MoveFileWait,
+		activities.Cantemo.GetTaskInfo,
+	}
 }
 
 // registerActivitiesInStruct registers all methods in a struct as activities
@@ -142,39 +148,52 @@ func main() {
 		go rclone.StartFileTransferQueue()
 	}
 
+	buildClients(environment.Get())
+
 	registerWorker(c, environment.GetQueue(), workerOptions)
+}
+
+// buildClients constructs every service client once, from the configuration, and hands
+// them to the activities that use them. Nothing reaches for a client later.
+func buildClients(cfg *environment.Config) {
+	vsClient := vsapi.NewClient(cfg.Vidispine)
+	cantemoClient := cantemo.NewClient(cfg.Cantemo)
+
+	activities.Vidispine.Client = vsClient
+	activities.Cantemo.Client = cantemoClient
+
+	activities.Platform.Vidispine = vsClient
+	activities.Platform.Cantemo = cantemoClient
+
+	activities.Util.Vidispine = vsClient
+	activities.Util.Subtrans = subtrans.NewClient(cfg.Subtrans)
+
+	activities.Directus = &activities.DirectusActivities{
+		Client:         directus.NewClient(cfg.Directus),
+		ShortsFolderID: cfg.Directus.ShortsFolderID(),
+	}
+
+	clickUpClient, err := clickup.NewClient(cfg.ClickUp)
+	if err != nil {
+		log.Printf("Error creating ClickUp client: %v", err)
+	}
+	activities.ClickUp = &activities.ClickUpActivities{Client: clickUpClient}
+
+	vizClient, err := vizualizer.NewClient(cfg.Services)
+	if err != nil {
+		log.Printf("Error creating vizualizer client: %v", err)
+	}
+	activities.Vizualizer = &activities.VizualizerActivities{Client: vizClient}
 }
 
 func registerWorker(c client.Client, queue string, options worker.Options) {
 	w := worker.New(c, queue, options)
 
-	directusClient := directus.NewClient(environment.Get().Directus)
-	activities.Directus = &activities.DirectusActivities{
-		Client:         directusClient,
-		ShortsFolderID: environment.Get().Directus.ShortsFolderID(),
-	}
-
-	clickUpClient, err := clickup.NewClient(environment.Get().ClickUp)
-	if err != nil {
-		log.Printf("Error creating ClickUp client: %v", err)
-	}
-	activities.ClickUp = &activities.ClickUpActivities{
-		Client: clickUpClient,
-	}
-
-	vizClient, err := vizualizer.NewClient(environment.Get().Services)
-	if err != nil {
-		log.Printf("Error creating vizualizer client: %v", err)
-	}
-	activities.Vizualizer = &activities.VizualizerActivities{
-		Client: vizClient,
-	}
-
 	switch queue {
 	case environment.QueueDebug:
 		registerActivitiesInStruct(w, activities.Util)
 
-		for _, a := range utilActivities {
+		for _, a := range utilActivities() {
 			w.RegisterActivity(a)
 		}
 
@@ -200,7 +219,7 @@ func registerWorker(c client.Client, queue string, options worker.Options) {
 	case environment.QueueWorker:
 		registerActivitiesInStruct(w, activities.Util)
 
-		for _, a := range utilActivities {
+		for _, a := range utilActivities() {
 			w.RegisterActivity(a)
 		}
 
@@ -223,7 +242,7 @@ func registerWorker(c client.Client, queue string, options worker.Options) {
 	}
 
 	fmt.Println("STARTING")
-	err = w.Run(worker.InterruptCh())
+	err := w.Run(worker.InterruptCh())
 
 	log.Printf("Worker finished: %v", err)
 

--- a/cmd/worker/registration_test.go
+++ b/cmd/worker/registration_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bcc-code/bcc-media-flows/activities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The activity structs are pointers so boot can set their clients.
+// registerActivitiesInStruct reflects over them, and value-receiver methods are in a
+// pointer's method set — but a struct registering nothing would fail silently at
+// runtime, with the worker simply not answering those activities.
+func TestActivityStructsStillExposeTheirMethods(t *testing.T) {
+	structs := map[string]any{
+		"Util":      activities.Util,
+		"Vidispine": activities.Vidispine,
+		"Cantemo":   activities.Cantemo,
+		"Platform":  activities.Platform,
+		"Live":      activities.Live,
+	}
+
+	for name, s := range structs {
+		assert.Positive(t, reflect.TypeOf(s).NumMethod(), "%s registers no activities", name)
+	}
+}
+
+// The registration list captures method values, which copy the receiver. Building it
+// before the clients exist would register activities holding a nil client.
+func TestUtilActivitiesAreBuiltAfterTheClients(t *testing.T) {
+	require.NotEmpty(t, utilActivities())
+
+	for _, a := range utilActivities() {
+		assert.Equal(t, reflect.Func, reflect.TypeOf(a).Kind())
+	}
+}

--- a/services/cantemo/client.go
+++ b/services/cantemo/client.go
@@ -37,11 +37,9 @@ type Config interface {
 	Token() string
 }
 
-func NewFromConfig(cfg Config) *Client {
-	return NewClient(cfg.URL(), cfg.Token())
-}
+func NewClient(cfg Config) *Client {
+	baseURL, authToken := cfg.URL(), cfg.Token()
 
-func NewClient(baseURL, authToken string) *Client {
 	baseURL = strings.TrimSuffix(baseURL, "/")
 
 	client := httpx.New(httpx.Config{

--- a/services/cantemo/client.go
+++ b/services/cantemo/client.go
@@ -38,9 +38,8 @@ type Config interface {
 }
 
 func NewClient(cfg Config) *Client {
-	baseURL, authToken := cfg.URL(), cfg.Token()
-
-	baseURL = strings.TrimSuffix(baseURL, "/")
+	baseURL := strings.TrimSuffix(cfg.URL(), "/")
+	authToken := cfg.Token()
 
 	client := httpx.New(httpx.Config{
 		Service: serviceName,

--- a/services/cantemo/client_test.go
+++ b/services/cantemo/client_test.go
@@ -6,6 +6,14 @@ import (
 	"testing"
 )
 
+type testConfig struct {
+	url   string
+	token string
+}
+
+func (c testConfig) URL() string   { return c.url }
+func (c testConfig) Token() string { return c.token }
+
 // TestAddRelation tests is a bare-bones check,
 // it does not check if the relation was actually added.
 func TestAddRelation(t *testing.T) {
@@ -20,7 +28,7 @@ func TestAddRelation(t *testing.T) {
 		t.Skip("CANTEMO_TOKEN not set")
 	}
 
-	client := NewClient(cantemoBaseURL, cantemoToken)
+	client := NewClient(testConfig{url: cantemoBaseURL, token: cantemoToken})
 	err := client.AddRelation("VX-parent", "VX-child")
 	assert.NoError(t, err)
 }
@@ -37,7 +45,7 @@ func TestClient_GetTranscriptionJSON(t *testing.T) {
 		t.Skip("CANTEMO_TOKEN not set")
 	}
 
-	client := NewClient(baseURL, token)
+	client := NewClient(testConfig{url: baseURL, token: token})
 	tr, err := client.GetTranscriptionJSON("VX-486350")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, tr)
@@ -55,7 +63,7 @@ func TestClient_GetPreview(t *testing.T) {
 		t.Skip("CANTEMO_TOKEN not set")
 	}
 
-	client := NewClient(baseURL, token)
+	client := NewClient(testConfig{url: baseURL, token: token})
 	meta, err := client.GetPreviewUrl("VX-486350")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, meta)
@@ -73,7 +81,7 @@ func TestClient_GetFiles(t *testing.T) {
 		t.Skip("CANTEMO_TOKEN not set")
 	}
 
-	client := NewClient(baseURL, token)
+	client := NewClient(testConfig{url: baseURL, token: token})
 	files, err := client.GetFiles(
 		"/",
 		"imported",

--- a/services/cantemo/httpx_test.go
+++ b/services/cantemo/httpx_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestClient_HasATimeout(t *testing.T) {
-	client := NewClient("http://cantemo.example", "token")
+	client := NewClient(testConfig{url: "http://cantemo.example", token: "token"})
 
 	assert.Positive(t, client.restyClient.GetClient().Timeout)
 }
@@ -26,7 +26,7 @@ func TestClient_SendsTheAuthTokenAndAcceptHeaders(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL, "secret-token")
+	client := NewClient(testConfig{url: server.URL, token: "secret-token"})
 	_, err := client.GetFiles("/mnt/x", "imported", "storage", 0, "")
 
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestClient_BaseURLTrailingSlashIsTrimmed(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL+"/", "token")
+	client := NewClient(testConfig{url: server.URL + "/", token: "token"})
 	err := client.AddRelation("VX-1", "VX-2")
 
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestClient_DescribeErrorFallsBackToTheSharedDescription(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL, "token")
+	client := NewClient(testConfig{url: server.URL, token: "token"})
 	_, err := client.GetFiles("/mnt/x", "imported", "storage", 0, "")
 
 	require.Error(t, err)

--- a/services/cantemo/methods_test.go
+++ b/services/cantemo/methods_test.go
@@ -31,7 +31,7 @@ func routedServer(t *testing.T, bodyByPrefix map[string]string) (*Client, *[]str
 	}))
 	t.Cleanup(server.Close)
 
-	return NewClient(server.URL, "token"), &requested
+	return NewClient(testConfig{url: server.URL, token: "token"}), &requested
 }
 
 func TestGetFormats_SuccessParsesTheFormats(t *testing.T) {
@@ -92,7 +92,7 @@ func TestGetTranscriptionJSON_DownloadFailureIsAnError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL, "token")
+	client := NewClient(testConfig{url: server.URL, token: "token"})
 	transcription, err := client.GetTranscriptionJSON("VX-1")
 
 	require.Error(t, err)
@@ -106,7 +106,7 @@ func TestGetPreviewUrl_ReturnsAnAbsoluteURL(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL, "token")
+	client := NewClient(testConfig{url: server.URL, token: "token"})
 	url, err := client.GetPreviewUrl("VX-1")
 
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestGetFiles_SendsTheListingParameters(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL, "token")
+	client := NewClient(testConfig{url: server.URL, token: "token"})
 	_, err := client.GetFiles("/mnt/x", "imported", "isilon", 3, "name:a.mxf")
 
 	require.NoError(t, err)
@@ -243,7 +243,7 @@ func TestMoveFileAndRenameFile(t *testing.T) {
 			}))
 			t.Cleanup(server.Close)
 
-			client := NewClient(server.URL, "token")
+			client := NewClient(testConfig{url: server.URL, token: "token"})
 			taskID, err := test.call(client)
 
 			require.NoError(t, err)
@@ -320,7 +320,7 @@ func TestAddRelation_PostsToTheRelationPath(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL, "token")
+	client := NewClient(testConfig{url: server.URL, token: "token"})
 	err := client.AddRelation("VX-parent", "VX-child")
 
 	require.NoError(t, err)

--- a/services/cantemo/status_test.go
+++ b/services/cantemo/status_test.go
@@ -21,7 +21,7 @@ func cantemoServer(t *testing.T, status int, contentType, body string) *Client {
 	}))
 	t.Cleanup(server.Close)
 
-	return NewClient(server.URL, "token")
+	return NewClient(testConfig{url: server.URL, token: "token"})
 }
 
 // Hole 1, the important one. resty only unmarshals an error body for JSON/XML, so the

--- a/services/clickup/client.go
+++ b/services/clickup/client.go
@@ -48,7 +48,10 @@ type Config interface {
 }
 
 func NewClient(cfg Config) (*Client, error) {
-	baseURL, workspaceID, viewID, token := cfg.FrontdoorBaseURL(), cfg.WorkspaceID(), cfg.ShortsViewID(), cfg.ShortsViewToken()
+	baseURL := cfg.FrontdoorBaseURL()
+	workspaceID := cfg.WorkspaceID()
+	viewID := cfg.ShortsViewID()
+	token := cfg.ShortsViewToken()
 
 	if baseURL == "" {
 		baseURL = defaultBaseURL

--- a/services/clickup/client.go
+++ b/services/clickup/client.go
@@ -47,11 +47,9 @@ type Config interface {
 	ShortsViewToken() string
 }
 
-func NewFromConfig(cfg Config) (*Client, error) {
-	return NewClient(cfg.FrontdoorBaseURL(), cfg.WorkspaceID(), cfg.ShortsViewID(), cfg.ShortsViewToken())
-}
+func NewClient(cfg Config) (*Client, error) {
+	baseURL, workspaceID, viewID, token := cfg.FrontdoorBaseURL(), cfg.WorkspaceID(), cfg.ShortsViewID(), cfg.ShortsViewToken()
 
-func NewClient(baseURL, workspaceID, viewID, token string) (*Client, error) {
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}

--- a/services/clickup/client_test.go
+++ b/services/clickup/client_test.go
@@ -12,6 +12,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testConfig struct {
+	baseURL     string
+	workspaceID string
+	viewID      string
+	token       string
+}
+
+func (c testConfig) FrontdoorBaseURL() string { return c.baseURL }
+func (c testConfig) WorkspaceID() string      { return c.workspaceID }
+func (c testConfig) ShortsViewID() string     { return c.viewID }
+func (c testConfig) ShortsViewToken() string  { return c.token }
+
 func viewPage(lastPage bool, taskIDs ...string) string {
 	ids, _ := json.Marshal(taskIDs)
 	last := "false"
@@ -46,7 +58,7 @@ func clickupServer(t *testing.T, pages []string, tasksBody string) (*Client, *in
 	}))
 	t.Cleanup(server.Close)
 
-	client, err := NewClient(server.URL, "ws-1", "view-1", "token-1")
+	client, err := NewClient(testConfig{baseURL: server.URL, workspaceID: "ws-1", viewID: "view-1", token: "token-1"})
 	require.NoError(t, err)
 
 	return client, &posts
@@ -77,7 +89,7 @@ func TestListTasks_ViewLoadFailureIsAnError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client, err := NewClient(server.URL, "ws-1", "view-1", "token-1")
+	client, err := NewClient(testConfig{baseURL: server.URL, workspaceID: "ws-1", viewID: "view-1", token: "token-1"})
 	require.NoError(t, err)
 
 	tasks, err := client.ListTasks()
@@ -99,7 +111,7 @@ func TestListTasks_TaskFetchFailureIsAnError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client, err := NewClient(server.URL, "ws-1", "view-1", "token-1")
+	client, err := NewClient(testConfig{baseURL: server.URL, workspaceID: "ws-1", viewID: "view-1", token: "token-1"})
 	require.NoError(t, err)
 
 	tasks, err := client.ListTasks()
@@ -143,7 +155,7 @@ func TestClient_SendsTheShareToken(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client, err := NewClient(server.URL, "ws-1", "view-1", "token-1")
+	client, err := NewClient(testConfig{baseURL: server.URL, workspaceID: "ws-1", viewID: "view-1", token: "token-1"})
 	require.NoError(t, err)
 
 	_, err = client.ListTasks()
@@ -165,7 +177,7 @@ func TestClient_RequestsTheViewPaths(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client, err := NewClient(server.URL, "ws-1", "view-1", "token-1")
+	client, err := NewClient(testConfig{baseURL: server.URL, workspaceID: "ws-1", viewID: "view-1", token: "token-1"})
 	require.NoError(t, err)
 
 	_, err = client.ListTasks()
@@ -177,7 +189,7 @@ func TestClient_RequestsTheViewPaths(t *testing.T) {
 }
 
 func TestNewClient_EmptyArgumentsUseTheDefaults(t *testing.T) {
-	client, err := NewClient("", "", "", "")
+	client, err := NewClient(testConfig{baseURL: "", workspaceID: "", viewID: "", token: ""})
 
 	require.NoError(t, err)
 	assert.Equal(t, defaultBaseURL, client.baseURL)
@@ -188,7 +200,7 @@ func TestNewClient_EmptyArgumentsUseTheDefaults(t *testing.T) {
 }
 
 func TestClient_HasATimeout(t *testing.T) {
-	client, err := NewClient("", "", "", "")
+	client, err := NewClient(testConfig{baseURL: "", workspaceID: "", viewID: "", token: ""})
 	require.NoError(t, err)
 
 	assert.Positive(t, client.client.GetClient().Timeout)

--- a/services/directus/client.go
+++ b/services/directus/client.go
@@ -30,11 +30,9 @@ type Config interface {
 	APIKey() string
 }
 
-func NewFromConfig(cfg Config) *Client {
-	return NewClient(cfg.BaseURL(), cfg.APIKey())
-}
+func NewClient(cfg Config) *Client {
+	baseURL, apiKey := cfg.BaseURL(), cfg.APIKey()
 
-func NewClient(baseURL, apiKey string) *Client {
 	client := httpx.New(httpx.Config{
 		Service: serviceName,
 		BaseURL: baseURL,

--- a/services/directus/client.go
+++ b/services/directus/client.go
@@ -31,7 +31,8 @@ type Config interface {
 }
 
 func NewClient(cfg Config) *Client {
-	baseURL, apiKey := cfg.BaseURL(), cfg.APIKey()
+	baseURL := cfg.BaseURL()
+	apiKey := cfg.APIKey()
 
 	client := httpx.New(httpx.Config{
 		Service: serviceName,

--- a/services/directus/client_test.go
+++ b/services/directus/client_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testConfig struct {
+	baseURL string
+	apiKey  string
+}
+
+func (c testConfig) BaseURL() string { return c.baseURL }
+func (c testConfig) APIKey() string  { return c.apiKey }
+
 func directusServer(t *testing.T, status int, body string) *Client {
 	t.Helper()
 
@@ -21,7 +29,7 @@ func directusServer(t *testing.T, status int, body string) *Client {
 	}))
 	t.Cleanup(server.Close)
 
-	return NewClient(server.URL, "test-api-key")
+	return NewClient(testConfig{baseURL: server.URL, apiKey: "test-api-key"})
 }
 
 func recordingServer(t *testing.T, body string) (*Client, *http.Request) {
@@ -35,7 +43,7 @@ func recordingServer(t *testing.T, body string) (*Client, *http.Request) {
 	}))
 	t.Cleanup(server.Close)
 
-	return NewClient(server.URL, "test-api-key"), captured
+	return NewClient(testConfig{baseURL: server.URL, apiKey: "test-api-key"}), captured
 }
 
 func TestClient_ServerErrorsAreErrors(t *testing.T) {
@@ -75,7 +83,7 @@ func TestClient_HTMLErrorBodyIsAnError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL, "test-api-key")
+	client := NewClient(testConfig{baseURL: server.URL, apiKey: "test-api-key"})
 	asset, err := client.GetAssetByMediabankenID("MB-1")
 
 	require.Error(t, err)
@@ -172,7 +180,7 @@ func TestCreateStyledImage_RejectsAnUnknownStyleWithoutCallingDirectus(t *testin
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL, "test-api-key")
+	client := NewClient(testConfig{baseURL: server.URL, apiKey: "test-api-key"})
 	_, err := client.CreateStyledImage("file-1", "banner")
 
 	require.Error(t, err)
@@ -218,7 +226,7 @@ func TestUploadFile_SendsTheFileAndParsesTheResult(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL, "test-api-key")
+	client := NewClient(testConfig{baseURL: server.URL, apiKey: "test-api-key"})
 	file, err := client.UploadFile("folder-1", path)
 
 	require.NoError(t, err)
@@ -229,7 +237,7 @@ func TestUploadFile_SendsTheFileAndParsesTheResult(t *testing.T) {
 }
 
 func TestClient_TimeoutCoversTheUpload(t *testing.T) {
-	client := NewClient("http://directus.example", "test-api-key")
+	client := NewClient(testConfig{baseURL: "http://directus.example", apiKey: "test-api-key"})
 
 	assert.GreaterOrEqual(t, client.client.GetClient().Timeout, uploadTimeout)
 }

--- a/services/subtrans/client.go
+++ b/services/subtrans/client.go
@@ -24,7 +24,8 @@ type Config interface {
 }
 
 func NewClient(cfg Config) *Client {
-	baseURL, apiKey := cfg.BaseURL(), cfg.APIKey()
+	baseURL := cfg.BaseURL()
+	apiKey := cfg.APIKey()
 
 	client := httpx.New(httpx.Config{
 		Service: serviceName,

--- a/services/subtrans/client.go
+++ b/services/subtrans/client.go
@@ -23,11 +23,9 @@ type Config interface {
 	APIKey() string
 }
 
-func NewFromConfig(cfg Config) *Client {
-	return NewClient(cfg.BaseURL(), cfg.APIKey())
-}
+func NewClient(cfg Config) *Client {
+	baseURL, apiKey := cfg.BaseURL(), cfg.APIKey()
 
-func NewClient(baseURL string, apiKey string) *Client {
 	client := httpx.New(httpx.Config{
 		Service: serviceName,
 		BaseURL: baseURL,

--- a/services/subtrans/client_test.go
+++ b/services/subtrans/client_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testConfig struct {
+	baseURL string
+	apiKey  string
+}
+
+func (c testConfig) BaseURL() string { return c.baseURL }
+func (c testConfig) APIKey() string  { return c.apiKey }
+
 func subtransServer(t *testing.T, status int, contentType, body string) *Client {
 	t.Helper()
 
@@ -21,7 +29,7 @@ func subtransServer(t *testing.T, status int, contentType, body string) *Client 
 	}))
 	t.Cleanup(server.Close)
 
-	return NewClient(server.URL, "test-api-key")
+	return NewClient(testConfig{baseURL: server.URL, apiKey: "test-api-key"})
 }
 
 func routingServer(t *testing.T, storyBody string, exportStatus int, exportBody string) (*Client, *int) {
@@ -41,7 +49,7 @@ func routingServer(t *testing.T, storyBody string, exportStatus int, exportBody 
 	}))
 	t.Cleanup(server.Close)
 
-	return NewClient(server.URL, "test-api-key"), &exports
+	return NewClient(testConfig{baseURL: server.URL, apiKey: "test-api-key"}), &exports
 }
 
 const oneNorwegianLanguage = `{"id":42,"name":"AABC-%lang%","languages":[{"isoName":"NOR","approved":true}]}`
@@ -152,7 +160,7 @@ func TestClient_SendsTheAPIKeyOnEveryRequest(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL, "test-api-key")
+	client := NewClient(testConfig{baseURL: server.URL, apiKey: "test-api-key"})
 	_, err := client.GetSubtitles("42", SubTypeSRT, true)
 
 	require.NoError(t, err)
@@ -187,7 +195,7 @@ func TestGetSubtitles_PassesApprovedOnlyThrough(t *testing.T) {
 			}))
 			t.Cleanup(server.Close)
 
-			client := NewClient(server.URL, "test-api-key")
+			client := NewClient(testConfig{baseURL: server.URL, apiKey: "test-api-key"})
 			_, err := client.GetSubtitles("42", SubTypeSRT, approvedOnly)
 
 			require.NoError(t, err)
@@ -200,7 +208,7 @@ func TestClient_TransportErrorDoesNotLeakTheKey(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	server.Close()
 
-	client := NewClient(server.URL, "s3cr3t-api-key")
+	client := NewClient(testConfig{baseURL: server.URL, apiKey: "s3cr3t-api-key"})
 
 	for _, test := range []struct {
 		name string

--- a/services/vidispine/vsapi/http.go
+++ b/services/vidispine/vsapi/http.go
@@ -44,11 +44,9 @@ type Config interface {
 	Password() string
 }
 
-func NewFromConfig(cfg Config) *Client {
-	return NewClient(cfg.BaseURL(), cfg.Username(), cfg.Password())
-}
+func NewClient(cfg Config) *Client {
+	baseURL, username, password := cfg.BaseURL(), cfg.Username(), cfg.Password()
 
-func NewClient(baseURL string, username string, password string) *Client {
 	// The retries reach POST and DELETE, so the timeout has to outlast a slow call
 	// rather than merely a healthy one: retrying a working AddShapeToItem or
 	// CreatePlaceholder creates a second shape or job.

--- a/services/vidispine/vsapi/http.go
+++ b/services/vidispine/vsapi/http.go
@@ -45,7 +45,9 @@ type Config interface {
 }
 
 func NewClient(cfg Config) *Client {
-	baseURL, username, password := cfg.BaseURL(), cfg.Username(), cfg.Password()
+	baseURL := cfg.BaseURL()
+	username := cfg.Username()
+	password := cfg.Password()
 
 	// The retries reach POST and DELETE, so the timeout has to outlast a slow call
 	// rather than merely a healthy one: retrying a working AddShapeToItem or

--- a/services/vidispine/vsapi/http_test.go
+++ b/services/vidispine/vsapi/http_test.go
@@ -13,6 +13,17 @@ import (
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vscommon"
 )
 
+// testConfig is what a client needs, without the environment.
+type testConfig struct {
+	baseURL  string
+	username string
+	password string
+}
+
+func (c testConfig) BaseURL() string  { return c.baseURL }
+func (c testConfig) Username() string { return c.username }
+func (c testConfig) Password() string { return c.password }
+
 // vsServer serves a fixed status and body for every request, and records how many
 // requests it saw.
 func vsServer(t *testing.T, status int, body string) (*Client, *int) {
@@ -27,7 +38,7 @@ func vsServer(t *testing.T, status int, body string) (*Client, *int) {
 	}))
 	t.Cleanup(server.Close)
 
-	return NewClient(server.URL, "user", "pass"), &calls
+	return NewClient(testConfig{baseURL: server.URL, username: "user", password: "pass"}), &calls
 }
 
 // A server error must reach the caller as an error. resty leaves err nil for 4xx/5xx
@@ -79,7 +90,7 @@ func TestClient_NonJSONErrorBodyIsStillAnError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "user", "pass")
+	client := NewClient(testConfig{baseURL: server.URL, username: "user", password: "pass"})
 
 	result, err := client.GetShapes("VX-1")
 
@@ -127,7 +138,7 @@ func TestClient_FileExistsInStorageTolerates404(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "user", "pass")
+	client := NewClient(testConfig{baseURL: server.URL, username: "user", password: "pass"})
 
 	exists, err := client.FileExistsInStorage("VX-42", "/mnt/isilon/some/file.mxf")
 
@@ -150,7 +161,7 @@ func TestClient_FileExistsInStorageStillErrorsOn500(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "user", "pass")
+	client := NewClient(testConfig{baseURL: server.URL, username: "user", password: "pass"})
 
 	_, err := client.FileExistsInStorage("VX-42", "/mnt/isilon/some/file.mxf")
 

--- a/services/vizualizer/client.go
+++ b/services/vizualizer/client.go
@@ -25,11 +25,9 @@ type Config interface {
 	Vizualizer() string
 }
 
-func NewFromConfig(cfg Config) (*Client, error) {
-	return NewClient(cfg.Vizualizer())
-}
+func NewClient(cfg Config) (*Client, error) {
+	baseURL := cfg.Vizualizer()
 
-func NewClient(baseURL string) (*Client, error) {
 	if baseURL == "" {
 		return nil, fmt.Errorf("vizualizer baseURL not set")
 	}

--- a/services/vizualizer/client_test.go
+++ b/services/vizualizer/client_test.go
@@ -10,6 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testConfig struct {
+	baseURL string
+}
+
+func (c testConfig) Vizualizer() string { return c.baseURL }
+
 func decodeJSON(r *http.Request, target any) error {
 	defer func() { _ = r.Body.Close() }()
 	return json.NewDecoder(r.Body).Decode(target)
@@ -25,14 +31,14 @@ func vizServer(t *testing.T, status int, contentType, body string) *Client {
 	}))
 	t.Cleanup(server.Close)
 
-	client, err := NewClient(server.URL)
+	client, err := NewClient(testConfig{baseURL: server.URL})
 	require.NoError(t, err)
 
 	return client
 }
 
 func TestNewClient_RequiresABaseURL(t *testing.T) {
-	client, err := NewClient("")
+	client, err := NewClient(testConfig{baseURL: ""})
 
 	require.Error(t, err)
 	assert.Nil(t, client)
@@ -65,7 +71,7 @@ func TestGetJob_RequiresAJobID(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client, err := NewClient(server.URL)
+	client, err := NewClient(testConfig{baseURL: server.URL})
 	require.NoError(t, err)
 
 	_, err = client.GetJob("")
@@ -96,7 +102,7 @@ func TestGetJob_RequestsTheJobPath(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client, err := NewClient(server.URL)
+	client, err := NewClient(testConfig{baseURL: server.URL})
 	require.NoError(t, err)
 
 	_, err = client.GetJob("job-1")
@@ -134,7 +140,7 @@ func TestCreateVisualization_SendsTheRequestBody(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client, err := NewClient(server.URL)
+	client, err := NewClient(testConfig{baseURL: server.URL})
 	require.NoError(t, err)
 
 	_, err = client.CreateVisualization(CreateVisualizationRequest{
@@ -190,7 +196,7 @@ func TestHealth(t *testing.T) {
 }
 
 func TestClient_HasATimeout(t *testing.T) {
-	client, err := NewClient("http://vizualizer.example")
+	client, err := NewClient(testConfig{baseURL: "http://vizualizer.example"})
 	require.NoError(t, err)
 
 	assert.Positive(t, client.client.GetClient().Timeout)

--- a/workflows/ingest/import_audio_from_reaper.go
+++ b/workflows/ingest/import_audio_from_reaper.go
@@ -87,7 +87,7 @@ func RelateAudioToVideo(ctx workflow.Context, params RelateAudioToVideoParams) e
 		}
 
 		// Add relation
-		err = wfutils.Execute(ctx, cantemo.AddRelation, cantemo.AddRelationParams{
+		err = wfutils.Execute(ctx, activities.Cantemo.AddRelation, cantemo.AddRelationParams{
 			Child:  assetResult.AssetID,
 			Parent: params.VideoVXID,
 		}).Get(ctx, nil)

--- a/workflows/misc/cleanup_production.go
+++ b/workflows/misc/cleanup_production.go
@@ -107,7 +107,7 @@ func MoveFileByImportDate(ctx context.Context, params MoveFileByImportDateParams
 		return nil, fmt.Errorf("not implemented: moving files between different storages")
 	}
 
-	filesResult, err := cantemo.GetFiles(ctx, cantemo.GetFilesParams{
+	filesResult, err := activities.Cantemo.GetFiles(ctx, cantemo.GetFilesParams{
 		Path:     "/",
 		Storages: []string{storageID},
 		Page:     1,
@@ -129,7 +129,7 @@ func MoveFileByImportDate(ctx context.Context, params MoveFileByImportDateParams
 
 		renameData, err := generateRenameParams(ctx, file, oldName, "", params.SourceStorageID)
 
-		_, err = cantemo.RenameFile(ctx, renameData)
+		_, err = activities.Cantemo.RenameFile(ctx, renameData)
 		return nil, err
 	}
 
@@ -137,7 +137,7 @@ func MoveFileByImportDate(ctx context.Context, params MoveFileByImportDateParams
 }
 
 func generateRenameParams(ctx context.Context, file cantemoservice.Objects, oldName, prefix, oldStorage string) (*cantemo.RenameFileParams, error) {
-	formats, err := cantemo.GetFormats(ctx, cantemo.GetFormatsParams{
+	formats, err := activities.Cantemo.GetFormats(ctx, cantemo.GetFormatsParams{
 		ItemID: file.Item.ID,
 	})
 

--- a/workflows/misc/slow_move_files.go
+++ b/workflows/misc/slow_move_files.go
@@ -3,6 +3,7 @@ package miscworkflows
 import (
 	"context"
 	"fmt"
+	"github.com/bcc-code/bcc-media-flows/activities"
 	"github.com/bcc-code/bcc-media-flows/activities/cantemo"
 	vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
 	"github.com/bcc-code/bcc-media-flows/environment"
@@ -230,7 +231,7 @@ func MoveFilesWorkerFlow(ctx workflow.Context) error {
 				NewPath:           newPath,
 			}
 
-			err := wfutils.Execute(ctx, cantemo.MoveFileWait, &renameParams).Wait(ctx)
+			err := wfutils.Execute(ctx, activities.Cantemo.MoveFileWait, &renameParams).Wait(ctx)
 			if err != nil {
 				workflow.GetLogger(ctx).Error("Failed to rename file", "error", err)
 				continue


### PR DESCRIPTION
> **Stacked on #469.** Review that first.

Two changes, both about where a client comes from.

### A client is built from a config, and only from a config

`NewClient` took loose strings and `NewFromConfig` sat on top, so there were two ways to build every client and the config-shaped one was optional. There is one now:

```go
func NewClient(cfg Config) *Client
```

The six service test packages each declare the three or four getters they need. A test now says *what* it is configuring instead of relying on argument order:

```go
NewClient(testConfig{baseURL: server.URL, username: "u", password: "p"})
```

### `GetClient()` is gone

It built a **fresh client on every activity call** — a new resty client and connection pool each time — and reached for the global config to do it. `cmd/worker` now builds each client once and hands it over:

```go
vsClient := vsapi.NewClient(cfg.Vidispine)

activities.Vidispine.Client   = vsClient
activities.Platform.Vidispine = vsClient
activities.Util.Subtrans      = subtrans.NewClient(cfg.Subtrans)
```

`cmd/trigger_ui` already did this — it builds its vsapi client in `main` and keeps it on the server struct — so this brings the worker in line.

### Two things that would have broken quietly

- **`utilActivities` was a package variable** holding method values. A method value copies its receiver, so it captured the cantemo activities *before* the clients existed — registering four activities with a nil client, with nothing to say so. It is a function now, called at registration time.
- **The activity structs are pointers** so boot can set their fields, and `registerActivitiesInStruct` finds methods by reflection. A struct that registered nothing would fail at runtime, not at compile time, so `TestActivityStructsStillExposeTheirMethods` asserts each one still exposes methods.

### Replay safety

The cantemo activities were package functions and are now methods, which changes how workflows reference them (`cantemo.AddRelation` → `activities.Cantemo.AddRelation`). **The registered name does not change**: `getFunctionName` takes the short name and strips `-fm`, so a package function and a method value both register as `AddRelation`, which is also what `registerActivitiesInStruct` uses.

`GetResolutions` in `activities/vidispine/meta.go` became a method too. It was a package function that nothing registered or executed — dead as an activity.

### Verification

`go build ./...`, `go vet ./...`, `go test ./...` and `workflowcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)