### PR TITLE
Fix metadata aliasing, bogus und subs entry, and BmmTitle condition

### DIFF
--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `services/vidispine/export.go` — `convertFromClipTCTimeToSequenceRelativeTime` mutates the caller's metadata; every clip gets a bogus `und` subtitle entry (`allSubLanguages.Add("und")` outside its nil guard); BMM-title check tests the wrong variable.
 - `services/transcode/subtitles.go` — `specialASSConverter` ignores write/scan errors; truncated `.ass` burns in as success.
 - `paths/paths.go` — `Prepend` writes into the variadic backing array, rewriting the caller's slice. Latent: all current callers pass literals.
 - `cache/store.go` — unchecked type assertion on a flat key namespace; janitor goroutine starts from `init()`; TTL hardcoded to 5 min.

--- a/services/vidispine/export.go
+++ b/services/vidispine/export.go
@@ -495,7 +495,7 @@ func GetDataForExport(client Client, itemVXID string, languagesToExport []string
 	}
 
 	var bmmTitle *string
-	if str := meta.Get(vscommon.FieldBmmTitle, ""); strings.TrimSpace(title) != "" {
+	if str := meta.Get(vscommon.FieldBmmTitle, ""); strings.TrimSpace(str) != "" {
 		bmmTitle = &str
 	}
 
@@ -589,8 +589,8 @@ func addSubtitlesAndTranscriptionsToClips(client Client, clips []*Clip, allowAI 
 			shape := clipShapes.GetShape("Transcribed_Subtitle_SRT")
 			if shape != nil && shape.GetPath() != "" {
 				clip.SubtitleFiles["und"] = shape.GetPath()
+				allSubLanguages.Add("und")
 			}
-			allSubLanguages.Add("und")
 		}
 
 		shape := clipShapes.GetShape("transcription_json")
@@ -621,7 +621,11 @@ func convertFromClipTCTimeToSequenceRelativeTime(clip *Clip, chapter *vsapi.Meta
 	delta := clip.SequenceIn - clip.InSeconds
 
 	for name, terseValue := range chapter.Terse {
-		out.Terse[name] = terseValue
+		out.Terse[name] = make([]*vsapi.MetadataField, len(terseValue))
+		for i, value := range terseValue {
+			copied := *value
+			out.Terse[name][i] = &copied
+		}
 
 		for i, value := range chapter.Terse[name] {
 			// Convert to seconds so we can use math

--- a/services/vidispine/testdata/GetDataForExport/VX-431566.json
+++ b/services/vidispine/testdata/GetDataForExport/VX-431566.json
@@ -670,7 +670,7 @@
   "SafeTitle": "TITLE_OF_THE_SEQUENCE",
   "Title": "TITLE_OF_THE_SEQUENCE",
   "ImportDate": "2022-10-30T15:18:46.52Z",
-  "BmmTitle": "",
+  "BmmTitle": null,
   "BmmTrackID": null,
   "OriginalLanguage": "no",
   "TranscribedLanguage": "no"

--- a/services/vidispine/testdata/GetDataForExport/VX-447459.json
+++ b/services/vidispine/testdata/GetDataForExport/VX-447459.json
@@ -374,7 +374,7 @@
   "SafeTitle": "SOTM_7v2123_SEQ",
   "Title": "SOTM_7v2123_SEQ",
   "ImportDate": "2023-03-27T13:04:00.235Z",
-  "BmmTitle": "",
+  "BmmTitle": null,
   "BmmTrackID": null,
   "OriginalLanguage": "no",
   "TranscribedLanguage": "no"

--- a/services/vidispine/testdata/GetDataForExport/VX-460824.json
+++ b/services/vidispine/testdata/GetDataForExport/VX-460824.json
@@ -101,7 +101,7 @@
     }
   ],
   "SafeTitle": "SS23_20230801_1900_PGM_MU1_Kre_J_Smith_Tale",
-  "BmmTitle": "",
+  "BmmTitle": null,
   "Title": "SS23_20230801_1900_PGM_MU1 - Kåre J. Smith - Tale",
   "ImportDate": "2023-08-01T16:54:19.396Z",
   "TranscribedLanguage": "no",

--- a/services/vidispine/testdata/GetDataForExport/VX-464406.json
+++ b/services/vidispine/testdata/GetDataForExport/VX-464406.json
@@ -103,7 +103,7 @@
   "Title": "SEQ_TITLE_2 - Kåre J. Smith - Tale",
   "SafeTitle": "SEQ_TITLE_2_Kre_J_Smith_Tale",
   "ImportDate": "2023-08-08T19:39:55.559Z",
-  "BmmTitle": "",
+  "BmmTitle": null,
   "OriginalLanguage": "no",
   "TranscribedLanguage": "no"
 }

--- a/services/vidispine/testdata/GetDataForExport/VX-464458.json
+++ b/services/vidispine/testdata/GetDataForExport/VX-464458.json
@@ -13,7 +13,7 @@
   ],
   "SafeTitle": "SS23_20230717_1100_MAS_NOR",
   "Title": "SS23_20230717_1100_MAS_NOR",
-  "BmmTitle": "",
+  "BmmTitle": null,
   "ImportDate": "2023-08-10T12:15:12.525Z",
   "OriginalLanguage": "no",
   "TranscribedLanguage": "no"


### PR DESCRIPTION
convertFromClipTCTimeToSequenceRelativeTime mutated the caller's metadata through shared pointers; allSubLanguages.Add("und") sat outside its nil guard so every clip got a bogus und subtitle entry; the BmmTitle guard tested the wrong variable. Golden fixtures updated where they encoded the bug.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/13-telegram-enum-init`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)