### PR TITLE
Lowercase the extension in IsMedia

### DIFF
--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `utils/files.go` — `ValidRawFilename` lowercases the extension but `IsMedia` does not, so `.MOV`/`.MXF` skip transcode/analysis.
 - `utils/tc_samples.go` — divides by caller-supplied fps with no zero check; NTSC treated as 30 instead of 30000/1001 (~3.6 s drift per hour).
 - `services/subtrans/client.go` — file name concatenated into URL path unescaped; `stripBOM` uses `bytes.Trim` (cutset) instead of `TrimPrefix`.
 - `services/rclone/queue.go` — abandoned waiters leak their queued channels (cleanup is only opportunistic); ctx cancellation unblocks the caller but the entry stays.

--- a/utils/files.go
+++ b/utils/files.go
@@ -44,7 +44,7 @@ func ValidRawFilename(filename string) bool {
 }
 
 func IsMedia(filename string) bool {
-	extension := filepath.Ext(filename)
+	extension := strings.ToLower(filepath.Ext(filename))
 	return lo.Contains(mediaExtensions, extension)
 }
 

--- a/utils/files_test.go
+++ b/utils/files_test.go
@@ -35,6 +35,13 @@ func TestIsDirEmpty(t *testing.T) {
 	assert.False(t, empty)
 }
 
+func TestIsMedia(t *testing.T) {
+	assert.True(t, utils.IsMedia("clip.mov"))
+	assert.True(t, utils.IsMedia("CLIP.MOV"))
+	assert.True(t, utils.IsMedia("clip.MXF"))
+	assert.False(t, utils.IsMedia("image.PNG"))
+}
+
 func TestValidRawFilename(t *testing.T) {
 	// Ø is not allowed
 	assert.False(t, utils.ValidRawFilename("KJS80_INTERVJUFILM_BRØDRE_RCC_AUD_V02.wav"))


### PR DESCRIPTION
ValidRawFilename lowercases but IsMedia did not, so .MOV/.MXF files were ingested yet skipped media analysis.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/07-isdirempty-eof`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)