### PR TITLE
Return SignalWithStartWorkflow error from StartFilesWorkerFlow

### DIFF
--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `workflows/misc/slow_move_files.go:50` — `_, _ = c.SignalWithStartWorkflow(...)` then `return nil` in a local activity; the swallowed error also defeats the `MaximumAttempts: 5` retry policy, so a failed start is invisible.
 - `workflows/export/vx_export_bmm.go:62,407` — `panic` in workflow code; workflow task retries forever. Return errors.
 - `workflows/misc/cleanup_production.go` — `MoveFileByImportDate` activity is registered nowhere (the workflow itself is intentionally unregistered); latent trap for whoever enables the flow.
 - `services/vidispine/export.go` — `StreamID`/`ChannelID` are `uint`; `zxx`/`und` have -1 channel offsets that wrap to garbage stream IDs. Make them `int` and reject negatives.

--- a/workflows/misc/slow_move_files.go
+++ b/workflows/misc/slow_move_files.go
@@ -47,7 +47,7 @@ func MoveMBFile(ctx workflow.Context, params MoveMBFileParams) error {
 
 func StartFilesWorkerFlow(ctx context.Context, params MoveMBFileParams) error {
 	c := ctx.Value(ClientContextKey).(client.Client)
-	_, _ = c.SignalWithStartWorkflow(
+	_, err := c.SignalWithStartWorkflow(
 		context.Background(),
 		"move_mb_file",
 		MoveMBFileSignalName,
@@ -65,6 +65,9 @@ func StartFilesWorkerFlow(ctx context.Context, params MoveMBFileParams) error {
 		},
 		MoveFilesWorkerFlow,
 	)
+	if err != nil {
+		return fmt.Errorf("signal-with-start move_mb_file workflow: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
The error was discarded and nil returned unconditionally, so a failed start was invisible and the MaximumAttempts:5 retry policy never engaged.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/01-shorts-os-stat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)