### PR TITLE
Build telegram chat enum after chat IDs are loaded

### DIFF
--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `services/telegram/chats.go` — enum built from zero-valued members at init; `Parse`/`Contains` are silently wrong.
 - `services/vidispine/export.go` — `convertFromClipTCTimeToSequenceRelativeTime` mutates the caller's metadata; every clip gets a bogus `und` subtitle entry (`allSubLanguages.Add("und")` outside its nil guard); BMM-title check tests the wrong variable.
 - `services/transcode/subtitles.go` — `specialASSConverter` ignores write/scan errors; truncated `.ass` burns in as success.
 - `paths/paths.go` — `Prepend` writes into the variadic backing array, rewriting the caller's slice. Latent: all current callers pass literals.

--- a/services/telegram/chats.go
+++ b/services/telegram/chats.go
@@ -14,12 +14,12 @@ type Chat enum.Member[int64]
 //
 // !!!! You need to update that too !!!!
 var (
-	ChatVOD       = Chat{Value: 0}
-	ChatOslofjord = Chat{Value: 0}
-	ChatOther     = Chat{Value: 0}
-	ChatBMM       = Chat{Value: 0}
+	ChatVOD       Chat
+	ChatOslofjord Chat
+	ChatOther     Chat
+	ChatBMM       Chat
 
-	Chats = enum.New(ChatVOD, ChatOslofjord, ChatOther, ChatBMM)
+	Chats enum.Enum[Chat, int64]
 )
 
 func init() {
@@ -29,4 +29,6 @@ func init() {
 	ChatOslofjord.Value = cfg.Telegram.ChatOslofjord()
 	ChatOther.Value = cfg.Telegram.ChatOther()
 	ChatBMM.Value = cfg.Telegram.ChatBMM()
+
+	Chats = enum.New(ChatVOD, ChatOslofjord, ChatOther, ChatBMM)
 }


### PR DESCRIPTION
enum.New ran at package-var init before init() assigned the env-derived IDs, freezing all members as {Value: 0} and breaking Parse/Contains/Members.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/12-ftp-login-leak`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)