### PR TITLE
Use Task.Result/Task.Wait instead of Future.Get

### DIFF
--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -1182,11 +1182,6 @@ most if the proxy were ever misconfigured, bypassed, or reached from an already-
   that no input can reach. `bootstrap.TemporalClient()` is the one that can fail, and httpin
   calls it once at boot.
 
-- **38 `.Get(ctx, nil)` call sites are `Task.Wait(ctx)` spelled out.** `Task` already has
-  `Wait` for exactly this (`utils/workflows/execute.go`), and the `nil` form reads as
-  "discard the result" rather than "wait for it". Not touched in the `.Result(ctx)` sweep,
-  which only covered the sites that actually deserialize a value.
-
 - **`XDCAM playout never reads its mux result.`** `workflows/export/vx_export_playout.go`
   waited on `TranscodePlayoutMux` into a `muxResult` nothing ever read — the output path is
   found again by copying the whole `params.OutputDir`. It is now `_, err`, but the activity

--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -1181,3 +1181,20 @@ most if the proxy were ever misconfigured, bypassed, or reached from an already-
   `return temporalClient, nil` over a package variable, so every caller has an error branch
   that no input can reach. `bootstrap.TemporalClient()` is the one that can fail, and httpin
   calls it once at boot.
+
+- **38 `.Get(ctx, nil)` call sites are `Task.Wait(ctx)` spelled out.** `Task` already has
+  `Wait` for exactly this (`utils/workflows/execute.go`), and the `nil` form reads as
+  "discard the result" rather than "wait for it". Not touched in the `.Result(ctx)` sweep,
+  which only covered the sites that actually deserialize a value.
+
+- **`XDCAM playout never reads its mux result.`** `workflows/export/vx_export_playout.go`
+  waited on `TranscodePlayoutMux` into a `muxResult` nothing ever read — the output path is
+  found again by copying the whole `params.OutputDir`. It is now `_, err`, but the activity
+  returning a `PlayoutMuxResult` no caller wants suggests either the result or the field
+  should go.
+
+- **`CollectChildResults` still calls `future.Get` directly.** `utils/workflows/common.go:28`
+  is the one workflow-side site left on `.Get`, and deliberately: it relies on `Result`
+  staying `nil` on failure so `ResultOrError.Result` distinguishes "no result" from a
+  zero-valued one, which `Task.Result`'s pointer allocation would erase. Worth revisiting
+  if `ResultOrError` ever grows an explicit "ok" flag.

--- a/utils/workflows/execute.go
+++ b/utils/workflows/execute.go
@@ -54,6 +54,13 @@ func (f Task[TR]) Wait(ctx workflow.Context) error {
 	return f.Future.Get(ctx, nil)
 }
 
+// Waiter is the part of Task that does not mention the result type, so one
+// slice can hold tasks returning different things when all the caller does is
+// wait for them.
+type Waiter interface {
+	Wait(ctx workflow.Context) error
+}
+
 // FutureResult is Task.Result for a bare workflow.Future, for the places where
 // the Task wrapper is not available: selector callbacks are handed the future
 // itself, and child workflows are started through the SDK rather than Execute.

--- a/utils/workflows/execute.go
+++ b/utils/workflows/execute.go
@@ -54,6 +54,15 @@ func (f Task[TR]) Wait(ctx workflow.Context) error {
 	return f.Future.Get(ctx, nil)
 }
 
+// FutureResult is Task.Result for a bare workflow.Future, for the places where
+// the Task wrapper is not available: selector callbacks are handed the future
+// itself, and child workflows are started through the SDK rather than Execute.
+//
+//workflowcheck:ignore
+func FutureResult[TR any](ctx workflow.Context, future workflow.Future) (TR, error) {
+	return Task[TR]{Future: future}.Result(ctx)
+}
+
 // activityOptionsWithDefaults fills in the timeouts a workflow left unset.
 //
 // A workflow only has activity options if it called

--- a/workflows/export/generate_short.go
+++ b/workflows/export/generate_short.go
@@ -108,8 +108,10 @@ func GenerateShort(ctx workflow.Context, params GenerateShortDataParams) (*Gener
 		OriginalLanguage: exportData.OriginalLanguage,
 	}
 
