### PR TITLE
Register MoveFileByImportDate as a UtilActivities activity

### DIFF
--- a/activities/move_file_by_import_date.go
+++ b/activities/move_file_by_import_date.go
@@ -1,0 +1,124 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/bcc-code/bcc-media-flows/activities/cantemo"
+	avidispine "github.com/bcc-code/bcc-media-flows/activities/vidispine"
+	cantemoservice "github.com/bcc-code/bcc-media-flows/services/cantemo"
+)
+
+var regIllegalChars = regexp.MustCompile(`([^a-zA-Z0-9\-._]|\s)`)
+
+type MoveFileByImportDateParams struct {
+	SourceStorageID      string
+	DestinationStorageID string
+	FileName             string
+}
+
+func (ua UtilActivities) MoveFileByImportDate(ctx context.Context, params MoveFileByImportDateParams) (any, error) {
+	storageID := params.SourceStorageID
+	fileName := params.FileName
+
+	if params.SourceStorageID != params.DestinationStorageID {
+		return nil, errors.New("not implemented: moving files between different storages")
+	}
+
+	filesResult, err := Cantemo.GetFiles(ctx, cantemo.GetFilesParams{
+		Path:     "/",
+		Storages: []string{storageID},
+		Page:     1,
+		Query:    fileName,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range filesResult.Objects {
+		oldName := file.Name
+		oldPath := path.Dir(file.Path)
+
+		// We are only interested in files that are not sorted into directories
+		if oldPath != "." && oldPath != "" {
+			continue
+		}
+
+		renameData, err := generateRenameParams(ctx, file, oldName, "", params.SourceStorageID)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = Cantemo.RenameFile(ctx, renameData)
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func generateRenameParams(ctx context.Context, file cantemoservice.Objects, oldName, prefix, oldStorage string) (*cantemo.RenameFileParams, error) {
+	formats, err := Cantemo.GetFormats(ctx, cantemo.GetFormatsParams{
+		ItemID: file.Item.ID,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var fileFormat *cantemoservice.Format
+	for _, format := range formats {
+		for _, f := range format.Files {
+			if f.ID == file.ID {
+				ff := format
+				fileFormat = &ff
+				break
+			}
+		}
+	}
+
+	if fileFormat == nil {
+		return nil, fmt.Errorf("no format found for file %s", file.ID)
+	}
+
+	// This whole section is here in order to get the timestamp of the file import.
+	// There is a timestamp on the format, but it seems to be the same everywhere
+	shapes, err := Vidispine.GetShapes(ctx, avidispine.VXOnlyParam{
+		VXID: file.Item.ID,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, shape := range shapes.Shape {
+		if shape.ID == fileFormat.ID {
+			ts, err := time.Parse("2006-01-02T15:04:05.000-0700", shape.Created)
+			if err != nil {
+				return nil, err
+			}
+
+			file.Timestamp = ts
+		}
+	}
+
+	newName := regIllegalChars.ReplaceAllString(oldName, "_")
+	newPath := fmt.Sprintf("%04d/%02d/%02d/%s", file.Timestamp.Year(), file.Timestamp.Month(), file.Timestamp.Day(), prefix)
+
+	if strings.Contains(fileFormat.Name, "low") {
+		newPath = "aux/" + newPath
+	}
+
+	return &cantemo.RenameFileParams{
+		NewPath:           newPath + newName,
+		ItemID:            file.Item.ID,
+		ShapeID:           fileFormat.ID,
+		SourceStorage:     oldStorage,
+		DestinatinStorage: oldStorage,
+	}, nil
+}

--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `workflows/misc/cleanup_production.go` — `MoveFileByImportDate` activity is registered nowhere (the workflow itself is intentionally unregistered); latent trap for whoever enables the flow.
 - `services/vidispine/export.go` — `StreamID`/`ChannelID` are `uint`; `zxx`/`und` have -1 channel offsets that wrap to garbage stream IDs. Make them `int` and reject negatives.
 - `languages/` — empty language codes collide in the two-letter map (`ParseLanguageCode("")` returns a wrong language); `utils/languages.go` map miss returns a zero `Language` that looks like Norwegian. Guard empty keys, use the `, ok` form.
 - `utils/files.go` — `IsDirEmpty` returns `(true, nil)` on any I/O error; feeds directory deletion. Check `errors.Is(err, io.EOF)`.

--- a/workflows/misc/cleanup_production.go
+++ b/workflows/misc/cleanup_production.go
@@ -1,23 +1,15 @@
 package miscworkflows
 
 import (
-	"context"
-	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/bcc-code/bcc-media-flows/activities"
-	"github.com/bcc-code/bcc-media-flows/activities/cantemo"
-	avidispine "github.com/bcc-code/bcc-media-flows/activities/vidispine"
-	cantemoservice "github.com/bcc-code/bcc-media-flows/services/cantemo"
 	wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"github.com/samber/lo"
 	"go.temporal.io/sdk/workflow"
-	"path"
-	"regexp"
-	"strings"
-	"time"
 )
-
-var regIllegalChars = regexp.MustCompile(`([^a-zA-Z0-9\-._]|\s)`)
 
 type SortFilesByImportedDateParams struct {
 	SourceStorageID      string
@@ -64,7 +56,7 @@ func SortFilesByImportedDate(
 		jobs := map[string]wfutils.Task[any]{}
 		for _, fileName := range items {
 			fileName := strings.TrimPrefix(fileName, "./")
-			j := wfutils.Execute(ctx, MoveFileByImportDate, MoveFileByImportDateParams{
+			j := wfutils.Execute(ctx, activities.Util.MoveFileByImportDate, activities.MoveFileByImportDateParams{
 				SourceStorageID:      params.SourceStorageID,
 				DestinationStorageID: params.DestinationStorageID,
 				FileName:             fileName,
@@ -92,108 +84,4 @@ func SortFilesByImportedDate(
 	}
 
 	return nil
-}
-
-type MoveFileByImportDateParams struct {
-	SourceStorageID      string
-	DestinationStorageID string
-	FileName             string
-}
-
-func MoveFileByImportDate(ctx context.Context, params MoveFileByImportDateParams) (any, error) {
-	storageID := params.SourceStorageID
-	fileName := params.FileName
-
-	if params.SourceStorageID != params.DestinationStorageID {
-		return nil, errors.New("not implemented: moving files between different storages")
-	}
-
-	filesResult, err := activities.Cantemo.GetFiles(ctx, cantemo.GetFilesParams{
-		Path:     "/",
-		Storages: []string{storageID},
-		Page:     1,
-		Query:    fileName,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	for _, file := range filesResult.Objects {
-		oldName := file.Name
-		oldPath := path.Dir(file.Path)
-
-		// We are only interested in files that are not sorted into directories
-		if oldPath != "." && oldPath != "" {
-			continue
-		}
-
-		renameData, err := generateRenameParams(ctx, file, oldName, "", params.SourceStorageID)
-
-		_, err = activities.Cantemo.RenameFile(ctx, renameData)
-		return nil, err
-	}
-
-	return nil, nil
-}
-
-func generateRenameParams(ctx context.Context, file cantemoservice.Objects, oldName, prefix, oldStorage string) (*cantemo.RenameFileParams, error) {
-	formats, err := activities.Cantemo.GetFormats(ctx, cantemo.GetFormatsParams{
-		ItemID: file.Item.ID,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	var fileFormat *cantemoservice.Format
-	for _, format := range formats {
-		for _, f := range format.Files {
-			if f.ID == file.ID {
-				ff := format
-				fileFormat = &ff
-				break
-			}
-		}
-	}
-
-	if fileFormat == nil {
-		return nil, fmt.Errorf("no format found for file %s", file.ID)
-	}
-
-	// This whole section is here in order to get the timestamp of the file import.
-	// There is a timestamp on the format, but it seems to be the same everywhere
-	shapes, err := activities.Vidispine.GetShapes(ctx, avidispine.VXOnlyParam{
-		VXID: file.Item.ID,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	for _, shape := range shapes.Shape {
-		if shape.ID == fileFormat.ID {
-			ts, err := time.Parse("2006-01-02T15:04:05.000-0700", shape.Created)
-			if err != nil {
-				return nil, err
-			}
-
-			file.Timestamp = ts
-		}
-	}
-
-	newName := regIllegalChars.ReplaceAllString(oldName, "_")
-	newPath := fmt.Sprintf("%04d/%02d/%02d/%s", file.Timestamp.Year(), file.Timestamp.Month(), file.Timestamp.Day(), prefix)
-
-	if strings.Contains(fileFormat.Name, "low") {
-		newPath = "aux/" + newPath
-	}
-
-	return &cantemo.RenameFileParams{
-		NewPath:           newPath + newName,
-		ItemID:            file.Item.ID,
-		ShapeID:           fileFormat.ID,
-		SourceStorage:     oldStorage,
-		DestinatinStorage: oldStorage,
-	}, nil
 }


### PR DESCRIPTION
The activity was defined in the workflow package and registered nowhere; anyone enabling the (intentionally unregistered) cleanup workflow would hit a missing activity at runtime. Also checks the previously ignored generateRenameParams error.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/03-vx-export-bmm-panics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)