### PR TITLE
Fix transfer queue leak from abandoned waiters

### DIFF
--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `services/rclone/queue.go` — abandoned waiters leak their queued channels (cleanup is only opportunistic); ctx cancellation unblocks the caller but the entry stays.
 - `services/ftp/client.go` — failed `Login` leaks the dialled connection (no `Quit`).
 - `services/telegram/chats.go` — enum built from zero-valued members at init; `Parse`/`Contains` are silently wrong.
 - `services/vidispine/export.go` — `convertFromClipTCTimeToSequenceRelativeTime` mutates the caller's metadata; every clip gets a bogus `und` subtitle entry (`allSubLanguages.Add("und")` outside its nil guard); BMM-title check tests the wrong variable.

--- a/services/rclone/queue.go
+++ b/services/rclone/queue.go
@@ -29,12 +29,26 @@ func waitForTransferSlot(ctx context.Context, priority Priority, timeout time.Du
 	case <-ch:
 		break
 	case <-ctx.Done():
+		removeFromTransferQueue(priority, ch)
 		return ctx.Err()
 	case <-time.After(timeout):
+		removeFromTransferQueue(priority, ch)
 		return errTimeout
 	}
 
 	return nil
+}
+
+func removeFromTransferQueue(priority Priority, ch chan bool) {
+	queueLock.Lock()
+	defer queueLock.Unlock()
+	queue := transferQueue[priority]
+	for i, c := range queue {
+		if c == ch {
+			transferQueue[priority] = append(queue[:i], queue[i+1:]...)
+			return
+		}
+	}
 }
 
 func StartFileTransferQueue() {
@@ -56,35 +70,31 @@ func checkFileTransferQueue() {
 		return
 	}
 
+	dispatchTransferSlots(count)
+}
+
+func dispatchTransferSlots(count int) {
 	queueLock.Lock()
 	defer queueLock.Unlock()
 
 	for _, priority := range Priorities.Members() {
-		started := 0
-		for _, ch := range transferQueue[priority] {
+		var remaining []chan bool
+		for i, ch := range transferQueue[priority] {
+			if count >= maxConcurrentTransfers {
+				remaining = append(remaining, transferQueue[priority][i:]...)
+				break
+			}
 
-			// This is a non-blocking send, so if the channel is full, we can skip it.
-			// It basically means that the other side is not listening and we can move on.
-			// this approach works because we're using an unbuffered channel
+			// This is a non-blocking send, so if nobody is listening on the
+			// unbuffered channel we keep the entry for the next round; the
+			// waiter removes itself when it gives up.
 			select {
 			case ch <- true:
 				count++
-				started++
 			default:
-			}
-
-			if count >= maxConcurrentTransfers {
-				// If we've reached the maximum number of concurrent transfers, then we can stop processing the queue
-				// and remove the items that we've already started
-				transferQueue[priority] = transferQueue[priority][started:]
-				return
+				remaining = append(remaining, ch)
 			}
 		}
-
-		if started > 0 {
-			// If we get to here, then we've exhausted the queue for this priority and can replace it with an empty slice
-			transferQueue[priority] = []chan bool{}
-		}
+		transferQueue[priority] = remaining
 	}
-
 }

--- a/services/rclone/queue_test.go
+++ b/services/rclone/queue_test.go
@@ -1,0 +1,98 @@
+package rclone
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func queueLen(priority Priority) int {
+	queueLock.Lock()
+	defer queueLock.Unlock()
+	return len(transferQueue[priority])
+}
+
+func resetTransferQueue() {
+	queueLock.Lock()
+	defer queueLock.Unlock()
+	for _, priority := range Priorities.Members() {
+		transferQueue[priority] = []chan bool{}
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.True(t, cond())
+}
+
+func TestWaitForTransferSlotRemovesAbandonedWaiters(t *testing.T) {
+	resetTransferQueue()
+	defer resetTransferQueue()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := waitForTransferSlot(ctx, PriorityNormal, time.Minute)
+			assert.ErrorIs(t, err, context.Canceled)
+		}()
+	}
+
+	waitFor(t, func() bool { return queueLen(PriorityNormal) == 3 })
+	cancel()
+	wg.Wait()
+
+	assert.Equal(t, 0, queueLen(PriorityNormal))
+
+	dispatchTransferSlots(0)
+	assert.Equal(t, 0, queueLen(PriorityNormal))
+}
+
+func TestWaitForTransferSlotRemovesTimedOutWaiters(t *testing.T) {
+	resetTransferQueue()
+	defer resetTransferQueue()
+
+	err := waitForTransferSlot(context.Background(), PriorityLow, 10*time.Millisecond)
+	assert.ErrorIs(t, err, errTimeout)
+	assert.Equal(t, 0, queueLen(PriorityLow))
+}
+
+func TestDispatchTransferSlotsKeepsUnservedWaiters(t *testing.T) {
+	resetTransferQueue()
+	defer resetTransferQueue()
+
+	served := make(chan error, 3)
+	for i := 0; i < 3; i++ {
+		go func() {
+			served <- waitForTransferSlot(context.Background(), PriorityHigh, 5*time.Second)
+		}()
+	}
+
+	waitFor(t, func() bool { return queueLen(PriorityHigh) == 3 })
+
+	waitFor(t, func() bool {
+		dispatchTransferSlots(maxConcurrentTransfers - 1)
+		return queueLen(PriorityHigh) == 2
+	})
+	require.NoError(t, <-served)
+
+	waitFor(t, func() bool {
+		dispatchTransferSlots(0)
+		return queueLen(PriorityHigh) == 0
+	})
+	require.NoError(t, <-served)
+	require.NoError(t, <-served)
+}


### PR DESCRIPTION
Waiters that hit ctx cancel or timeout left their channel queued forever; dispatch also dropped entries positionally regardless of which were served. Abandon paths now remove their channel; dispatch keeps exactly the unserved entries.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/10-subtrans-url-bom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)