### PR TITLE
Use Task.Result and FutureResult at the four sites #475 left

### DIFF
--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -714,8 +714,17 @@ most if the proxy were ever misconfigured, bypassed, or reached from an already-
 
 ### Project conventions (`CLAUDE.md`)
 
-- **`.Result(ctx)` over `.Get(ctx, &x)`:** 93 `.Get(ctx` call sites remain, e.g.
-  `workflows/ingest/multitrack.go:60,75`.
+- **`.Result(ctx)` over `.Get(ctx, &x)`: done.** Every `Task` is now read with
+  `.Result(ctx)` or waited on with `.Wait(ctx)`. A `grep` for `.Get(ctx` still returns 29
+  hits and none of them is a violation, so they are listed here rather than found again:
+  five `GetChildWorkflowExecution().Get(ctx, nil)` child-*started* handshakes, three calls
+  inside `Task[T]` that are its `Result`/`Get`/`Wait`, one comment, `activities/pubsub.go:26`
+  (Pub/Sub, not Temporal), `services/bmm/trigger.go:42` (a client-side `WorkflowRun`),
+  `CollectChildResults` (`utils/workflows/common.go:28`, which keeps `.Get` so its result
+  stays `nil` on failure), and seventeen `.Get(ctx, nil)` on `ExecuteChildWorkflow` and
+  `ExecuteLocalActivity` futures, which are not `Task`s and have no `Wait`. Converting those
+  seventeen means wrapping the SDK's child-workflow future, which is a bigger change than the
+  convention asks for.
 
 - **`github.com/orsinium-labs/enum` over string constants.** The codebase already does this
   well in 11 places (`paths/paths.go:32`, `workflows/export/vx_export.go:21`,

--- a/workflows/ingest/incremental_ingest.go
+++ b/workflows/ingest/incremental_ingest.go
@@ -408,10 +408,9 @@ func listReaperFiles(ctx workflow.Context, sessionID, videoVXID string) (*activi
 		return &activities.ReaperResult{}, nil
 	}
 
-	result := &activities.ReaperResult{}
-	err := wfutils.Execute(ctx, activities.Live.ListReaperFiles, &activities.ListReaperFilesParams{
+	result, err := wfutils.Execute(ctx, activities.Live.ListReaperFiles, &activities.ListReaperFilesParams{
 		SessionID: sessionID,
-	}).Get(ctx, result)
+	}).Result(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/workflows/ingest/mu1_mu2_extract.go
+++ b/workflows/ingest/mu1_mu2_extract.go
@@ -35,13 +35,11 @@ func ExtractAudioFromMU1MU2(ctx workflow.Context, input ExtractAudioFromMU1MU2In
 		Tags: []string{"original"},
 	})
 
-	Mu1Result := &vsactivity.GetFileFromVXResult{}
-	Mu2Result := &vsactivity.GetFileFromVXResult{}
-	err := MU1FileFuture.Get(ctx, Mu1Result)
+	Mu1Result, err := MU1FileFuture.Result(ctx)
 	if err != nil {
 		return err
 	}
-	err = MU2FileFuture.Get(ctx, Mu2Result)
+	Mu2Result, err := MU2FileFuture.Result(ctx)
 	if err != nil {
 		return err
 	}

--- a/workflows/vb_export/vb_export_dubbing.go
+++ b/workflows/vb_export/vb_export_dubbing.go
@@ -99,8 +99,7 @@ func VBExportToDubbing(ctx workflow.Context, params VBExportChildWorkflowParams)
 func postTranscodeAudio(ctx workflow.Context, originalFile paths.Path, destinationBase paths.Path, lang string) func(f workflow.Future) {
 	logger := workflow.GetLogger(ctx)
 	return func(f workflow.Future) {
-		res := &common.AudioResult{}
-		err := f.Get(ctx, res)
+		res, err := wfutils.FutureResult[*common.AudioResult](ctx, f)
 		if err != nil {
 			logger.Error("Error transcoding audio", "error", err)
 			return


### PR DESCRIPTION
#475 converted the `.Get(ctx, …)` call sites onto `Task.Result(ctx)` and `Task.Wait(ctx)`, but four were missed, and none of them is one of the two exceptions that PR called out.

| file | was | now |
| --- | --- | --- |
| `workflows/ingest/mu1_mu2_extract.go:40,44` | `MU1FileFuture.Get(ctx, Mu1Result)` | `MU1FileFuture.Result(ctx)` |
| `workflows/ingest/incremental_ingest.go:414` | `wfutils.Execute(…).Get(ctx, result)` | `wfutils.Execute(…).Result(ctx)` |
| `workflows/vb_export/vb_export_dubbing.go:103` | `f.Get(ctx, res)` in a selector callback | `wfutils.FutureResult[*common.AudioResult](ctx, f)` |

The first two read real `Task`s — the values come straight from `wfutils.Execute` — through the raw future, which is the pattern the convention exists to remove. Both also pre-allocated the result only to hand its address to `Get`; `Result` already does that for a pointer `TR`, so the literals go with it.

`postTranscodeAudio` is a selector callback, so the `Task` is genuinely gone by the time the future arrives. That is what `FutureResult` exists for, and `vx_export_vod.go:265` already reads a `*common.AudioResult` out of a callback that way.

### One deliberate non-simplification

`listReaperFiles` keeps its explicit error branch rather than becoming a bare `return …Result(ctx)`. For a pointer result `Result` allocates *before* it waits, so returning it straight through would hand callers a non-nil empty `*ReaperResult` alongside the error, where the signature has always promised `nil`. A caller that skipped the error check would read that as "the reaper recorded nothing" — the failure mode #457 fixed one level up.

### What is left on `.Get`, and why it stays

In-scope sites go **22 → 18**. A `grep` for `.Get(ctx` still returns 29 hits and none is a violation, so `potential_improvements.md` now lists them instead of the stale "93 sites remain" entry — otherwise the next person to grep finds 29 hits and reads them as debt:

- five `GetChildWorkflowExecution().Get(ctx, nil)` child-*started* handshakes
- three calls inside `Task[T]` that **are** its `Result`/`Get`/`Wait`
- one comment, `activities/pubsub.go:26` (Pub/Sub), `services/bmm/trigger.go:42` (client-side `WorkflowRun`)
- `CollectChildResults`, which keeps `.Get` so its result stays `nil` on failure
- seventeen `.Get(ctx, nil)` on `ExecuteChildWorkflow` / `ExecuteLocalActivity` futures — not `Task`s, no `Wait`. Converting those means wrapping the SDK's child-workflow future, which is a bigger change than the convention asks for.

### Verification

`make test` green end to end: `go vet ./...`, `go test -race ./...`, and `workflowcheck`. No persisted shape changes — nothing here crosses a Temporal boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)