### PR TITLE
Move thumbnail existence check into a FileExists activity

### DIFF
--- a/activities/files.go
+++ b/activities/files.go
@@ -192,6 +192,20 @@ func (ua UtilActivities) ListFiles(ctx context.Context, input FileInput) (paths.
 	}), err
 }
 
+func (ua UtilActivities) FileExists(ctx context.Context, input FileInput) (bool, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Info("Starting FileExists")
+
+	_, err := os.Stat(input.Path.Local())
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (ua UtilActivities) DeletePath(ctx context.Context, input DeletePathInput) (any, error) {
 	log := activity.GetLogger(ctx)
 	activity.RecordHeartbeat(ctx, "DeletePath")

--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `workflows/export/shorts.go:442` — `os.Stat` inside workflow code (`generateThumbnailForShort`); not replay-safe. Use `wfutils.RcloneCheckFileExists`.
 - `workflows/misc/slow_move_files.go:50` — `_, _ = c.SignalWithStartWorkflow(...)` then `return nil` in a local activity; the swallowed error also defeats the `MaximumAttempts: 5` retry policy, so a failed start is invisible.
 - `workflows/export/vx_export_bmm.go:62,407` — `panic` in workflow code; workflow task retries forever. Return errors.
 - `workflows/misc/cleanup_production.go` — `MoveFileByImportDate` activity is registered nowhere (the workflow itself is intentionally unregistered); latent trap for whoever enables the flow.

--- a/utils/workflows/files.go
+++ b/utils/workflows/files.go
@@ -189,6 +189,12 @@ func IsImage(ctx workflow.Context, file paths.Path) (bool, error) {
 	return strings.HasPrefix(*mimeType, "image"), nil
 }
 
+func FileExists(ctx workflow.Context, file paths.Path) (bool, error) {
+	return Execute(ctx, activities.Util.FileExists, activities.FileInput{
+		Path: file,
+	}).Result(ctx)
+}
+
 func RcloneCheckFileExists(ctx workflow.Context, file paths.Path) (bool, error) {
 	return Execute(ctx, activities.Util.RcloneCheckFileExists, activities.RcloneSingleFileInput{
 		File: file,

--- a/workflows/export/shorts.go
+++ b/workflows/export/shorts.go
@@ -13,7 +13,6 @@ import (
 	"github.com/bcc-code/bcc-media-flows/utils"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"go.temporal.io/sdk/workflow"
-	"os"
 	"strconv"
 	"strings"
 )
@@ -439,8 +438,11 @@ func generateThumbnailForShort(ctx workflow.Context, destFolder paths.Path, shor
 
 	outputFilePath := destFolder.Append(short.MBMetadata.ID + ".jpg")
 
-	_, err := os.Stat(outputFilePath.Local())
-	if err == nil {
+	exists, err := wfutils.RcloneCheckFileExists(ctx, outputFilePath)
+	if err != nil {
+		return outputFilePath, err
+	}
+	if exists {
 		return outputFilePath, nil
 	}
 

--- a/workflows/export/shorts.go
+++ b/workflows/export/shorts.go
@@ -438,7 +438,7 @@ func generateThumbnailForShort(ctx workflow.Context, destFolder paths.Path, shor
 
 	outputFilePath := destFolder.Append(short.MBMetadata.ID + ".jpg")
 
-	exists, err := wfutils.RcloneCheckFileExists(ctx, outputFilePath)
+	exists, err := wfutils.FileExists(ctx, outputFilePath)
 	if err != nil {
 		return outputFilePath, err
 	}


### PR DESCRIPTION
os.Stat ran directly in workflow code (not replay-safe). The check stays a local stat — the storage is a local mount on the workers — but now runs in a new `UtilActivities.FileExists` activity (with a `wfutils.FileExists` helper) instead of on the workflow goroutine.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/00-bugs-list-validation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)