### PR TITLE
Fix cache store: safe type assertions, lazy janitor, TTL parameter

### DIFF
--- a/cache/store.go
+++ b/cache/store.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const DefaultTTL = time.Minute * 5
+
 type entry struct {
 	Expiry time.Time
 	Value  any
@@ -12,6 +14,13 @@ type entry struct {
 
 var lock = sync.Mutex{}
 var store = map[string]entry{}
+
+var startJanitor = sync.OnceFunc(func() {
+	j := &janitor{
+		interval: time.Minute * 1,
+	}
+	go j.start()
+})
 
 type janitor struct {
 	interval time.Duration
@@ -41,33 +50,29 @@ func (j *janitor) clear() {
 	}
 }
 
-func init() {
-	j := &janitor{
-		interval: time.Minute * 1,
-	}
-	go j.start()
-}
-
 func Get[T any](key string) *T {
 	lock.Lock()
 	i, ok := store[key]
 	lock.Unlock()
 	if ok && i.Expiry.After(time.Now()) {
-		return i.Value.(*T)
+		if v, ok := i.Value.(*T); ok {
+			return v
+		}
 	}
 	return nil
 }
 
-func Set[T any](key string, value *T) {
+func Set[T any](key string, value *T, ttl time.Duration) {
+	startJanitor()
 	lock.Lock()
 	defer lock.Unlock()
 	store[key] = entry{
-		Expiry: time.Now().Add(time.Minute * 5),
+		Expiry: time.Now().Add(ttl),
 		Value:  value,
 	}
 }
 
-func GetOrSet[T any](key string, factory func() (*T, error)) (*T, error) {
+func GetOrSet[T any](key string, ttl time.Duration, factory func() (*T, error)) (*T, error) {
 	v := Get[T](key)
 	if v != nil {
 		return v, nil
@@ -76,6 +81,6 @@ func GetOrSet[T any](key string, factory func() (*T, error)) (*T, error) {
 	if err != nil {
 		return nil, err
 	}
-	Set(key, v)
+	Set(key, v, ttl)
 	return v, nil
 }

--- a/cache/store_test.go
+++ b/cache/store_test.go
@@ -1,0 +1,35 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetTypeMismatchIsMiss(t *testing.T) {
+	type a struct{ X int }
+	type b struct{ Y string }
+
+	Set("mismatch", &a{X: 1}, DefaultTTL)
+
+	if got := Get[b]("mismatch"); got != nil {
+		t.Fatalf("expected nil for mismatched type, got %v", got)
+	}
+	if got := Get[a]("mismatch"); got == nil || got.X != 1 {
+		t.Fatalf("expected original value, got %v", got)
+	}
+}
+
+func TestSetCustomTTLExpiry(t *testing.T) {
+	v := "hello"
+	Set("short", &v, 10*time.Millisecond)
+
+	if got := Get[string]("short"); got == nil || *got != "hello" {
+		t.Fatalf("expected value before expiry, got %v", got)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	if got := Get[string]("short"); got != nil {
+		t.Fatalf("expected nil after expiry, got %v", got)
+	}
+}

--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `cache/store.go` — unchecked type assertion on a flat key namespace; janitor goroutine starts from `init()`; TTL hardcoded to 5 min.
 - `activities/crop_shorts.go` — ffprobe runs on the worker queue (no ffmpeg installed) and its error is discarded, silently producing 25 fps crops for 50 fps material. Already documented as a known limitation in `activities/queues_test.go`.
 - 42 `errcheck` findings (verified 2026-08-21): dropped errors in ingest/export/misc workflows (Telegram sends, metadata writes, etc.).
 - Panic-prone indexing without length checks: `multitrack` (service + ingest workflow), `playout_mux`, `vsapi/metadata` `GetInOut`, trigger_ui resolution index from unvalidated form input.

--- a/services/ffmpeg/probe.go
+++ b/services/ffmpeg/probe.go
@@ -168,7 +168,7 @@ func doProbe(path string) (*FFProbeResult, error) {
 
 // ProbeFile returns information about the specified video file. Requires ffprobe present.
 func ProbeFile(filePath string) (*FFProbeResult, error) {
-	return cache.GetOrSet("probe:"+filePath, func() (*FFProbeResult, error) {
+	return cache.GetOrSet("probe:"+filePath, cache.DefaultTTL, func() (*FFProbeResult, error) {
 		return doProbe(filePath)
 	})
 }


### PR DESCRIPTION
Type mismatch on a flat key namespace panicked instead of missing; the janitor goroutine started from init(); the TTL was hardcoded. Set/GetOrSet now take a TTL and DefaultTTL is exported.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/16-paths-prepend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)