### PR TITLE
Stop Prepend from mutating the caller's slice

### DIFF
--- a/paths/paths.go
+++ b/paths/paths.go
@@ -181,9 +181,10 @@ func (p Path) Append(path ...string) Path {
 }
 
 // Prepend prepends the path with the given paths
-func (p Path) Prepend(paths ...string) Path {
-	for i, path := range paths {
-		paths[i] = strings.TrimPrefix(path, "/")
+func (p Path) Prepend(path ...string) Path {
+	paths := make([]string, 0, len(path))
+	for _, part := range path {
+		paths = append(paths, strings.TrimPrefix(part, "/"))
 	}
 	return Path{
 		Drive: p.Drive,

--- a/paths/paths_test.go
+++ b/paths/paths_test.go
@@ -54,6 +54,16 @@ func Test_Lucid(t *testing.T) {
 	assert.Equal(t, "lucid:lucidlink/tesing/test/test/Felles/Opptak1/lkajhdwid-323.wav", lucidPath.Rclone())
 }
 
+func Test_PrependDoesNotMutateInput(t *testing.T) {
+	p := Path{Drive: IsilonDrive, Path: "file.mov"}
+	segments := []string{"/a", "/b"}
+
+	res := p.Prepend(segments...)
+
+	assert.Equal(t, []string{"/a", "/b"}, segments)
+	assert.Equal(t, "/a/b/file.mov", res.Path)
+}
+
 func Test_FileCatalyst(t *testing.T) {
 	pathString := "/mnt/filecatalyst/ingestgrow/MDTES01_MU1.mxf"
 

--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `paths/paths.go` — `Prepend` writes into the variadic backing array, rewriting the caller's slice. Latent: all current callers pass literals.
 - `cache/store.go` — unchecked type assertion on a flat key namespace; janitor goroutine starts from `init()`; TTL hardcoded to 5 min.
 - `activities/crop_shorts.go` — ffprobe runs on the worker queue (no ffmpeg installed) and its error is discarded, silently producing 25 fps crops for 50 fps material. Already documented as a known limitation in `activities/queues_test.go`.
 - 42 `errcheck` findings (verified 2026-08-21): dropped errors in ingest/export/misc workflows (Telegram sends, metadata writes, etc.).


### PR DESCRIPTION
Prepend wrote trimmed values into the variadic backing array; it now builds a fresh slice like Append.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/15-subtitles-ass-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)