-	var clipResult MergeExportDataResult
-	err = workflow.ExecuteChildWorkflow(ctx, MergeExportData, mergeExportDataParams).Get(ctx, &clipResult)
+	clipResult, err := wfutils.FutureResult[*MergeExportDataResult](
+		ctx,
+		workflow.ExecuteChildWorkflow(ctx, MergeExportData, mergeExportDataParams),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -237,8 +239,7 @@ type cropShortRequest struct {
 func cropShortVideo(ctx workflow.Context, req cropShortRequest) error {
 	logger := workflow.GetLogger(ctx)
 
-	var cropRes activities.CropShortResult
-	err := wfutils.Execute(ctx, activities.Util.CropShortActivity, activities.CropShortInput{
+	cropRes, err := wfutils.Execute(ctx, activities.Util.CropShortActivity, activities.CropShortInput{
 		InputVideoPath:  req.Video,
 		OutputVideoPath: req.Output,
 		// SubtitlePath is left out: subtitle burn-in is disabled for now.
@@ -247,7 +248,7 @@ func cropShortVideo(ctx workflow.Context, req cropShortRequest) error {
 		InSeconds:    req.InSeconds,
 		OutSeconds:   req.OutSeconds,
 		SceneChanges: req.SceneChanges,
-	}).Get(ctx, &cropRes)
+	}).Result(ctx)
 	if err != nil {
 		logger.Error("CropShortActivity failed: " + err.Error())
 		return err

--- a/workflows/export/isilon_export.go
+++ b/workflows/export/isilon_export.go
@@ -80,8 +80,7 @@ func IsilonExport(ctx workflow.Context, params IsilonExportParams) error {
 
 	ctx = workflow.WithChildOptions(ctx, wfutils.GetVXDefaultWorkflowOptions(ctx, params.VXID))
 
-	var mergeResult MergeExportDataResult
-	err = workflow.ExecuteChildWorkflow(ctx, MergeExportData, MergeExportDataParams{
+	mergeResult, err := wfutils.FutureResult[*MergeExportDataResult](ctx, workflow.ExecuteChildWorkflow(ctx, MergeExportData, MergeExportDataParams{
 		ExportData:       data,
 		TempDir:          tempDir,
 		SubtitlesDir:     subtitlesOutputDir,
@@ -91,7 +90,7 @@ func IsilonExport(ctx workflow.Context, params IsilonExportParams) error {
 		MakeTranscript:   false,
 		Languages:        selectedLanguages,
 		OriginalLanguage: data.OriginalLanguage,
-	}).Get(ctx, &mergeResult)
+	}))
 
 	if err != nil {
 		wfutils.SendTelegramError(ctx, telegram.ChatOther, params.VXID, err)

--- a/workflows/export/merge_export_data.go
+++ b/workflows/export/merge_export_data.go
@@ -45,15 +45,15 @@ func MergeExportData(ctx workflow.Context, params MergeExportDataParams) (*Merge
 
 	ctx = workflow.WithActivityOptions(ctx, wfutils.GetDefaultActivityOptions())
 
-	var transcriptTask workflow.Future
+	var transcriptTask wfutils.Task[*activities.MergeTranscriptResult]
 	if params.MakeTranscript && jsonTranscriptFile != nil {
 		transcriptTask = wfutils.Execute(ctx, activities.Util.MergeTranscriptJSON, activities.MergeTranscriptJSONParams{
 			MergeInput:      *jsonTranscriptFile,
 			DestinationPath: params.TempDir,
-		}).Future
+		})
 	}
 
-	var audioTasks = map[string]workflow.Future{}
+	var audioTasks = map[string]wfutils.Task[*common.MergeResult]{}
 	if params.MakeAudio {
 		keys, err := wfutils.GetMapKeysSafely(ctx, audioMergeInputs)
 		if err != nil {
@@ -64,11 +64,11 @@ func MergeExportData(ctx workflow.Context, params MergeExportDataParams) (*Merge
 				continue
 			}
 			mi := audioMergeInputs[lang]
-			audioTasks[lang] = wfutils.Execute(ctx, activities.Audio.TranscodeMergeAudio, *mi).Future
+			audioTasks[lang] = wfutils.Execute(ctx, activities.Audio.TranscodeMergeAudio, *mi)
 		}
 	}
 
-	var subtitleTasks = map[string]workflow.Future{}
+	var subtitleTasks = map[string]wfutils.Task[*common.MergeResult]{}
 	if params.MakeSubtitles {
 		keys, err := wfutils.GetMapKeysSafely(ctx, subtitleMergeInputs)
 		if err != nil {
@@ -76,16 +76,14 @@ func MergeExportData(ctx workflow.Context, params MergeExportDataParams) (*Merge
 		}
 		for _, lang := range keys {
 			mi := subtitleMergeInputs[lang]
-			subtitleTasks[lang] = wfutils.Execute(ctx, activities.Video.TranscodeMergeSubtitles, *mi).Future
+			subtitleTasks[lang] = wfutils.Execute(ctx, activities.Video.TranscodeMergeSubtitles, *mi)
 		}
 
 	}
 
 	var videoFile *paths.Path
 	if params.MakeVideo {
-		videoTask := wfutils.Execute(ctx, activities.Video.TranscodeMergeVideo, mergeInput)
-		var result common.MergeResult
-		err := videoTask.Get(ctx, &result)
+		result, err := wfutils.Execute(ctx, activities.Video.TranscodeMergeVideo, mergeInput).Result(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -104,9 +102,8 @@ func MergeExportData(ctx workflow.Context, params MergeExportDataParams) (*Merge
 
 	jsonTranscriptResult := map[string]paths.Path{}
 
-	if params.MakeTranscript && transcriptTask != nil {
-		var res activities.MergeTranscriptResult
-		err := transcriptTask.Get(ctx, &res)
+	if params.MakeTranscript && transcriptTask.Future != nil {
+		res, err := transcriptTask.Result(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -228,7 +225,7 @@ func exportDataToMergeInputs(data *vidispine.ExportData, tempDir, subtitlesDir p
 }
 
 // collectMergedPaths waits for one merge per language and keeps where each landed.
-func collectMergedPaths(ctx workflow.Context, tasks map[string]workflow.Future) (map[string]paths.Path, error) {
+func collectMergedPaths(ctx workflow.Context, tasks map[string]wfutils.Task[*common.MergeResult]) (map[string]paths.Path, error) {
 	langs, err := wfutils.GetMapKeysSafely(ctx, tasks)
 	if err != nil {
 		return nil, err
@@ -236,8 +233,7 @@ func collectMergedPaths(ctx workflow.Context, tasks map[string]workflow.Future) 
 
 	files := map[string]paths.Path{}
 	for _, lang := range langs {
-		var result common.MergeResult
-		err = tasks[lang].Get(ctx, &result)
+		result, err := tasks[lang].Result(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/workflows/export/vx_export.go
+++ b/workflows/export/vx_export.go
@@ -133,14 +133,13 @@ func VXExport(ctx workflow.Context, params VXExportParams) ([]wfutils.ResultOrEr
 		destinations = append(destinations, d)
 	}
 
-	var data *vidispine.ExportData
-	err := wfutils.Execute(ctx, avidispine.Vidispine.GetExportDataActivity, avidispine.GetExportDataParams{
+	data, err := wfutils.Execute(ctx, avidispine.Vidispine.GetExportDataActivity, avidispine.GetExportDataParams{
 		VXID:        params.VXID,
 		Languages:   params.Languages,
 		AudioSource: params.AudioSource,
 		Subclip:     params.Subclip,
 		SubsAllowAI: params.SubsAllowAI,
-	}).Get(ctx, &data)
+	}).Result(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -171,8 +170,7 @@ func VXExport(ctx workflow.Context, params VXExportParams) ([]wfutils.ResultOrEr
 
 	bmmOnly := len(params.Destinations) == 1 && (params.Destinations[0] == AssetExportDestinationBMM.Value || params.Destinations[0] == AssetExportDestinationBMMIntegration.Value)
 
-	var mergeResult MergeExportDataResult
-	err = workflow.ExecuteChildWorkflow(ctx, MergeExportData, MergeExportDataParams{
+	mergeResult, err := wfutils.FutureResult[*MergeExportDataResult](ctx, workflow.ExecuteChildWorkflow(ctx, MergeExportData, MergeExportDataParams{
 		ExportData:       data,
 		TempDir:          tempDir,
 		SubtitlesDir:     subtitlesOutputDir,
@@ -182,7 +180,7 @@ func VXExport(ctx workflow.Context, params VXExportParams) ([]wfutils.ResultOrEr
 		MakeTranscript:   true,
 		Languages:        params.Languages,
 		OriginalLanguage: data.OriginalLanguage,
-	}).Get(ctx, &mergeResult)
+	}))
 	if err != nil {
 		wfutils.SendTelegramText(ctx, telegramChat, fmt.Sprintf("🟥 Export of `%s` failed:\n```\n%s\n```", params.VXID, err.Error()))
 		return nil, err
@@ -200,7 +198,7 @@ func VXExport(ctx workflow.Context, params VXExportParams) ([]wfutils.ResultOrEr
 		childParams := VXExportChildWorkflowParams{
 			ParentParams:              params,
 			ExportData:                *data,
-			MergeResult:               mergeResult,
+			MergeResult:               *mergeResult,
 			TempDir:                   tempDir,
 			OutputDir:                 outputDir.Append(dest.Value),
 			RunID:                     workflow.GetInfo(ctx).OriginalRunID,

--- a/workflows/export/vx_export_bmm.go
+++ b/workflows/export/vx_export_bmm.go
@@ -98,10 +98,9 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 		return nil, err
 	}
 
-	var chapters []asset.TimedMetadata
-	err = wfutils.Execute(ctx, activities.Platform.GetTimedMetadataChaptersActivity, platform_activities.GetTimedMetadataChaptersParams{
+	chapters, err := wfutils.Execute(ctx, activities.Platform.GetTimedMetadataChaptersActivity, platform_activities.GetTimedMetadataChaptersParams{
 		Clips: params.ExportData.Clips,
-	}).Get(ctx, &chapters)
+	}).Result(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -149,26 +148,25 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 func normalizeAudioPerLanguage(ctx workflow.Context, params VXExportChildWorkflowParams, langs []string) (map[string]activities.NormalizeAudioResult, error) {
 	logger := workflow.GetLogger(ctx)
 
-	futures := map[string]workflow.Future{}
+	futures := map[string]wfutils.Task[*activities.NormalizeAudioResult]{}
 	for _, lang := range langs {
 		futures[lang] = wfutils.Execute(ctx, activities.Audio.NormalizeAudioActivity, activities.NormalizeAudioParams{
 			FilePath:              params.MergeResult.AudioFiles[lang],
 			TargetLUFS:            targetLufs,
 			PerformOutputAnalysis: true,
 			OutputPath:            params.TempDir,
-		}).Future
+		})
 	}
 
 	results := map[string]activities.NormalizeAudioResult{}
 	for _, lang := range langs {
-		result := activities.NormalizeAudioResult{}
-		err := futures[lang].Get(ctx, &result)
+		result, err := futures[lang].Result(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to normalize audio for language %s: %w", lang, err)
 		}
 
 		logger.Debug("Normalized audio for language", lang, result)
-		results[lang] = result
+		results[lang] = *result
 		params.MergeResult.AudioFiles[lang] = result.FilePath
 	}
 
@@ -181,17 +179,17 @@ func encodeAudioPerLanguage(
 	langs []string,
 	normalized map[string]activities.NormalizeAudioResult,
 ) (map[string][]common.AudioResult, error) {
-	futures := map[string][]workflow.Future{}
+	futures := map[string][]wfutils.Task[*common.AudioResult]{}
 	for _, lang := range langs {
 		audio := normalized[lang]
 
-		var encodings []workflow.Future
+		var encodings []wfutils.Task[*common.AudioResult]
 		for _, bitrate := range aacBitrates {
 			encodings = append(encodings, wfutils.Execute(ctx, activities.Audio.TranscodeToAudioAac, common.AudioInput{
 				Path:            audio.FilePath,
 				DestinationPath: params.OutputDir,
 				Bitrate:         bitrate,
-			}).Future)
+			}))
 		}
 
 		for _, bitrate := range mp3Bitrates {
@@ -200,7 +198,7 @@ func encodeAudioPerLanguage(
 				DestinationPath: params.OutputDir,
 				Bitrate:         bitrate,
 				ForceCBR:        true,
-			}).Future)
+			}))
 		}
 
 		futures[lang] = encodings
@@ -210,13 +208,12 @@ func encodeAudioPerLanguage(
 	for _, lang := range langs {
 		var encodings []common.AudioResult
 		for _, future := range futures[lang] {
-			var res common.AudioResult
-			err := future.Get(ctx, &res)
+			res, err := future.Result(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to transcode audio for language %s: %w", lang, err)
 			}
 
-			encodings = append(encodings, res)
+			encodings = append(encodings, *res)
 		}
 
 		results[lang] = encodings

--- a/workflows/export/vx_export_playout.go
+++ b/workflows/export/vx_export_playout.go
@@ -34,28 +34,26 @@ func VXExportToXDCAM(ctx workflow.Context, params VXExportChildWorkflowParams) (
 	}
 
 	// Transcode video using playout encoding
-	var videoResult common.VideoResult
-	err = wfutils.Execute(ctx, activities.Video.TranscodeToXDCAMActivity, activities.EncodeParams{
+	videoResult, err := wfutils.Execute(ctx, activities.Video.TranscodeToXDCAMActivity, activities.EncodeParams{
 		Bitrate:    "50M",
 		FilePath:   *params.MergeResult.VideoFile,
 		OutputDir:  xdcamOutputDir,
 		Resolution: utils.Resolution1080,
 		FrameRate:  25,
 		Interlace:  true,
-	}).Get(ctx, &videoResult)
+	}).Result(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// Mux into MXF file with 16 audio channels
-	var muxResult *common.PlayoutMuxResult
-	err = wfutils.Execute(ctx, activities.Video.TranscodePlayoutMux, common.PlayoutMuxInput{
+	_, err = wfutils.Execute(ctx, activities.Video.TranscodePlayoutMux, common.PlayoutMuxInput{
 		VideoFilePath:     videoResult.OutputPath,
 		AudioFilePaths:    params.MergeResult.AudioFiles,
 		SubtitleFilePaths: params.MergeResult.SubtitleFiles,
 		OutputDir:         params.OutputDir,
 		FallbackLanguage:  "nor",
-	}).Get(ctx, &muxResult)
+	}).Result(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/workflows/export/vx_export_vod.go
+++ b/workflows/export/vx_export_vod.go
@@ -122,7 +122,7 @@ func VXExportToVOD(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	service.fileFutures.Wait(ctx)
 
 	for _, task := range service.tasks {
-		err = task.Get(ctx, nil)
+		err = task.Wait(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -291,7 +291,7 @@ type vxExportVodService struct {
 	fileFutures *wfutils.FutureGroup
 	smilVideos  map[resolutionString]smil.Video
 	files       []asset.IngestFileMeta
-	tasks       []workflow.Future
+	tasks       []wfutils.Task[bool]
 	errs        []error
 }
 
@@ -447,5 +447,5 @@ func (v *vxExportVodService) copyToIngest(ctx workflow.Context, path paths.Path)
 		v.errs = append(v.errs, err)
 		return
 	}
-	v.tasks = append(v.tasks, wfutils.Execute(ctx, activities.Util.RcloneWaitForJob, activities.RcloneWaitForJobInput{JobID: jobID}).Future)
+	v.tasks = append(v.tasks, wfutils.Execute(ctx, activities.Util.RcloneWaitForJob, activities.RcloneWaitForJobInput{JobID: jobID}))
 }

--- a/workflows/export/vx_export_vod.go
+++ b/workflows/export/vx_export_vod.go
@@ -76,8 +76,7 @@ func VXExportToVOD(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 	}
 
 	onVideoCreated := func(f workflow.Future, resolution utils.Resolution) {
-		var result common.VideoResult
-		err := f.Get(ctx, &result)
+		result, err := wfutils.FutureResult[*common.VideoResult](ctx, f)
 		if err != nil {
 			logger.Error("Failed to get video result", "error", err)
 			service.errs = append(service.errs, err)
@@ -227,7 +226,7 @@ func prepareAudioFiles(ctx workflow.Context, mergeResult MergeExportDataResult, 
 		if err != nil {
 			return nil, err
 		}
-		normalizedFutures := map[string]workflow.Future{}
+		normalizedFutures := map[string]wfutils.Task[*activities.NormalizeAudioResult]{}
 		// Normalize audio
 		for _, lang := range langs {
 			audio := mergeResult.AudioFiles[lang]
@@ -237,13 +236,12 @@ func prepareAudioFiles(ctx workflow.Context, mergeResult MergeExportDataResult, 
 				PerformOutputAnalysis: true,
 				OutputPath:            tempDir,
 			})
-			normalizedFutures[lang] = future.Future
+			normalizedFutures[lang] = future
 		}
 
 		for _, lang := range langs {
 			future := normalizedFutures[lang]
-			normalizedRes := activities.NormalizeAudioResult{}
-			err := future.Get(ctx, &normalizedRes)
+			normalizedRes, err := future.Result(ctx)
 			if err != nil {
 				workflow.GetLogger(ctx).Error("Failed to get normalized audio result", "error", err)
 				return nil, fmt.Errorf("failed to normalize audio for language %s: %w", lang, err)
@@ -264,8 +262,7 @@ func prepareAudioFiles(ctx workflow.Context, mergeResult MergeExportDataResult, 
 
 	var audioFiles = map[string]paths.Path{}
 	audioKeys, err := startAudioTasks(ctx, prepareFilesSelector, mergeResult.AudioFiles, tempDir, func(f workflow.Future, l string) {
-		var result common.AudioResult
-		err := f.Get(ctx, &result)
+		result, err := wfutils.FutureResult[*common.AudioResult](ctx, f)
 		if err != nil {
 			workflow.GetLogger(ctx).Error("Failed to get audio result", "error", err)
 			return
@@ -330,8 +327,7 @@ func (v *vxExportVodService) setMetadataAndPublishToVOD(
 	ingestData.SmilFile = "aws.smil"
 	if chapterDataWF != nil {
 		ingestData.ChaptersFile = "chapters.json"
-		var chaptersData []asset.TimedMetadata
-		err = chapterDataWF.Get(ctx, &chaptersData)
+		chaptersData, err := wfutils.FutureResult[[]asset.TimedMetadata](ctx, chapterDataWF)
 		if err != nil {
 			return nil, err
 		}
@@ -394,8 +390,7 @@ func sortedVideos(streams map[resolutionString]smil.Video, qualities []Resolutio
 func (v *vxExportVodService) handleFileWorkflowFuture(ctx workflow.Context, lang string, resolution utils.Resolution, f workflow.Future) {
 	logger := workflow.GetLogger(ctx)
 
-	var result common.MuxResult
-	err := f.Get(ctx, &result)
+	result, err := wfutils.FutureResult[*common.MuxResult](ctx, f)
 	if err != nil {
 		logger.Error("Failed to get mux result", "error", err)
 		v.errs = append(v.errs, err)
@@ -417,8 +412,7 @@ func (v *vxExportVodService) handleFileWorkflowFuture(ctx workflow.Context, lang
 
 func (v *vxExportVodService) handleStreamWorkflowFuture(ctx workflow.Context, resolutionWithLanguages ResolutionWithLanguages, f workflow.Future) {
 	logger := workflow.GetLogger(ctx)
-	var result common.MuxResult
-	err := f.Get(ctx, &result)
+	result, err := wfutils.FutureResult[*common.MuxResult](ctx, f)
 	if err != nil {
 		logger.Error("Failed to get mux result", "error", err)
 		v.errs = append(v.errs, err)

--- a/workflows/ingest/common.go
+++ b/workflows/ingest/common.go
@@ -181,10 +181,10 @@ func notifyImportCompleted(ctx workflow.Context, recipients []string, jobID int,
 	}
 
 	msg, _ := telegram.NewMessage(telegram.ChatOther, content)
-	wfutils.Execute(ctx, activities.Util.SendTelegramMessage, msg).Get(ctx, nil)
+	wfutils.Execute(ctx, activities.Util.SendTelegramMessage, msg).Wait(ctx)
 
 	email, _ := emails.NewMessage(content, recipients, nil, nil)
-	return wfutils.Execute(ctx, activities.Util.SendEmail, email).Get(ctx, nil)
+	return wfutils.Execute(ctx, activities.Util.SendEmail, email).Wait(ctx)
 }
 
 func notifyImportFailed(ctx workflow.Context, recipients []string, jobID int, filesByAssetID []paths.Path, importError error) error {
@@ -204,7 +204,7 @@ func notifyImportFailed(ctx workflow.Context, recipients []string, jobID int, fi
 		return err
 	}
 
-	wfutils.Execute(ctx, activities.Util.SendTelegramMessage, msg).Get(ctx, nil)
+	wfutils.Execute(ctx, activities.Util.SendTelegramMessage, msg).Wait(ctx)
 	email, _ := emails.NewMessage(content, recipients, nil, nil)
-	return wfutils.Execute(ctx, activities.Util.SendEmail, email).Get(ctx, nil)
+	return wfutils.Execute(ctx, activities.Util.SendEmail, email).Wait(ctx)
 }

--- a/workflows/ingest/common.go
+++ b/workflows/ingest/common.go
@@ -30,10 +30,9 @@ type ImportTagResult struct {
 }
 
 func ImportFileAsTag(ctx workflow.Context, tag string, path paths.Path, title string) (*ImportTagResult, error) {
-	var result vsactivity.CreatePlaceholderResult
-	err := wfutils.Execute(ctx, activities.Vidispine.CreatePlaceholderActivity, vsactivity.CreatePlaceholderParams{
+	result, err := wfutils.Execute(ctx, activities.Vidispine.CreatePlaceholderActivity, vsactivity.CreatePlaceholderParams{
 		Title: title,
-	}).Get(ctx, &result)
+	}).Result(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -42,12 +41,11 @@ func ImportFileAsTag(ctx workflow.Context, tag string, path paths.Path, title st
 	// can lag the worker's view by minutes due to NFS metadata caching. We
 	// optimistically kick off the import without waiting and let
 	// WaitForImportTag handle the visibility wait + retry on JOB_FAILED.
-	var job vsactivity.ImportFileResult
-	err = wfutils.Execute(ctx, activities.Vidispine.ImportFileAsShapeActivity, vsactivity.ImportFileAsShapeParams{
+	job, err := wfutils.Execute(ctx, activities.Vidispine.ImportFileAsShapeActivity, vsactivity.ImportFileAsShapeParams{
 		AssetID:  result.AssetID,
 		FilePath: path,
 		ShapeTag: tag,
-	}).Get(ctx, &job)
+	}).Result(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +76,13 @@ func WaitForImportTag(ctx workflow.Context, result *ImportTagResult) error {
 		return vErr
 	}
 
-	var newJob vsactivity.ImportFileResult
-	if iErr := wfutils.Execute(ctx, activities.Vidispine.ImportFileAsShapeActivity, vsactivity.ImportFileAsShapeParams{
+	newJob, iErr := wfutils.Execute(ctx, activities.Vidispine.ImportFileAsShapeActivity, vsactivity.ImportFileAsShapeParams{
 		AssetID:  result.AssetID,
 		FilePath: result.FilePath,
 		ShapeTag: result.ShapeTag,
 		Replace:  true,
-	}).Get(ctx, &newJob); iErr != nil {
+	}).Result(ctx)
+	if iErr != nil {
 		return iErr
 	}
 

--- a/workflows/ingest/import_audio_from_reaper.go
+++ b/workflows/ingest/import_audio_from_reaper.go
@@ -54,10 +54,9 @@ func RelateAudioToVideo(ctx workflow.Context, params RelateAudioToVideoParams) e
 		}
 
 		// Create placeholder
-		var assetResult vsactivity.CreatePlaceholderResult
-		err = wfutils.Execute(ctx, activities.Vidispine.CreatePlaceholderActivity, vsactivity.CreatePlaceholderParams{
+		assetResult, err := wfutils.Execute(ctx, activities.Vidispine.CreatePlaceholderActivity, vsactivity.CreatePlaceholderParams{
 			Title: path.Base(),
-		}).Get(ctx, &assetResult)
+		}).Result(ctx)
 		if err != nil {
 			return err
 		}
@@ -162,10 +161,9 @@ func doImportAudioFileFromReaper(ctx workflow.Context, params ImportAudioFileFro
 		return err
 	}
 
-	isSilent := false
-	err = wfutils.Execute(ctx, activities.Audio.DetectSilence, common.DetectSilenceInput{
+	isSilent, err := wfutils.Execute(ctx, activities.Audio.DetectSilence, common.DetectSilenceInput{
 		Path: tempFile,
-	}).Get(ctx, &isSilent)
+	}).Result(ctx)
 
 	if err != nil {
 		return err
@@ -187,11 +185,10 @@ func doImportAudioFileFromReaper(ctx workflow.Context, params ImportAudioFileFro
 
 	outputFolder := params.OutputPath
 
-	getFileResult := vsactivity.GetFileFromVXResult{}
-	err = wfutils.Execute(ctx, activities.Vidispine.GetFileFromVXActivity, vsactivity.GetFileFromVXParams{
+	getFileResult, err := wfutils.Execute(ctx, activities.Vidispine.GetFileFromVXActivity, vsactivity.GetFileFromVXParams{
 		VXID: params.VideoVXID,
 		Tags: []string{"original"},
-	}).Get(ctx, &getFileResult)
+	}).Result(ctx)
 	if err != nil {
 		return err
 	}

--- a/workflows/ingest/import_audio_from_reaper.go
+++ b/workflows/ingest/import_audio_from_reaper.go
@@ -67,7 +67,7 @@ func RelateAudioToVideo(ctx workflow.Context, params RelateAudioToVideoParams) e
 			FilePath: path,
 			AssetID:  assetResult.AssetID,
 			Growing:  false,
-		}).Get(ctx, nil)
+		}).Wait(ctx)
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func RelateAudioToVideo(ctx workflow.Context, params RelateAudioToVideoParams) e
 		err = wfutils.Execute(ctx, activities.Cantemo.AddRelation, cantemo.AddRelationParams{
 			Child:  assetResult.AssetID,
 			Parent: params.VideoVXID,
-		}).Get(ctx, nil)
+		}).Wait(ctx)
 		if err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ func RelateAudioToVideo(ctx workflow.Context, params RelateAudioToVideoParams) e
 			GroupID: "System",
 			Key:     languages.LanguagesByISO[lang].RelatedMBFieldID,
 			Value:   assetResult.AssetID,
-		}).Get(ctx, nil)
+		}).Wait(ctx)
 		if err != nil {
 			logger.Error(fmt.Sprintf("SetVXMetadataFieldActivity: %s", err.Error()))
 		}
@@ -108,7 +108,7 @@ func RelateAudioToVideo(ctx workflow.Context, params RelateAudioToVideoParams) e
 			ItemID: assetResult.AssetID,
 			Key:    vscommon.FieldLanguagesRecorded.Value,
 			Value:  lang,
-		}).Get(ctx, nil)
+		}).Wait(ctx)
 
 		if err != nil {
 			return err

--- a/workflows/ingest/incremental_ingest.go
+++ b/workflows/ingest/incremental_ingest.go
@@ -124,7 +124,7 @@ func doIncremental(ctx workflow.Context, params IncrementalParams) error {
 
 	err = wfutils.Execute(ctx, activities.Vidispine.CloseFile, vsactivity.CloseFileParams{
 		FileID: jobResult.FileID,
-	}).Get(ctx, nil)
+	}).Wait(ctx)
 	if err != nil {
 		return err
 	}
@@ -170,7 +170,7 @@ func doIncremental(ctx workflow.Context, params IncrementalParams) error {
 
 	_ = wfutils.Execute(ctx, activities.Vidispine.CreateThumbnailsActivity, vsactivity.CreateThumbnailsParams{
 		AssetID: videoVXID,
-	}).Get(ctx, nil)
+	}).Wait(ctx)
 
 	var errors []error
 	for _, f := range importAudioFuture {

--- a/workflows/ingest/incremental_ingest.go
+++ b/workflows/ingest/incremental_ingest.go
@@ -98,12 +98,11 @@ func doIncremental(ctx workflow.Context, params IncrementalParams) error {
 
 	wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟦 Starting live ingest: https://vault.bcc.media/item/%s", videoVXID))
 
-	var jobResult vsactivity.FileJobResult
-	err = wfutils.Execute(ctx, activities.Vidispine.AddFileToPlaceholder, vsactivity.AddFileToPlaceholderParams{
+	jobResult, err := wfutils.Execute(ctx, activities.Vidispine.AddFileToPlaceholder, vsactivity.AddFileToPlaceholderParams{
 		AssetID:  videoVXID,
 		FilePath: rawPath,
 		Growing:  true,
-	}).Get(ctx, &jobResult)
+	}).Result(ctx)
 	if err != nil {
 		return err
 	}
@@ -229,10 +228,9 @@ func syncAudioToVideo(ctx workflow.Context, videoVXID string) {
 func createGrowingPlaceholder(ctx workflow.Context, in paths.Path) (string, error) {
 	logger := workflow.GetLogger(ctx)
 
-	var assetResult vsactivity.CreatePlaceholderResult
-	err := wfutils.Execute(ctx, activities.Vidispine.CreatePlaceholderActivity, vsactivity.CreatePlaceholderParams{
+	assetResult, err := wfutils.Execute(ctx, activities.Vidispine.CreatePlaceholderActivity, vsactivity.CreatePlaceholderParams{
 		Title: in.Base(),
-	}).Get(ctx, &assetResult)
+	}).Result(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -255,8 +253,7 @@ func startReaperSession(ctx workflow.Context, existing string) string {
 		return existing
 	}
 
-	sessionID := ""
-	err := wfutils.Execute(ctx, activities.Live.StartReaper, nil).Get(ctx, &sessionID)
+	sessionID, err := wfutils.Execute(ctx, activities.Live.StartReaper, nil).Result(ctx)
 	if err != nil {
 		wfutils.SendTelegramText(ctx, telegram.ChatOther, fmt.Sprintf("🟦 Unable to start reaper. Start it manually and notify Matjaz!\n\n```%s```", err.Error()))
 	}

--- a/workflows/ingest/masters.go
+++ b/workflows/ingest/masters.go
@@ -187,11 +187,10 @@ func uploadMaster(ctx workflow.Context, params MasterParams) (*MasterResult, err
 }
 
 func analyzeAudioAndSetMetadata(ctx workflow.Context, assetID string, path paths.Path) (*common.AnalyzeEBUR128Result, error) {
-	var result common.AnalyzeEBUR128Result
-	err := wfutils.Execute(ctx, activities.Audio.AnalyzeEBUR128Activity, activities.AnalyzeEBUR128Params{
+	result, err := wfutils.Execute(ctx, activities.Audio.AnalyzeEBUR128Activity, activities.AnalyzeEBUR128Params{
 		FilePath:       path,
 		TargetLoudness: -24,
-	}).Get(ctx, &result)
+	}).Result(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +212,7 @@ func analyzeAudioAndSetMetadata(ctx workflow.Context, assetID string, path paths
 		}
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 func masterFilename(props ingest.JobProperty) (string, error) {

--- a/workflows/ingest/masters.go
+++ b/workflows/ingest/masters.go
@@ -95,7 +95,7 @@ func processMaster(ctx workflow.Context, sourceFile paths.Path, destinationFile 
 	// This just triggers the task, the actual work is done in the background by Vidispine
 	_ = wfutils.Execute(ctx, activities.Vidispine.CreateThumbnailsActivity, vsactivity.CreateThumbnailsParams{
 		AssetID: result.AssetID,
-	}).Get(ctx, nil)
+	}).Wait(ctx)
 
 	if _, err := createPreviewsAsync(ctx, []string{result.AssetID}); err != nil {
 		return "", err

--- a/workflows/ingest/mu1_mu2_extract.go
+++ b/workflows/ingest/mu1_mu2_extract.go
@@ -95,7 +95,7 @@ func ExtractAudioFromMU1MU2(ctx workflow.Context, input ExtractAudioFromMU1MU2In
 	}
 
 	filesToImport := map[string]paths.Path{}
-	var futures []workflow.Future
+	var tasks []wfutils.Waiter
 
 	// Align audio from MU1 and MU2
 
@@ -114,7 +114,7 @@ func ExtractAudioFromMU1MU2(ctx workflow.Context, input ExtractAudioFromMU1MU2In
 				Start:  float64(-sampleOffset) / float64(48000),
 			})
 
-			futures = append(futures, f.Future)
+			tasks = append(tasks, f)
 			filesToImport[languages.LanguagesByMU2[key].ISO6391] = outputFile
 		}
 	} else if sampleOffset > 0 {
@@ -128,7 +128,7 @@ func ExtractAudioFromMU1MU2(ctx workflow.Context, input ExtractAudioFromMU1MU2In
 				Samples:    sampleOffset,
 			})
 
-			futures = append(futures, f.Future)
+			tasks = append(tasks, f)
 			filesToImport[languages.LanguagesByMU2[key].ISO6391] = outputFile
 		}
 	} else {
@@ -148,13 +148,13 @@ func ExtractAudioFromMU1MU2(ctx workflow.Context, input ExtractAudioFromMU1MU2In
 			Source:      file,
 			Destination: destinationFile,
 		})
-		futures = append(futures, f.Future)
+		tasks = append(tasks, f)
 		filesToImport[languages.LanguagesByMU1[i].ISO6391] = destinationFile
 	}
 
 	errors := ""
-	for _, f := range futures {
-		err = f.Get(ctx, nil)
+	for _, t := range tasks {
+		err = t.Wait(ctx)
 		if err != nil {
 			errors += err.Error() + "\n"
 		}

--- a/workflows/ingest/mu1_mu2_extract.go
+++ b/workflows/ingest/mu1_mu2_extract.go
@@ -47,13 +47,12 @@ func ExtractAudioFromMU1MU2(ctx workflow.Context, input ExtractAudioFromMU1MU2In
 	}
 
 	// Calculte TC difference between MU1 and MU2
-	sampleOffset := int(0)
-	err = wfutils.Execute(ctx, activities.Video.GetVideoOffset, activities.GetVideoOffsetInput{
+	sampleOffset, err := wfutils.Execute(ctx, activities.Video.GetVideoOffset, activities.GetVideoOffsetInput{
 		VideoPath1:      Mu1Result.FilePath,
 		VideoPath2:      Mu2Result.FilePath,
 		VideoFPS:        25,
 		AudioSampleRate: 48000,
-	}).Get(ctx, &sampleOffset)
+	}).Result(ctx)
 	if err != nil {
 		return err
 	}

--- a/workflows/ingest/multitrack.go
+++ b/workflows/ingest/multitrack.go
@@ -54,11 +54,10 @@ func Multitrack(ctx workflow.Context, params MasterParams) (*MasterResult, error
 
 	var channels paths.Files
 	for _, f := range files {
-		var parts paths.Files
-		err = wfutils.Execute(ctx, activities.Audio.SplitAudioChannels, activities.SplitAudioChannelsInput{
+		parts, err := wfutils.Execute(ctx, activities.Audio.SplitAudioChannels, activities.SplitAudioChannelsInput{
 			FilePath:  f,
 			OutputDir: tempDir,
-		}).Get(ctx, &parts)
+		}).Result(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -68,11 +67,10 @@ func Multitrack(ctx workflow.Context, params MasterParams) (*MasterResult, error
 	// make sure the files are sorted
 	sort.Sort(channels)
 
-	var muxResult activities.MultitrackMuxResult
-	err = wfutils.Execute(ctx, activities.Video.MultitrackMux, activities.MultitrackMuxInput{
+	muxResult, err := wfutils.Execute(ctx, activities.Video.MultitrackMux, activities.MultitrackMuxInput{
 		Files:     channels,
 		OutputDir: params.OutputDir,
-	}).Get(ctx, &muxResult)
+	}).Result(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/workflows/ingest/raw_material.go
+++ b/workflows/ingest/raw_material.go
@@ -127,8 +127,7 @@ func RawMaterial(ctx workflow.Context, params RawMaterialParams) (map[string]pat
 
 	for _, id := range mediaAssetIDs {
 		task := mediaAnalyzeTasks[id]
-		var result ffmpeg.StreamInfo
-		err = task.Get(ctx, &result)
+		result, err := task.Result(ctx)
 		if err != nil {
 			return imported, err
 		}

--- a/workflows/ingest/raw_material.go
+++ b/workflows/ingest/raw_material.go
@@ -141,7 +141,7 @@ func RawMaterial(ctx workflow.Context, params RawMaterialParams) (map[string]pat
 		if result.HasVideo {
 			err = wfutils.Execute(ctx, activities.Vidispine.CreateThumbnailsActivity, vsactivity.CreateThumbnailsParams{
 				AssetID: id,
-			}).Get(ctx, nil)
+			}).Wait(ctx)
 			if err != nil {
 				return imported, err
 			}

--- a/workflows/ingest/sync_fix.go
+++ b/workflows/ingest/sync_fix.go
@@ -71,8 +71,7 @@ func IngestSyncFix(ctx workflow.Context, params IngestSyncFixParams) error {
 
 		f := wfutils.Execute(ctx, activities.Util.RcloneWaitForJob, activities.RcloneWaitForJobInput{JobID: jobID}).Future
 		group.Add(f, func(future workflow.Future) {
-			var copied bool
-			err := future.Get(ctx, &copied)
+			copied, err := wfutils.FutureResult[bool](ctx, future)
 			if err != nil {
 				errs = append(errs, err)
 				return

--- a/workflows/misc/watch_folder_transcode.go
+++ b/workflows/misc/watch_folder_transcode.go
@@ -101,7 +101,7 @@ func WatchFolderTranscode(ctx workflow.Context, params WatchFolderTranscodeInput
 	if encode, ok := watchFolderEncodes[params.FolderName]; ok {
 		encode.params.FilePath = path
 		encode.params.OutputDir = tmpFolder
-		err = wfutils.Execute(ctx, encode.activity, encode.params).Get(ctx, &transcodeOutput)
+		transcodeOutput, err = wfutils.Execute(ctx, encode.activity, encode.params).Result(ctx)
 	} else {
 		switch params.FolderName {
 		case common.FolderTranscribe:


### PR DESCRIPTION
Every workflow-side call that read an activity or child-workflow result went through the raw future, so the result type was asserted by hand at each call site and only checked at runtime by the converter — the exact thing `Task[T]` exists to carry.

## `.Get(ctx, &x)` → `.Result(ctx)`

35 of 37 sites. Most just lose the `var x T` above them. Where the `Task` was thrown away to store a bare `workflow.Future` in a map or slice, the container now holds `Task[T]` — `merge_export_data.go` (audio/subtitle/transcript tasks and `collectMergedPaths`'s signature), `vx_export_bmm.go`, `vx_export_vod.go`.

Where the future genuinely arrives without its wrapper — selector callbacks are handed the future itself, and child workflows come from the SDK — `wfutils.FutureResult[T](ctx, f)` wraps it back up.

Two kept `.Get` on purpose: `CollectChildResults` needs its result to stay `nil` on failure, which `Task.Result`'s pointer allocation would erase; and `services/bmm`'s `client.WorkflowRun` is not a `Task` at all.

## `.Get(ctx, nil)` → `.Wait(ctx)`

15 of 38 sites. The `nil` form reads as "discard the result" rather than "wait for this", which is misleading at the notification and thumbnail calls where there was never a result to discard.

Two slices held bare futures only to wait on them. `vx_export_vod`'s is all `RcloneWaitForJob` and becomes `[]Task[bool]`; `mu1_mu2_extract`'s mixes trim, prepend-silence and copy results, so it becomes `[]Waiter` — a new one-method interface for the part of `Task` that does not name the result type.

The other 23 are child workflows, local activities, selector callbacks, and `GetChildWorkflowExecution()` start-waits. None is a `Task`.

## Two things this surfaced

- `vx_export_playout.go` was waiting on `TranscodePlayoutMux` into a `muxResult` nothing ever read — the output is found again by copying the whole `OutputDir`. Now `_, err =`, and noted in `potential_improvements.md` since the activity returning a result no caller wants is the real smell.
- `CollectChildResults`'s reliance on a nil result is now written down rather than implied.

`go build ./...`, `go vet ./...`, `gofmt -l` and `go test ./...` are clean. No behaviour change intended anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)