### PR TITLE
Close FTP connection when login fails

### DIFF
--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `services/ftp/client.go` — failed `Login` leaks the dialled connection (no `Quit`).
 - `services/telegram/chats.go` — enum built from zero-valued members at init; `Parse`/`Contains` are silently wrong.
 - `services/vidispine/export.go` — `convertFromClipTCTimeToSequenceRelativeTime` mutates the caller's metadata; every clip gets a bogus `und` subtitle entry (`allSubLanguages.Add("und")` outside its nil guard); BMM-title check tests the wrong variable.
 - `services/transcode/subtitles.go` — `specialASSConverter` ignores write/scan errors; truncated `.ass` burns in as success.

--- a/services/ftp/client.go
+++ b/services/ftp/client.go
@@ -1,8 +1,10 @@
 package ftp
 
 import (
-	"github.com/jlaffaye/ftp"
+	"errors"
 	"time"
+
+	"github.com/jlaffaye/ftp"
 )
 
 type Client struct {
@@ -17,7 +19,7 @@ func NewClient(addr, username, password string) (*Client, error) {
 
 	err = conn.Login(username, password)
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(err, conn.Quit())
 	}
 
 	return &Client{


### PR DESCRIPTION
A failed Login returned without Quit, leaking the dialled socket.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/11-rclone-queue-leak`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)