### PR TITLE
Guard unchecked slice and map indexing against panics

### DIFF
--- a/cmd/trigger_ui/isilon_export.go
+++ b/cmd/trigger_ui/isilon_export.go
@@ -1,8 +1,10 @@
 package main
 
 import (
-	"github.com/bcc-code/bcc-media-flows/environment"
+	"fmt"
 	"net/http"
+
+	"github.com/bcc-code/bcc-media-flows/environment"
 
 	"github.com/bcc-code/bcc-media-flows/services/vidispine"
 	"github.com/bcc-code/bcc-media-flows/services/vidispine/vsapi"
@@ -68,6 +70,11 @@ func (s *TriggerServer) isilonExportPOST(ctx *gin.Context) {
 	vsResolutions, err := s.vidispine.GetResolutions(vxID)
 	if err != nil {
 		renderErrorPage(ctx, http.StatusInternalServerError, err)
+		return
+	}
+
+	if resolutionIndex < 0 || resolutionIndex >= len(vsResolutions) {
+		renderErrorPage(ctx, http.StatusBadRequest, fmt.Errorf("invalid resolution index %d", resolutionIndex))
 		return
 	}
 

--- a/cmd/trigger_ui/main.go
+++ b/cmd/trigger_ui/main.go
@@ -295,6 +295,10 @@ func (s *TriggerServer) vxExportPOST(ctx *gin.Context) {
 
 	var selectedResolutions []utils.Resolution
 	for _, i := range resolutionIndexes {
+		if i < 0 || i >= len(vsresolutions) {
+			renderErrorPage(ctx, http.StatusBadRequest, fmt.Errorf("invalid resolution index %d", i))
+			return
+		}
 		r := vsresolutions[i]
 		selectedResolutions = append(selectedResolutions, utils.Resolution{
 			Width:  r.Width,

--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -5,7 +5,6 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 ## Bugs
 
 - 42 `errcheck` findings (verified 2026-08-21): dropped errors in ingest/export/misc workflows (Telegram sends, metadata writes, etc.).
-- Panic-prone indexing without length checks: `multitrack` (service + ingest workflow), `playout_mux`, `vsapi/metadata` `GetInOut`, trigger_ui resolution index from unvalidated form input.
 
 ## Security
 

--- a/services/transcode/multitrack.go
+++ b/services/transcode/multitrack.go
@@ -1,6 +1,7 @@
 package transcode
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,6 +10,10 @@ import (
 )
 
 func MultitrackMux(files paths.Files, outputPath paths.Path, cb ffmpeg.ProgressCallback) (*paths.Path, error) {
+	if len(files) == 0 {
+		return nil, errors.New("no input files for multitrack mux")
+	}
+
 	lines := []string{
 		"Multitrack VB",
 		"",

--- a/services/transcode/playout_mux.go
+++ b/services/transcode/playout_mux.go
@@ -136,18 +136,16 @@ func generateFFmpegParamsForPlayoutMux(input common.PlayoutMuxInput, outputPath 
 		}
 	}
 
+	useStream := func(streams map[string][]string, lang string) (string, error) {
+		if len(streams[lang]) == 0 {
+			return "", fmt.Errorf("no remaining audio stream for language %s", lang)
+		}
+		stream := streams[lang][0]
+		streams[lang] = streams[lang][1:]
+		return stream, nil
+	}
 	leftStreams := map[string][]string{}
-	useLeftStream := func(lang string) string {
-		stream := leftStreams[lang][0]
-		leftStreams[lang] = leftStreams[lang][1:]
-		return stream
-	}
 	rightStreams := map[string][]string{}
-	useRightStream := func(lang string) string {
-		stream := rightStreams[lang][0]
-		rightStreams[lang] = rightStreams[lang][1:]
-		return stream
-	}
 
 	var filterParts []string
 	for _, lang := range audioLanguages {
@@ -203,10 +201,16 @@ func generateFFmpegParamsForPlayoutMux(input common.PlayoutMuxInput, outputPath 
 		if f.CopyFrom != "" {
 			lang = f.CopyFrom
 		}
-		label := useLeftStream(lang)
+		label, err := useStream(leftStreams, lang)
+		if err != nil {
+			return nil, err
+		}
 		params = append(params, "-map", fmt.Sprintf("[%s]", label))
 		if f.Stereo {
-			label = useRightStream(lang)
+			label, err = useStream(rightStreams, lang)
+			if err != nil {
+				return nil, err
+			}
 			params = append(params, "-map", fmt.Sprintf("[%s]", label))
 		}
 	}

--- a/services/vidispine/vsapi/metadata.go
+++ b/services/vidispine/vsapi/metadata.go
@@ -178,7 +178,7 @@ func (c *Client) AddToItemMetadataField(params ItemMetadataFieldParams) error {
 // for use with ffmpeg
 func (m *MetadataResult) GetInOut(beginTC string) (float64, float64, error) {
 	var v *MetadataField
-	if val, ok := m.Terse[vscommon.FieldTitle.Value]; !ok {
+	if val, ok := m.Terse[vscommon.FieldTitle.Value]; !ok || len(val) == 0 {
 		// This should not happen as everything should have a title
 		return 0, 0, errors.New("Missing title")
 	} else {

--- a/services/vidispine/vsapi/metadata_test.go
+++ b/services/vidispine/vsapi/metadata_test.go
@@ -59,6 +59,28 @@ func Test_GetInOut_SubclipErr(t *testing.T) {
 	assert.Equal(t, 0.0, out)
 }
 
+func Test_GetInOut_EmptyTitle(t *testing.T) {
+	m := MetadataResult{
+		Terse: map[string][]*MetadataField{
+			vscommon.FieldTitle.Value: {},
+		},
+	}
+
+	in, out, err := m.GetInOut("")
+	assert.EqualError(t, err, "Missing title")
+	assert.Equal(t, 0.0, in)
+	assert.Equal(t, 0.0, out)
+}
+
+func Test_GetInOut_MissingTitle(t *testing.T) {
+	m := MetadataResult{Terse: map[string][]*MetadataField{}}
+
+	in, out, err := m.GetInOut("")
+	assert.EqualError(t, err, "Missing title")
+	assert.Equal(t, 0.0, in)
+	assert.Equal(t, 0.0, out)
+}
+
 func Test_GenerateMetUpdateXML(t *testing.T) {
 	buf, _ := createSetItemMetadataFieldXml(xmlSetItemMetadataFieldParams{
 		StartTC: "-INF",

--- a/workflows/ingest/multitrack.go
+++ b/workflows/ingest/multitrack.go
@@ -2,6 +2,7 @@ package ingestworkflows
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 
 	"github.com/bcc-code/bcc-media-flows/activities"
@@ -48,6 +49,10 @@ func Multitrack(ctx workflow.Context, params MasterParams) (*MasterResult, error
 	files, err := wfutils.ListFiles(ctx, *params.Directory)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no files found in directory %s", params.Directory.Local())
 	}
 
 	sort.Sort(files)


### PR DESCRIPTION
Empty-input and missing-key indexing in MultitrackMux, the ingest multitrack workflow, playout mux stream maps, vsapi GetInOut, and trigger_ui resolution indexes from form input now return errors / HTTP 400 instead of panicking.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/18-crop-shorts-ffprobe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)