### PR TITLE
Route CropShortActivity to the transcode queue and surface probe errors

### DIFF
--- a/activities/crop_shorts.go
+++ b/activities/crop_shorts.go
@@ -27,12 +27,15 @@ type CropShortResult struct {
 	Arguments []string
 }
 
-func (ua UtilActivities) CropShortActivity(ctx context.Context, params CropShortInput) (*CropShortResult, error) {
+func (va VideoActivities) CropShortActivity(ctx context.Context, params CropShortInput) (*CropShortResult, error) {
 	cropFilter := buildCropFilter(params.KeyFrames)
 
 	info, err := ffmpeg.GetStreamInfo(params.InputVideoPath.Local())
+	if err != nil {
+		return nil, fmt.Errorf("probing %s for frame rate: %w", params.InputVideoPath.Local(), err)
+	}
 	rate := 25
-	if err == nil && info.FrameRate > 40 {
+	if info.FrameRate > 40 {
 		rate = 50
 	}
 

--- a/activities/queues_test.go
+++ b/activities/queues_test.go
@@ -51,6 +51,7 @@ func TestActivityNamesAreUniqueAcrossStructs(t *testing.T) {
 func TestGetQueueForActivityRoutesByStruct(t *testing.T) {
 	assert.Equal(t, environment.GetAudioQueue(), GetQueueForActivity(Audio.TranscodeToAudioWav))
 	assert.Equal(t, environment.GetTranscodeQueue(), GetQueueForActivity(Video.TranscodeToProResActivity))
+	assert.Equal(t, environment.GetTranscodeQueue(), GetQueueForActivity(Video.CropShortActivity))
 	assert.Equal(t, environment.GetLiveIngestQueue(), GetQueueForActivity(Live.StartReaper))
 
 	// Anything not claimed by a specialised queue runs on the worker queue.
@@ -61,12 +62,7 @@ func TestGetQueueForActivityRoutesByStruct(t *testing.T) {
 // ffmpegOnWorkerQueue lists the activities that reach for ffmpeg from a struct
 // that does not route to an ffmpeg queue. Every entry is a latent failure: the
 // worker image does not install ffmpeg, so the call fails there.
-//
-// CropShortActivity calls ffmpeg.GetStreamInfo to decide between 25 and 50 fps
-// and ignores the error, so on a worker without ffmpeg it silently picks 25.
-var ffmpegOnWorkerQueue = map[string]string{
-	"CropShortActivity": "reads the frame rate with ffprobe and falls back to 25 fps when it cannot",
-}
+var ffmpegOnWorkerQueue = map[string]string{}
 
 // The routing fallback cannot be anything but silent — a name says nothing
 // about what the activity needs — so an ffmpeg activity hung on the wrong

--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- `activities/crop_shorts.go` — ffprobe runs on the worker queue (no ffmpeg installed) and its error is discarded, silently producing 25 fps crops for 50 fps material. Already documented as a known limitation in `activities/queues_test.go`.
 - 42 `errcheck` findings (verified 2026-08-21): dropped errors in ingest/export/misc workflows (Telegram sends, metadata writes, etc.).
 - Panic-prone indexing without length checks: `multitrack` (service + ingest workflow), `playout_mux`, `vsapi/metadata` `GetInOut`, trigger_ui resolution index from unvalidated form input.
 

--- a/workflows/export/generate_short.go
+++ b/workflows/export/generate_short.go
@@ -239,7 +239,7 @@ type cropShortRequest struct {
 func cropShortVideo(ctx workflow.Context, req cropShortRequest) error {
 	logger := workflow.GetLogger(ctx)
 
-	cropRes, err := wfutils.Execute(ctx, activities.Util.CropShortActivity, activities.CropShortInput{
+	cropRes, err := wfutils.Execute(ctx, activities.Video.CropShortActivity, activities.CropShortInput{
 		InputVideoPath:  req.Video,
 		OutputVideoPath: req.Output,
 		// SubtitlePath is left out: subtitle burn-in is disabled for now.

--- a/workflows/export/generate_short_sequence_test.go
+++ b/workflows/export/generate_short_sequence_test.go
@@ -46,7 +46,7 @@ func TestGenerateShortActivityOrder(t *testing.T) {
 			Status:    "completed",
 			Keyframes: []activities.Keyframe{},
 		}, nil)
-	env.OnActivity(activities.Util.CropShortActivity, mock.Anything, mock.Anything).
+	env.OnActivity(activities.Video.CropShortActivity, mock.Anything, mock.Anything).
 		Return(&activities.CropShortResult{Arguments: []string{"-i", "in.mxf"}}, nil)
 	env.OnWorkflow(miscworkflows.ExecuteFFmpeg, mock.Anything, mock.Anything).Return(nil)
 


### PR DESCRIPTION
The activity ran on the worker queue (no ffmpeg) and discarded the ffprobe error, silently producing 25 fps crops for 50 fps material. It is now a VideoActivities method on the transcode queue and probe errors propagate.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/17-cache-store`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)