### PR TITLE
Propagate I/O errors from IsDirEmpty instead of reporting empty

### DIFF
--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `utils/files.go` — `IsDirEmpty` returns `(true, nil)` on any I/O error; feeds directory deletion. Check `errors.Is(err, io.EOF)`.
 - `utils/files.go` — `ValidRawFilename` lowercases the extension but `IsMedia` does not, so `.MOV`/`.MXF` skip transcode/analysis.
 - `utils/tc_samples.go` — divides by caller-supplied fps with no zero check; NTSC treated as 30 instead of 30000/1001 (~3.6 s drift per hour).
 - `services/subtrans/client.go` — file name concatenated into URL path unescaped; `stripBOM` uses `bytes.Trim` (cutset) instead of `TrimPrefix`.

--- a/utils/files.go
+++ b/utils/files.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -111,8 +113,8 @@ func IsDirEmpty(dir string) (bool, error) {
 	}
 	defer f.Close()
 
-	names, err := f.Readdirnames(1) // Try to read at least one entry
-	if err != nil && len(names) == 0 {
+	_, err = f.Readdirnames(1) // Try to read at least one entry
+	if errors.Is(err, io.EOF) {
 		return true, nil
 	}
 

--- a/utils/files_test.go
+++ b/utils/files_test.go
@@ -24,6 +24,15 @@ func TestIsDirEmpty(t *testing.T) {
 	empty, err = utils.IsDirEmpty("/this/path/does/not/exist")
 	assert.Error(t, err)
 	assert.False(t, empty)
+
+	file, err := os.CreateTemp("", "notadir")
+	assert.NoError(t, err)
+	defer os.Remove(file.Name())
+	assert.NoError(t, file.Close())
+
+	empty, err = utils.IsDirEmpty(file.Name())
+	assert.Error(t, err)
+	assert.False(t, empty)
 }
 
 func TestValidRawFilename(t *testing.T) {


### PR DESCRIPTION
Any Readdirnames error was reported as (true, nil) and fed directory deletion. Only io.EOF now means empty.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/06-languages-empty-codes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)