### PR TITLE
Use int for audio stream/channel IDs to handle negative offsets

### DIFF
--- a/common/merge.go
+++ b/common/merge.go
@@ -5,8 +5,8 @@ import (
 )
 
 type AudioStream struct {
-	StreamID  uint
-	ChannelID uint
+	StreamID  int
+	ChannelID int
 }
 
 type MergeInputItem struct {

--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `services/vidispine/export.go` — `StreamID`/`ChannelID` are `uint`; `zxx`/`und` have -1 channel offsets that wrap to garbage stream IDs. Make them `int` and reject negatives.
 - `languages/` — empty language codes collide in the two-letter map (`ParseLanguageCode("")` returns a wrong language); `utils/languages.go` map miss returns a zero `Language` that looks like Norwegian. Guard empty keys, use the `, ok` form.
 - `utils/files.go` — `IsDirEmpty` returns `(true, nil)` on any I/O error; feeds directory deletion. Check `errors.Is(err, io.EOF)`.
 - `utils/files.go` — `ValidRawFilename` lowercases the extension but `IsMedia` does not, so `.MOV`/`.MXF` skip transcode/analysis.

--- a/services/transcode/merge.go
+++ b/services/transcode/merge.go
@@ -119,7 +119,7 @@ func mergeItemToStereoStream(index int, tag string, item common.MergeInputItem) 
 
 	for _, stream := range item.Streams {
 		s, found := lo.Find(audioStreams, func(s ffmpeg.FFProbeStream) bool {
-			return s.Index == int(stream.StreamID)
+			return s.Index == stream.StreamID
 		})
 		if found {
 			streams = append(streams, s)

--- a/services/vidispine/export.go
+++ b/services/vidispine/export.go
@@ -283,23 +283,25 @@ func enrichClipWithEmbeddedAudio(client Client, clip *Clip, languagesToExport []
 				return nil, fmt.Errorf("unknown language %s", lang)
 			}
 
-			var streams []common.AudioStream
-			if langInfo.SoftronStartCh >= 0 {
-				streams = []common.AudioStream{
-					{
-						StreamID:  2,
-						ChannelID: langInfo.SoftronStartCh,
-					},
-					{
-						StreamID:  2,
-						ChannelID: langInfo.SoftronStartCh + 1,
-					},
-				}
+			// Languages without their own channel pair (zxx) carry the
+			// Norwegian floor audio.
+			startCh := langInfo.SoftronStartCh
+			if startCh < 0 {
+				startCh = languages.LanguagesByISO["nor"].SoftronStartCh
 			}
 
 			clip.AudioFiles[lang] = &AudioFile{
-				File:    shape.GetPath(),
-				Streams: streams,
+				File: shape.GetPath(),
+				Streams: []common.AudioStream{
+					{
+						StreamID:  2,
+						ChannelID: startCh,
+					},
+					{
+						StreamID:  2,
+						ChannelID: startCh + 1,
+					},
+				},
 			}
 		}
 

--- a/services/vidispine/export.go
+++ b/services/vidispine/export.go
@@ -199,8 +199,8 @@ func enrichClipWithRelatedAudios(client Client, clip *Clip, oLanguagesToExport [
 		if len(relatedAudioShape.AudioComponent) > 0 {
 			for i := 0; relatedAudioShape.AudioComponent[0].ChannelCount > i; i++ {
 				streams = append(streams, common.AudioStream{
-					ChannelID: uint(i),
-					StreamID:  uint(relatedAudioShape.AudioComponent[0].EssenceStreamID),
+					ChannelID: i,
+					StreamID:  relatedAudioShape.AudioComponent[0].EssenceStreamID,
 				})
 			}
 		} else {
@@ -242,8 +242,8 @@ func enrichClipWithEmbeddedAudio(client Client, clip *Clip, languagesToExport []
 			len(shape.AudioComponent), clip.VXID))
 
 		streams := []common.AudioStream{
-			{StreamID: uint(shape.AudioComponent[0].EssenceStreamID), ChannelID: 0},
-			{StreamID: uint(shape.AudioComponent[1].EssenceStreamID), ChannelID: 0},
+			{StreamID: shape.AudioComponent[0].EssenceStreamID, ChannelID: 0},
+			{StreamID: shape.AudioComponent[1].EssenceStreamID, ChannelID: 0},
 		}
 
 		for _, lang := range languagesToExport {
@@ -278,22 +278,28 @@ func enrichClipWithEmbeddedAudio(client Client, clip *Clip, languagesToExport []
 		// This is a softron file
 
 		for _, lang := range languagesToExport {
-			if langInfo, ok := languages.LanguagesByISO[lang]; ok {
-				clip.AudioFiles[lang] = &AudioFile{
-					File: shape.GetPath(),
-					Streams: []common.AudioStream{
-						{
-							StreamID:  2,
-							ChannelID: uint(langInfo.SoftronStartCh),
-						},
-						{
-							StreamID:  2,
-							ChannelID: uint(langInfo.SoftronStartCh) + 1,
-						},
+			langInfo, ok := languages.LanguagesByISO[lang]
+			if !ok {
+				return nil, fmt.Errorf("unknown language %s", lang)
+			}
+
+			var streams []common.AudioStream
+			if langInfo.SoftronStartCh >= 0 {
+				streams = []common.AudioStream{
+					{
+						StreamID:  2,
+						ChannelID: langInfo.SoftronStartCh,
+					},
+					{
+						StreamID:  2,
+						ChannelID: langInfo.SoftronStartCh + 1,
 					},
 				}
-			} else {
-				return nil, fmt.Errorf("unknown language %s", lang)
+			}
+
+			clip.AudioFiles[lang] = &AudioFile{
+				File:    shape.GetPath(),
+				Streams: streams,
 			}
 		}
 
@@ -306,8 +312,8 @@ func enrichClipWithEmbeddedAudio(client Client, clip *Clip, languagesToExport []
 			var streams []common.AudioStream
 			for i := 0; shape.AudioComponent[0].ChannelCount > i; i++ {
 				streams = append(streams, common.AudioStream{
-					StreamID:  uint(shape.AudioComponent[0].EssenceStreamID),
-					ChannelID: uint(i),
+					StreamID:  shape.AudioComponent[0].EssenceStreamID,
+					ChannelID: i,
 				})
 			}
 
@@ -328,7 +334,7 @@ func enrichClipWithEmbeddedAudio(client Client, clip *Clip, languagesToExport []
 				return nil, fmt.Errorf("found %d channels in audio component, expected 1", c.ChannelCount)
 			}
 			streams = append(streams, common.AudioStream{
-				StreamID:  uint(c.EssenceStreamID),
+				StreamID:  c.EssenceStreamID,
 				ChannelID: 0,
 			})
 		}
@@ -359,7 +365,7 @@ func enrichClipWithEmbeddedAudio(client Client, clip *Clip, languagesToExport []
 			}
 
 			streams = append(streams, common.AudioStream{
-				StreamID:  uint(c.EssenceStreamID),
+				StreamID:  c.EssenceStreamID,
 				ChannelID: 0,
 			})
 		}
@@ -379,11 +385,13 @@ func enrichClipWithEmbeddedAudio(client Client, clip *Clip, languagesToExport []
 	for _, lang := range languagesToExport {
 		if l, ok := languages.LanguagesByISO[lang]; ok {
 			var streams []common.AudioStream
-			for i := 0; i < l.MU1ChannelCount; i++ {
-				streams = append(streams, common.AudioStream{
-					StreamID:  uint(l.MU1ChannelStart + i),
-					ChannelID: 0,
-				})
+			if l.MU1ChannelStart >= 0 {
+				for i := 0; i < l.MU1ChannelCount; i++ {
+					streams = append(streams, common.AudioStream{
+						StreamID:  l.MU1ChannelStart + i,
+						ChannelID: 0,
+					})
+				}
 			}
 
 			clip.AudioFiles[lang] = &AudioFile{


### PR DESCRIPTION
StreamID/ChannelID were uint; zxx's -1 Softron offset wrapped to 2^64-1 and produced an invalid `pan=stereo|c0=c18446744073709551615` filter, failing the merge. Both fields are now int, and a language without its own Softron channel pair (zxx) falls back to the Norwegian floor audio (channels 0/1) instead. The MU1 path additionally guards against negative channel starts.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/04-register-move-file-by-import-date`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)