### PR TITLE
Fix fps validation and NTSC sample math in TCToSamples

### DIFF
--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `utils/tc_samples.go` — divides by caller-supplied fps with no zero check; NTSC treated as 30 instead of 30000/1001 (~3.6 s drift per hour).
 - `services/subtrans/client.go` — file name concatenated into URL path unescaped; `stripBOM` uses `bytes.Trim` (cutset) instead of `TrimPrefix`.
 - `services/rclone/queue.go` — abandoned waiters leak their queued channels (cleanup is only opportunistic); ctx cancellation unblocks the caller but the entry stays.
 - `services/ftp/client.go` — failed `Login` leaks the dialled connection (no `Quit`).

--- a/utils/tc_samples.go
+++ b/utils/tc_samples.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -18,6 +19,7 @@ var (
 
 func TCToSamples(tc string, fps int, sampleRate int) (int, error) {
 	frames := 0
+	fpsNum, fpsDen := fps, 1
 	var err error
 	if strings.Contains(tc, "@") {
 
@@ -25,9 +27,9 @@ func TCToSamples(tc string, fps int, sampleRate int) (int, error) {
 
 		switch splitTc[1] {
 		case FrameRatePAL.Value:
-			fps = 25
+			fpsNum, fpsDen = 25, 1
 		case FrameRateNTSC.Value:
-			fps = 30
+			fpsNum, fpsDen = 30000, 1001
 		default:
 			return 0, errors.New("invalid frame rate")
 		}
@@ -40,10 +42,17 @@ func TCToSamples(tc string, fps int, sampleRate int) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return frames * sampleRate / fps, nil
+	if fpsNum <= 0 || fpsDen <= 0 {
+		return 0, fmt.Errorf("invalid fps: %d", fps)
+	}
+	return frames * sampleRate * fpsDen / fpsNum, nil
 }
 
 func TimecodeToFrames(timecode string, frameRate int) (int, error) {
+	if frameRate <= 0 {
+		return 0, fmt.Errorf("invalid frame rate: %d", frameRate)
+	}
+
 	parts := strings.Split(timecode, ":")
 	if len(parts) != 4 {
 		return 0, errors.New("invalid timecode format")

--- a/utils/tc_samples_test.go
+++ b/utils/tc_samples_test.go
@@ -9,23 +9,30 @@ import (
 
 func TestTCToSamples(t *testing.T) {
 	type args struct {
-		tc          string
-		fps         int
-		sampleRate  int
-		expected    int
-		expectedErr error
+		tc         string
+		fps        int
+		sampleRate int
+		expected   int
+		expectErr  bool
 	}
 
 	tests := []args{
-		{"0:00:01:00", 25, 48000, 48000, nil},
-		{"0:00:00:01", 25, 48000, 1920, nil},
-		{"13:50:38:05", 25, 48000, 2392233600, nil},
-		{"180000@PAL", 25, 48000, 345600000, nil},
+		{"0:00:01:00", 25, 48000, 48000, false},
+		{"0:00:00:01", 25, 48000, 1920, false},
+		{"13:50:38:05", 25, 48000, 2392233600, false},
+		{"180000@PAL", 25, 48000, 345600000, false},
+		{"180000@NTSC", 0, 48000, 288288000, false},
+		{"0:00:01:00", 0, 48000, 0, true},
+		{"0:00:01:00", -25, 48000, 0, true},
 	}
 
 	for _, tt := range tests {
 		res, err := utils.TCToSamples(tt.tc, tt.fps, tt.sampleRate)
+		if tt.expectErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
 		assert.Equal(t, tt.expected, res)
-		assert.Equal(t, tt.expectedErr, err)
 	}
 }


### PR DESCRIPTION
Caller-supplied fps of 0 was an integer divide-by-zero; NTSC was treated as 30 instead of 30000/1001 (~3.6 s drift per hour). Math stays exact integer arithmetic.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/08-media-extension-case`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)