### PR TITLE
Return errors instead of panicking in BMM export workflow

### DIFF
--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `workflows/export/vx_export_bmm.go:62,407` — `panic` in workflow code; workflow task retries forever. Return errors.
 - `workflows/misc/cleanup_production.go` — `MoveFileByImportDate` activity is registered nowhere (the workflow itself is intentionally unregistered); latent trap for whoever enables the flow.
 - `services/vidispine/export.go` — `StreamID`/`ChannelID` are `uint`; `zxx`/`und` have -1 channel offsets that wrap to garbage stream IDs. Make them `int` and reject negatives.
 - `languages/` — empty language codes collide in the two-letter map (`ParseLanguageCode("")` returns a wrong language); `utils/languages.go` map miss returns a zero `Language` that looks like Norwegian. Guard empty keys, use the `, ok` form.

--- a/workflows/export/vx_export_bmm.go
+++ b/workflows/export/vx_export_bmm.go
@@ -46,20 +46,20 @@ type bmmConfig struct {
 	BaseURL string
 }
 
-func getBMMDestinationConfig(dst AssetExportDestination) bmmConfig {
+func getBMMDestinationConfig(dst AssetExportDestination) (bmmConfig, error) {
 	if dst == AssetExportDestinationBMM {
 		return bmmConfig{
 			Bucket:  "bmms3:/prod-bmm-mediabanken/",
 			BaseURL: "https://bmm-api.brunstad.org",
-		}
+		}, nil
 	} else if dst == AssetExportDestinationBMMIntegration {
 		return bmmConfig{
 			Bucket:  "bmms3:/int-bmm-mediabanken/",
 			BaseURL: "https://int-bmm-api.brunstad.org",
-		}
+		}, nil
 	}
 
-	panic(fmt.Errorf("unsupported destination: %s", dst))
+	return bmmConfig{}, fmt.Errorf("unsupported destination: %s", dst)
 }
 
 // VXExportToBMM exports the specified vx params to BMM
@@ -115,7 +115,10 @@ func VXExportToBMM(ctx workflow.Context, params VXExportChildWorkflowParams) (*V
 		return nil, fmt.Errorf("failed to write JSON file: %w", err)
 	}
 
-	config := getBMMDestinationConfig(params.ExportDestination)
+	config, err := getBMMDestinationConfig(params.ExportDestination)
+	if err != nil {
+		return nil, err
+	}
 
 	ingestFolder := params.ExportData.SafeTitle + "_" + workflow.GetInfo(ctx).OriginalRunID
 	err = wfutils.RcloneCopyDir(ctx, params.OutputDir.Rclone(), config.Bucket+ingestFolder, rclone.PriorityNormal)
@@ -250,7 +253,10 @@ func makeBMMJSON(
 	logger := workflow.GetLogger(ctx)
 
 	// Prepare data for the JSON file
-	jsonData := prepareBMMData(ctx, audioResults, normalizedResults)
+	jsonData, err := prepareBMMData(ctx, audioResults, normalizedResults)
+	if err != nil {
+		return nil, err
+	}
 	jsonData.Length = int(params.MergeResult.Duration)
 	jsonData.MediabankenID = fmt.Sprintf("%s-%s", params.ParentParams.VXID, HashTitle(params.ExportData.Title))
 	jsonData.ImportDate = params.ExportData.ImportDate
@@ -362,14 +368,14 @@ type BMMAudioFile struct {
 	Size            int64   `json:"size"`
 }
 
-func prepareBMMData(ctx workflow.Context, audioFiles map[string][]common.AudioResult, analysis map[string]activities.NormalizeAudioResult) BMMData {
+func prepareBMMData(ctx workflow.Context, audioFiles map[string][]common.AudioResult, analysis map[string]activities.NormalizeAudioResult) (BMMData, error) {
 	out := BMMData{
 		AudioFiles: map[string][]BMMAudioFile{},
 	}
 
 	audioFileKeys, err := wfutils.GetMapKeysSafely(ctx, audioFiles)
 	if err != nil {
-		return out
+		return out, err
 	}
 
 	for _, lang := range audioFileKeys {
@@ -403,8 +409,7 @@ func prepareBMMData(ctx workflow.Context, audioFiles map[string][]common.AudioRe
 			case file.Format == "mp3":
 				f.MimeType = "audio/mpeg"
 			default:
-				// Since this should never happen (only during dev), we panic
-				panic(fmt.Errorf("unsupported audio format: %s", file.Format))
+				return out, fmt.Errorf("unsupported audio format: %s", file.Format)
 			}
 
 			langFiles = append(langFiles, f)
@@ -413,8 +418,7 @@ func prepareBMMData(ctx workflow.Context, audioFiles map[string][]common.AudioRe
 		out.AudioFiles[lang] = langFiles
 	}
 
-	return out
-
+	return out, nil
 }
 
 func HashTitle(title string) string {


### PR DESCRIPTION
Two panics in workflow-goroutine code made the workflow task retry forever; both are now returned errors.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/02-slow-move-files-error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)