### PR TITLE
Propagate write and scan errors in specialASSConverter

### DIFF
--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `services/transcode/subtitles.go` — `specialASSConverter` ignores write/scan errors; truncated `.ass` burns in as success.
 - `paths/paths.go` — `Prepend` writes into the variadic backing array, rewriting the caller's slice. Latent: all current callers pass literals.
 - `cache/store.go` — unchecked type assertion on a flat key namespace; janitor goroutine starts from `init()`; TTL hardcoded to 5 min.
 - `activities/crop_shorts.go` — ffprobe runs on the worker queue (no ffmpeg installed) and its error is discarded, silently producing 25 fps crops for 50 fps material. Already documented as a known limitation in `activities/queues_test.go`.

--- a/services/transcode/subtitles.go
+++ b/services/transcode/subtitles.go
@@ -108,7 +108,9 @@ func specialASSConverter(header, inputFile, outputFile string, offset float64) e
 	}
 	defer outFile.Close()
 
-	outFile.WriteString(header)
+	if _, err := outFile.WriteString(header); err != nil {
+		return fmt.Errorf("writing ASS header to %s: %w", outputFile, err)
+	}
 
 	scanner := bufio.NewScanner(file)
 	var lineCount int
@@ -133,7 +135,9 @@ func specialASSConverter(header, inputFile, outputFile string, offset float64) e
 
 		if line == "" {
 			if len(textLines) > 0 {
-				writeEvent(outFile, startTime, endTime, textLines, offset)
+				if err := writeEvent(outFile, startTime, endTime, textLines, offset); err != nil {
+					return err
+				}
 				textLines = nil
 			}
 			lineCount = 0
@@ -142,12 +146,22 @@ func specialASSConverter(header, inputFile, outputFile string, offset float64) e
 		}
 	}
 
-	// Write the last event if the file doesn't end with a blank line
-	if len(textLines) > 0 {
-		writeEvent(outFile, startTime, endTime, textLines, offset)
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading %s: %w", inputFile, err)
 	}
 
-	return err
+	// Write the last event if the file doesn't end with a blank line
+	if len(textLines) > 0 {
+		if err := writeEvent(outFile, startTime, endTime, textLines, offset); err != nil {
+			return err
+		}
+	}
+
+	if err := outFile.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", outputFile, err)
+	}
+
+	return nil
 }
 
 func convertTimestamp(input string) string {
@@ -179,7 +193,7 @@ func convertTimestamp(input string) string {
 	return fmt.Sprintf("%s:%s:%s%s", hours, timeParts[1], secondsParts[0], secondsRounded)
 }
 
-func writeEvent(outFile *os.File, startTime, endTime string, textLines []string, offset float64) {
+func writeEvent(outFile *os.File, startTime, endTime string, textLines []string, offset float64) error {
 	startTime = convertTimeFormat(startTime)
 	endTime = convertTimeFormat(endTime)
 
@@ -193,7 +207,10 @@ func writeEvent(outFile *os.File, startTime, endTime string, textLines []string,
 	}
 
 	event := fmt.Sprintf("Dialogue: 0,%s,%s,Default,,0,0,0,,%s\n", startTime, endTime, text)
-	outFile.WriteString(event)
+	if _, err := outFile.WriteString(event); err != nil {
+		return fmt.Errorf("writing ASS event to %s: %w", outFile.Name(), err)
+	}
+	return nil
 }
 
 func convertTimeFormat(srtTime string) string {

--- a/services/transcode/subtitles_test.go
+++ b/services/transcode/subtitles_test.go
@@ -84,7 +84,7 @@ func Test_writeEvent_SingleLine(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	defer tmpFile.Close()
 
-	writeEvent(tmpFile, "00:00:01,000", "00:00:05,000", []string{"Hello world"}, 0.00011)
+	assert.NoError(t, writeEvent(tmpFile, "00:00:01,000", "00:00:05,000", []string{"Hello world"}, 0.00011))
 
 	content, err := os.ReadFile(tmpFile.Name())
 	assert.NoError(t, err)
@@ -99,7 +99,7 @@ func Test_writeEvent_TwoLines(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	defer tmpFile.Close()
 
-	writeEvent(tmpFile, "00:00:01,000", "00:00:05,000", []string{"Line one", "Line two"}, 0.00011)
+	assert.NoError(t, writeEvent(tmpFile, "00:00:01,000", "00:00:05,000", []string{"Line one", "Line two"}, 0.00011))
 
 	content, err := os.ReadFile(tmpFile.Name())
 	assert.NoError(t, err)
@@ -117,13 +117,23 @@ func Test_writeEvent_ThreeLines(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	defer tmpFile.Close()
 
-	writeEvent(tmpFile, "00:00:01,000", "00:00:05,000", []string{"A", "B", "C"}, 0.00011)
+	assert.NoError(t, writeEvent(tmpFile, "00:00:01,000", "00:00:05,000", []string{"A", "B", "C"}, 0.00011))
 
 	content, err := os.ReadFile(tmpFile.Name())
 	assert.NoError(t, err)
 
 	line := string(content)
 	assert.Contains(t, line, `A\NB\NC`)
+}
+
+func Test_writeEvent_ClosedFileReturnsError(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "subtitle_test_*.ass")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	assert.NoError(t, tmpFile.Close())
+
+	err = writeEvent(tmpFile, "00:00:01,000", "00:00:05,000", []string{"Hello"}, 0.00011)
+	assert.Error(t, err)
 }
 
 // CreateBurninASSFile returns (nil, err) when it cannot read the header, and


### PR DESCRIPTION
Write errors, scanner errors, and the Close error were all ignored, so a truncated .ass converted as success.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/14-vidispine-export-fixes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)