### PR TITLE
Check all remaining unchecked error returns

### DIFF
--- a/activities/analyze_test.go
+++ b/activities/analyze_test.go
@@ -28,7 +28,7 @@ func (s *AnalyzeTestSuite) TestGetMimeType_TextFile() {
 	t := s.T()
 
 	testFile := paths.MustParse("./testdata/generated/mime_test.txt")
-	os.MkdirAll(testFile.Dir().Local(), 0755)
+	s.Require().NoError(os.MkdirAll(testFile.Dir().Local(), 0755))
 	err := os.WriteFile(testFile.Local(), []byte("hello world"), 0644)
 	assert.NoError(t, err)
 

--- a/activities/audio.go
+++ b/activities/audio.go
@@ -91,7 +91,9 @@ func (aa AudioActivities) AdjustAudioToVideoStart(ctx context.Context, input Adj
 	videoTC, err := ffmpeg.GetTimeCode(input.VideoFile.Local())
 	if err != nil {
 		log.Warn(err.Error())
-		telegram.SendText(telegram.ChatOther, fmt.Sprintf("🟧 Unable to get timecode for `%s`. File imported unadjusted and *WILL* be out of sync with video.", input.AudioFile))
+		if _, terr := telegram.SendText(telegram.ChatOther, fmt.Sprintf("🟧 Unable to get timecode for `%s`. File imported unadjusted and *WILL* be out of sync with video.", input.AudioFile)); terr != nil {
+			log.Error("Failed to send telegram notification", "error", terr)
+		}
 	} else {
 		videoSamples, err = utils.TCToSamples(videoTC, 25, 48000)
 		if err != nil {
@@ -102,7 +104,9 @@ func (aa AudioActivities) AdjustAudioToVideoStart(ctx context.Context, input Adj
 	audioSamples, err := ffmpeg.GetTimeReference(input.AudioFile.Local())
 	if err != nil {
 		log.Warn(err.Error())
-		telegram.SendText(telegram.ChatOther, fmt.Sprintf("🟧 Unable to get timecode for `%s`. File imported unadjusted and *WILL* be out of sync with video.", input.AudioFile))
+		if _, terr := telegram.SendText(telegram.ChatOther, fmt.Sprintf("🟧 Unable to get timecode for `%s`. File imported unadjusted and *WILL* be out of sync with video.", input.AudioFile)); terr != nil {
+			log.Error("Failed to send telegram notification", "error", terr)
+		}
 	} else if videoSamples > 0 {
 		samplesToAdd += audioSamples - videoSamples
 	}

--- a/activities/audio_test.go
+++ b/activities/audio_test.go
@@ -30,7 +30,7 @@ func (s *AudioTestSuite) TestTranscodeToAudioAac() {
 
 	inputFile := paths.MustParse("./testdata/generated/aac_input.wav")
 	outputDir := paths.MustParse("./testdata/generated/aac_output/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	s.Require().NoError(os.MkdirAll(outputDir.Local(), 0755))
 	err := transcode.GenerateToneFile(440, 2, 48000, "01:00:00:00", inputFile)
 	assert.NoError(t, err)
 
@@ -55,7 +55,7 @@ func (s *AudioTestSuite) TestTranscodeToAudioWav() {
 
 	inputFile := paths.MustParse("./testdata/generated/wav_input.wav")
 	outputDir := paths.MustParse("./testdata/generated/wav_output/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	s.Require().NoError(os.MkdirAll(outputDir.Local(), 0755))
 	err := transcode.GenerateToneFile(440, 2, 48000, "01:00:00:00", inputFile)
 	assert.NoError(t, err)
 
@@ -79,7 +79,7 @@ func (s *AudioTestSuite) TestTranscodeToAudioWav_WithTimecode() {
 
 	inputFile := paths.MustParse("./testdata/generated/wav_tc_input.wav")
 	outputDir := paths.MustParse("./testdata/generated/wav_tc_output/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	s.Require().NoError(os.MkdirAll(outputDir.Local(), 0755))
 	err := transcode.GenerateToneFile(440, 2, 48000, "01:00:00:00", inputFile)
 	assert.NoError(t, err)
 
@@ -104,7 +104,7 @@ func (s *AudioTestSuite) TestPrepareForTranscription_WithAudio() {
 
 	testFile := paths.MustParse("./testdata/generated/transcription_input.mkv")
 	outputDir := paths.MustParse("./testdata/generated/transcription_output/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	s.Require().NoError(os.MkdirAll(outputDir.Local(), 0755))
 	testutils.GenerateSoftronTestFile(testFile, 2, 2)
 
 	aa := AudioActivities{}
@@ -128,7 +128,7 @@ func (s *AudioTestSuite) TestPrepareForTranscription_NoAudio() {
 
 	testFile := paths.MustParse("./testdata/generated/transcription_noaudio.mov")
 	outputDir := paths.MustParse("./testdata/generated/transcription_noaudio_output/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	s.Require().NoError(os.MkdirAll(outputDir.Local(), 0755))
 	testutils.GenerateVideoFile(testFile, testutils.VideoGeneratorParams{
 		Duration:  2,
 		FrameRate: 25,
@@ -181,7 +181,7 @@ func (s *AudioTestSuite) TestExtractAudio() {
 
 	testFile := paths.MustParse("./testdata/generated/extract_audio_input.mkv")
 	outputDir := paths.MustParse("./testdata/generated/extract_audio_output/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	s.Require().NoError(os.MkdirAll(outputDir.Local(), 0755))
 	testutils.GenerateSeparateAudioStreamsTestFile(testFile, 2, 2)
 
 	aa := AudioActivities{}
@@ -205,7 +205,7 @@ func (s *AudioTestSuite) TestExtractAudio_SpecificChannels() {
 
 	testFile := paths.MustParse("./testdata/generated/extract_specific_input.mkv")
 	outputDir := paths.MustParse("./testdata/generated/extract_specific_output/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	s.Require().NoError(os.MkdirAll(outputDir.Local(), 0755))
 	testutils.GenerateSeparateAudioStreamsTestFile(testFile, 3, 2)
 
 	aa := AudioActivities{}
@@ -250,7 +250,7 @@ func (s *AudioTestSuite) TestGenerateToneFile() {
 	t := s.T()
 
 	outputFile := paths.MustParse("./testdata/generated/tone_output.wav")
-	os.MkdirAll(outputFile.Dir().Local(), 0755)
+	s.Require().NoError(os.MkdirAll(outputFile.Dir().Local(), 0755))
 
 	aa := AudioActivities{}
 	s.env.RegisterActivity(aa.GenerateToneFile)

--- a/activities/files_test.go
+++ b/activities/files_test.go
@@ -47,9 +47,7 @@ func (s *UnitTestSuite) TestStandardizeFileName() {
 	assert.NotNil(t, res)
 
 	res2 := &FileResult{}
-	res.Get(res2)
-
-	assert.NoError(t, err)
+	assert.NoError(t, res.Get(res2))
 	assert.Equal(t, pathString+"/asdk_lkawd_823____.xYz", "./"+res2.Path.Local())
 }
 

--- a/activities/ftp.go
+++ b/activities/ftp.go
@@ -18,7 +18,7 @@ func (ua UtilActivities) FtpPlayoutRename(_ context.Context, params FtpPlayoutRe
 	if err != nil {
 		return nil, err
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	err = client.Rename(params.From, params.To)
 	if err != nil {

--- a/activities/normalize_test.go
+++ b/activities/normalize_test.go
@@ -83,7 +83,7 @@ func (s *NormalizeTestSuite) TestAdjustAudioLevelActivity() {
 
 	testFile := paths.MustParse("./testdata/generated/adjust_level_input.wav")
 	outputDir := paths.MustParse("./testdata/generated/adjust_level_output/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	s.Require().NoError(os.MkdirAll(outputDir.Local(), 0755))
 	err := transcode.GenerateToneFile(440, 3, 48000, "01:00:00:00", testFile)
 	assert.NoError(t, err)
 
@@ -111,7 +111,7 @@ func (s *NormalizeTestSuite) TestNormalizeAudioActivity_WithAdjustment() {
 
 	testFile := paths.MustParse("./testdata/generated/normalize_input.wav")
 	outputDir := paths.MustParse("./testdata/generated/normalize_output/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	s.Require().NoError(os.MkdirAll(outputDir.Local(), 0755))
 	err := transcode.GenerateToneFile(440, 3, 48000, "01:00:00:00", testFile)
 	assert.NoError(t, err)
 

--- a/activities/transconde_test.go
+++ b/activities/transconde_test.go
@@ -28,7 +28,7 @@ func (s *TranscodeTestSuite) TestAThing() {
 	// Change this path to where your test file is
 	testFilePath := "./testdata/5sec.mov"
 
-	os.MkdirAll("./testdata/generated/", 0755)
+	s.Require().NoError(os.MkdirAll("./testdata/generated/", 0755))
 
 	input := common.MergeInput{
 		Title: "Softron_20sec_64ch_1audio-por",

--- a/activities/util_download.go
+++ b/activities/util_download.go
@@ -39,7 +39,7 @@ func (ua UtilActivities) DownloadFileFromURL(ctx context.Context, in DownloadFil
 	if err != nil {
 		return nil, fmt.Errorf("download request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("download returned unexpected status: %s", resp.Status)

--- a/potential_improvements.md
+++ b/potential_improvements.md
@@ -4,7 +4,7 @@ Condensed 2026-08-21. Items confirmed fixed were removed. Bugs section validated
 
 ## Bugs
 
-- 42 `errcheck` findings (verified 2026-08-21): dropped errors in ingest/export/misc workflows (Telegram sends, metadata writes, etc.).
+- `activities/normalize.go:39` — `AnalyzeEBUR128Activity` ignores the `ffmpeg.GetStreamInfo` error and dereferences `probe.AudioStreams[0]`; a probe failure or a file without audio streams panics the activity.
 
 ## Security
 

--- a/services/bmm/raven.go
+++ b/services/bmm/raven.go
@@ -299,7 +299,7 @@ func queryRaven[T any](ctx context.Context, c *RavenClient, query string) ([]T, 
 	if err != nil {
 		return nil, fmt.Errorf("ravendb request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))

--- a/services/bmm/resolve.go
+++ b/services/bmm/resolve.go
@@ -21,14 +21,14 @@ func ResolveFileURL(ctx context.Context, rawURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented {
 		resp, err = doResolve(ctx, client, http.MethodGet, rawURL)
 		if err != nil {
 			return "", err
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/services/transcode/avc_intra_test.go
+++ b/services/transcode/avc_intra_test.go
@@ -15,7 +15,7 @@ import (
 func Test_AvcIntra_Progressive(t *testing.T) {
 	testFile := paths.MustParse("./testdata/generated/avci_prog.mov")
 	outputDir := paths.MustParse("./testdata/generated/results/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	assert.NoError(t, os.MkdirAll(outputDir.Local(), 0755))
 
 	testutils.GenerateVideoFile(testFile, testutils.VideoGeneratorParams{
 		DAR:       "16/9",
@@ -57,7 +57,7 @@ func Test_AvcIntra_Progressive(t *testing.T) {
 func Test_AvcIntra_Interlaced(t *testing.T) {
 	testFile := paths.MustParse("./testdata/generated/avci_interlaced.mov")
 	outputDir := paths.MustParse("./testdata/generated/results/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	assert.NoError(t, os.MkdirAll(outputDir.Local(), 0755))
 
 	testutils.GenerateVideoFile(testFile, testutils.VideoGeneratorParams{
 		DAR:       "16/9",

--- a/services/transcode/hap_test.go
+++ b/services/transcode/hap_test.go
@@ -16,8 +16,8 @@ func Test_HAP(t *testing.T) {
 	testFile := paths.MustParse("./testdata/generated/hap_test_input.mp4")
 	outputFile := paths.MustParse("./testdata/generated/results/" + testFile.Base())
 
-	os.MkdirAll(testFile.Dir().Local(), 0755)
-	os.MkdirAll(outputFile.Dir().Local(), 0755)
+	assert.NoError(t, os.MkdirAll(testFile.Dir().Local(), 0755))
+	assert.NoError(t, os.MkdirAll(outputFile.Dir().Local(), 0755))
 
 	cmd := exec.Command("ffmpeg",
 		"-f", "lavfi",
@@ -60,8 +60,8 @@ func Test_HAP_PlainFormat(t *testing.T) {
 	testFile := paths.MustParse("./testdata/generated/hap_test_plain.mp4")
 	outputFile := paths.MustParse("./testdata/generated/results/" + testFile.Base())
 
-	os.MkdirAll(testFile.Dir().Local(), 0755)
-	os.MkdirAll(outputFile.Dir().Local(), 0755)
+	assert.NoError(t, os.MkdirAll(testFile.Dir().Local(), 0755))
+	assert.NoError(t, os.MkdirAll(outputFile.Dir().Local(), 0755))
 
 	cmd := exec.Command("ffmpeg",
 		"-f", "lavfi",
@@ -101,8 +101,8 @@ func Test_HAP_WithAlpha(t *testing.T) {
 	testFile := paths.MustParse("./testdata/generated/hap_test_alpha.mov")
 	outputFile := paths.MustParse("./testdata/generated/results/" + testFile.Base())
 
-	os.MkdirAll(testFile.Dir().Local(), 0755)
-	os.MkdirAll(outputFile.Dir().Local(), 0755)
+	assert.NoError(t, os.MkdirAll(testFile.Dir().Local(), 0755))
+	assert.NoError(t, os.MkdirAll(outputFile.Dir().Local(), 0755))
 
 	// Generate a test video with alpha channel using ProRes 4444
 	cmd := exec.Command("ffmpeg",
@@ -153,7 +153,7 @@ func Test_HAP_WithAudio(t *testing.T) {
 	testFile := paths.MustParse("./testdata/generated/hap_test_audio.mp4")
 	outputFile := paths.MustParse("./testdata/generated/results/" + testFile.Base())
 
-	os.MkdirAll(outputFile.Dir().Local(), 0755)
+	assert.NoError(t, os.MkdirAll(outputFile.Dir().Local(), 0755))
 
 	testutils.GenerateSeparateAudioStreamsTestFile(testFile, 1, 2.0)
 

--- a/services/transcode/linear_normalize_test.go
+++ b/services/transcode/linear_normalize_test.go
@@ -15,7 +15,7 @@ import (
 func Test_AdjustAudioLevel_Stereo(t *testing.T) {
 	testFile := paths.MustParse("./testdata/generated/normalize_stereo.wav")
 	outputDir := paths.MustParse("./testdata/generated/results/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	assert.NoError(t, os.MkdirAll(outputDir.Local(), 0755))
 
 	testutils.GenerateMultichannelAudioFile(testFile, 2, 3)
 
@@ -39,7 +39,7 @@ func Test_AdjustAudioLevel_Stereo(t *testing.T) {
 func Test_AdjustAudioLevel_Mono(t *testing.T) {
 	testFile := paths.MustParse("./testdata/generated/normalize_mono.wav")
 	outputDir := paths.MustParse("./testdata/generated/results/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	assert.NoError(t, os.MkdirAll(outputDir.Local(), 0755))
 
 	testutils.GenerateMultichannelAudioFile(testFile, 1, 3)
 
@@ -62,7 +62,7 @@ func Test_AdjustAudioLevel_Mono(t *testing.T) {
 func Test_AdjustAudioLevel_TooManyChannels(t *testing.T) {
 	testFile := paths.MustParse("./testdata/generated/normalize_4ch.wav")
 	outputDir := paths.MustParse("./testdata/generated/results/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	assert.NoError(t, os.MkdirAll(outputDir.Local(), 0755))
 
 	testutils.GenerateMultichannelAudioFile(testFile, 4, 3)
 

--- a/services/transcode/mux_mxf_simple_test.go
+++ b/services/transcode/mux_mxf_simple_test.go
@@ -16,7 +16,7 @@ func Test_MuxToSimpleMXF(t *testing.T) {
 	videoFile := paths.MustParse("./testdata/generated/mxf_video.mov")
 	audioFile := paths.MustParse("./testdata/generated/mxf_audio.wav")
 	outputDir := paths.MustParse("./testdata/generated/results/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	assert.NoError(t, os.MkdirAll(outputDir.Local(), 0755))
 
 	testutils.GenerateVideoFile(videoFile, testutils.VideoGeneratorParams{
 		DAR:       "16/9",
@@ -28,7 +28,7 @@ func Test_MuxToSimpleMXF(t *testing.T) {
 		Profile:   "3",
 	})
 
-	transcode.GenerateToneFile(1000, 3, 48000, "01:00:00:00", audioFile)
+	assert.NoError(t, transcode.GenerateToneFile(1000, 3, 48000, "01:00:00:00", audioFile))
 
 	res, err := transcode.MuxToSimpleMXF(common.SimpleMuxInput{
 		FileName:        "test_output",
@@ -57,7 +57,7 @@ func Test_MuxToSimpleMXF_MultipleAudio(t *testing.T) {
 	audioFile1 := paths.MustParse("./testdata/generated/mxf_audio1.wav")
 	audioFile2 := paths.MustParse("./testdata/generated/mxf_audio2.wav")
 	outputDir := paths.MustParse("./testdata/generated/results/")
-	os.MkdirAll(outputDir.Local(), 0755)
+	assert.NoError(t, os.MkdirAll(outputDir.Local(), 0755))
 
 	testutils.GenerateVideoFile(videoFile, testutils.VideoGeneratorParams{
 		DAR:       "16/9",
@@ -69,8 +69,8 @@ func Test_MuxToSimpleMXF_MultipleAudio(t *testing.T) {
 		Profile:   "3",
 	})
 
-	transcode.GenerateToneFile(1000, 3, 48000, "01:00:00:00", audioFile1)
-	transcode.GenerateToneFile(500, 3, 48000, "01:00:00:00", audioFile2)
+	assert.NoError(t, transcode.GenerateToneFile(1000, 3, 48000, "01:00:00:00", audioFile1))
+	assert.NoError(t, transcode.GenerateToneFile(500, 3, 48000, "01:00:00:00", audioFile2))
 
 	res, err := transcode.MuxToSimpleMXF(common.SimpleMuxInput{
 		FileName:        "test_multi_audio",

--- a/services/transcode/preview.go
+++ b/services/transcode/preview.go
@@ -492,10 +492,13 @@ func muxFinishedPreview(inputFolder, outputFile string) error {
 		return err
 	}
 
-	defer f.Close()
-
 	_, err = f.WriteString("\n#EXT-X-ENDLIST")
 	if err != nil {
+		_ = f.Close()
+		return err
+	}
+
+	if err := f.Close(); err != nil {
 		return err
 	}
 

--- a/services/transcode/prores_test.go
+++ b/services/transcode/prores_test.go
@@ -17,7 +17,7 @@ func Test_ProRes(t *testing.T) {
 	outputFile := paths.MustParse("./testdata/generated/results/" + testFile.Base())
 
 	// Create output directory
-	os.MkdirAll(outputFile.Dir().Local(), 0755)
+	assert.NoError(t, os.MkdirAll(outputFile.Dir().Local(), 0755))
 
 	testutils.GenerateVideoFile(testFile, testutils.VideoGeneratorParams{
 		DAR:       "16/9",
@@ -67,7 +67,7 @@ func Test_ProResHyperdeck(t *testing.T) {
 	outputFile := paths.MustParse("./testdata/generated/results/" + testFile.Base())
 
 	// Create output directory
-	os.MkdirAll(outputFile.Dir().Local(), 0755)
+	assert.NoError(t, os.MkdirAll(outputFile.Dir().Local(), 0755))
 
 	testutils.GenerateVideoFile(testFile, testutils.VideoGeneratorParams{
 		DAR:       "16/9",

--- a/services/transcode/subtitles.go
+++ b/services/transcode/subtitles.go
@@ -100,13 +100,13 @@ func specialASSConverter(header, inputFile, outputFile string, offset float64) e
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	outFile, err := os.Create(outputFile)
 	if err != nil {
 		return err
 	}
-	defer outFile.Close()
+	defer func() { _ = outFile.Close() }()
 
 	if _, err := outFile.WriteString(header); err != nil {
 		return fmt.Errorf("writing ASS header to %s: %w", outputFile, err)

--- a/services/transcode/subtitles_test.go
+++ b/services/transcode/subtitles_test.go
@@ -81,8 +81,8 @@ func Test_convertTimeFormat(t *testing.T) {
 func Test_writeEvent_SingleLine(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "subtitle_test_*.ass")
 	assert.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
-	defer tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	defer func() { _ = tmpFile.Close() }()
 
 	assert.NoError(t, writeEvent(tmpFile, "00:00:01,000", "00:00:05,000", []string{"Hello world"}, 0.00011))
 
@@ -96,8 +96,8 @@ func Test_writeEvent_SingleLine(t *testing.T) {
 func Test_writeEvent_TwoLines(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "subtitle_test_*.ass")
 	assert.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
-	defer tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	defer func() { _ = tmpFile.Close() }()
 
 	assert.NoError(t, writeEvent(tmpFile, "00:00:01,000", "00:00:05,000", []string{"Line one", "Line two"}, 0.00011))
 
@@ -114,8 +114,8 @@ func Test_writeEvent_TwoLines(t *testing.T) {
 func Test_writeEvent_ThreeLines(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "subtitle_test_*.ass")
 	assert.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
-	defer tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	defer func() { _ = tmpFile.Close() }()
 
 	assert.NoError(t, writeEvent(tmpFile, "00:00:01,000", "00:00:05,000", []string{"A", "B", "C"}, 0.00011))
 
@@ -129,7 +129,7 @@ func Test_writeEvent_ThreeLines(t *testing.T) {
 func Test_writeEvent_ClosedFileReturnsError(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "subtitle_test_*.ass")
 	assert.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 	assert.NoError(t, tmpFile.Close())
 
 	err = writeEvent(tmpFile, "00:00:01,000", "00:00:05,000", []string{"Hello"}, 0.00011)

--- a/services/vidispine/vsapi/placeholder.go
+++ b/services/vidispine/vsapi/placeholder.go
@@ -43,9 +43,12 @@ func (c *Client) CreatePlaceholder(ingestType PlaceholderType, title string) (st
 	}
 
 	var body bytes.Buffer
-	tpl.Execute(&body, PlacholderTplData{
+	err := tpl.Execute(&body, PlacholderTplData{
 		Title: title,
 	})
+	if err != nil {
+		return "", fmt.Errorf("rendering placeholder template: %w", err)
+	}
 
 	result, err := c.restyClient.R().
 		SetHeader("content-type", "application/xml").

--- a/utils/files.go
+++ b/utils/files.go
@@ -111,7 +111,7 @@ func IsDirEmpty(dir string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	_, err = f.Readdirnames(1) // Try to read at least one entry
 	if errors.Is(err, io.EOF) {

--- a/utils/files_test.go
+++ b/utils/files_test.go
@@ -27,7 +27,7 @@ func TestIsDirEmpty(t *testing.T) {
 
 	file, err := os.CreateTemp("", "notadir")
 	assert.NoError(t, err)
-	defer os.Remove(file.Name())
+	defer func() { _ = os.Remove(file.Name()) }()
 	assert.NoError(t, file.Close())
 
 	empty, err = utils.IsDirEmpty(file.Name())

--- a/utils/testutils/audio.go
+++ b/utils/testutils/audio.go
@@ -10,7 +10,9 @@ import (
 )
 
 func GenerateDualMonoAudioFile(outFile paths.Path, length float64) paths.Path {
-	os.MkdirAll(outFile.Dir().Local(), 0755)
+	if err := os.MkdirAll(outFile.Dir().Local(), 0755); err != nil {
+		panic(err)
+	}
 
 	args := []string{
 		"-f", "lavfi",
@@ -34,7 +36,9 @@ func GenerateDualMonoAudioFile(outFile paths.Path, length float64) paths.Path {
 }
 
 func GenerateMultichannelAudioFile(outFile paths.Path, chCount int, length float64) paths.Path {
-	os.MkdirAll(outFile.Dir().Local(), 0755)
+	if err := os.MkdirAll(outFile.Dir().Local(), 0755); err != nil {
+		panic(err)
+	}
 
 	args := []string{}
 
@@ -60,7 +64,9 @@ func GenerateMultichannelAudioFile(outFile paths.Path, chCount int, length float
 }
 
 func GenerateSoftronTestFile(outFile paths.Path, chCount int, length float64) paths.Path {
-	os.MkdirAll(outFile.Dir().Local(), 0755)
+	if err := os.MkdirAll(outFile.Dir().Local(), 0755); err != nil {
+		panic(err)
+	}
 
 	args := []string{}
 	// Add audio inputs (start at 1, go one longer)

--- a/utils/testutils/video.go
+++ b/utils/testutils/video.go
@@ -19,7 +19,9 @@ type VideoGeneratorParams struct {
 }
 
 func GenerateVideoFile(outFile paths.Path, videoParams VideoGeneratorParams) paths.Path {
-	os.MkdirAll(outFile.Dir().Local(), 0755)
+	if err := os.MkdirAll(outFile.Dir().Local(), 0755); err != nil {
+		panic(err)
+	}
 	args := []string{
 		"-f", "lavfi",
 		"-i", fmt.Sprintf("testsrc=size=%dx%d:rate=%d:duration=%f", videoParams.Width, videoParams.Height, videoParams.FrameRate, videoParams.Duration),
@@ -46,7 +48,9 @@ func GenerateVideoFile(outFile paths.Path, videoParams VideoGeneratorParams) pat
 // GenerateVideoFileWithTimecode generates a video file (MXF) with an embedded timecode.
 // This is useful for testing activities that read timecodes from video files.
 func GenerateVideoFileWithTimecode(outFile paths.Path, timecode string, duration float64, fps int) paths.Path {
-	os.MkdirAll(outFile.Dir().Local(), 0755)
+	if err := os.MkdirAll(outFile.Dir().Local(), 0755); err != nil {
+		panic(err)
+	}
 
 	args := []string{
 		"-f", "lavfi",
@@ -71,7 +75,9 @@ func GenerateVideoFileWithTimecode(outFile paths.Path, timecode string, duration
 // growing files. MXF stores the stream layout in the header partition, so the
 // file can be probed while partial and piped to ffmpeg without seeking.
 func GenerateStreamableMXFTestFile(outFile paths.Path, audioTracks int, duration float64) paths.Path {
-	os.MkdirAll(outFile.Dir().Local(), 0755)
+	if err := os.MkdirAll(outFile.Dir().Local(), 0755); err != nil {
+		panic(err)
+	}
 
 	args := []string{
 		"-f", "lavfi",
@@ -110,7 +116,9 @@ func GenerateStreamableMXFTestFile(outFile paths.Path, audioTracks int, duration
 }
 
 func GenerateSeparateAudioStreamsTestFile(outFile paths.Path, audioTracks int, duration float64) paths.Path {
-	os.MkdirAll(outFile.Dir().Local(), 0755)
+	if err := os.MkdirAll(outFile.Dir().Local(), 0755); err != nil {
+		panic(err)
+	}
 
 	args := []string{}
 

--- a/utils/workflows/files.go
+++ b/utils/workflows/files.go
@@ -241,10 +241,14 @@ func RcloneWaitForFileGone(ctx workflow.Context, file paths.Path, notificationCh
 		}
 
 		template.Message = fmt.Sprintf("⚠️ File ```%s``` still exists, retrying in one minute (%d/%d)", file.Rclone(), i+1, retries)
-		msg.UpdateWithTemplate(template)
+		if err := msg.UpdateWithTemplate(template); err != nil {
+			workflow.GetLogger(ctx).Error("Failed to update telegram message", "error", err)
+		}
 		msg = SendTelegramMessage(ctx, msg)
 
-		workflow.Sleep(ctx, time.Minute)
+		if err := workflow.Sleep(ctx, time.Minute); err != nil {
+			return err
+		}
 	}
 
 	if fileExists {

--- a/workflows/export/vx_export_bmm_test.go
+++ b/workflows/export/vx_export_bmm_test.go
@@ -60,7 +60,7 @@ func (s *BMMExportTestSuite) doTestGenerateJson(t testData) {
 	s.NoError(err)
 
 	res := []byte{}
-	s.env.GetWorkflowResult(&res)
+	s.NoError(s.env.GetWorkflowResult(&res))
 	s.NotEmpty(res)
 
 	d := BMMData{}
@@ -185,7 +185,7 @@ func (s *BMMExportTestSuite) Test_MakeBMMJSON_SkipsBrokenTranscriptions() {
 	s.NoError(err)
 
 	res := []byte{}
-	s.env.GetWorkflowResult(&res)
+	s.NoError(s.env.GetWorkflowResult(&res))
 	s.NotEmpty(res)
 
 	output := BMMData{}

--- a/workflows/ingest/common.go
+++ b/workflows/ingest/common.go
@@ -180,7 +180,9 @@ func notifyImportCompleted(ctx workflow.Context, recipients []string, jobID int,
 	}
 
 	msg, _ := telegram.NewMessage(telegram.ChatOther, content)
-	wfutils.Execute(ctx, activities.Util.SendTelegramMessage, msg).Wait(ctx)
+	if err := wfutils.Execute(ctx, activities.Util.SendTelegramMessage, msg).Wait(ctx); err != nil {
+		workflow.GetLogger(ctx).Error("Failed to send telegram notification", "error", err)
+	}
 
 	email, _ := emails.NewMessage(content, recipients, nil, nil)
 	return wfutils.Execute(ctx, activities.Util.SendEmail, email).Wait(ctx)
@@ -203,7 +205,9 @@ func notifyImportFailed(ctx workflow.Context, recipients []string, jobID int, fi
 		return err
 	}
 
-	wfutils.Execute(ctx, activities.Util.SendTelegramMessage, msg).Wait(ctx)
+	if err := wfutils.Execute(ctx, activities.Util.SendTelegramMessage, msg).Wait(ctx); err != nil {
+		workflow.GetLogger(ctx).Error("Failed to send telegram notification", "error", err)
+	}
 	email, _ := emails.NewMessage(content, recipients, nil, nil)
 	return wfutils.Execute(ctx, activities.Util.SendEmail, email).Wait(ctx)
 }

--- a/workflows/ingest/import_subtitles_test.go
+++ b/workflows/ingest/import_subtitles_test.go
@@ -10,7 +10,6 @@ import (
 	//vsactivity "github.com/bcc-code/bcc-media-flows/activities/vidispine"
 	//wfutils "github.com/bcc-code/bcc-media-flows/utils/workflows"
 	"encoding/json"
-	"os"
 	"testing"
 	"time"
 
@@ -91,7 +90,7 @@ type ImportSubtitlesTestSuite struct {
 }
 
 func (s *ImportSubtitlesTestSuite) SetupTest() {
-	os.Setenv("TEMPORAL_DEBUG", "true")
+	s.T().Setenv("TEMPORAL_DEBUG", "true")
 	s.env = s.NewTestWorkflowEnvironment()
 }
 

--- a/workflows/ingest/masters_test.go
+++ b/workflows/ingest/masters_test.go
@@ -1,7 +1,6 @@
 package ingestworkflows
 
 import (
-	"os"
 	"testing"
 
 	"github.com/bcc-code/bcc-media-flows/activities"
@@ -25,7 +24,7 @@ type UnitTestSuite struct {
 
 func (s *UnitTestSuite) SetupTest() {
 	// Disable some timeout detection for easier debugging
-	os.Setenv("TEMPORAL_DEBUG", "true")
+	s.T().Setenv("TEMPORAL_DEBUG", "true")
 
 	s.env = s.NewTestWorkflowEnvironment()
 }

--- a/workflows/ingest/raw_material.go
+++ b/workflows/ingest/raw_material.go
@@ -34,7 +34,9 @@ func RawMaterialForm(ctx workflow.Context, params RawMaterialFormParams) error {
 
 	originalFiles, err := wfutils.ListFiles(ctx, params.Directory)
 	if err != nil {
-		notifyImportFailed(ctx, params.Targets, params.Metadata.JobProperty.JobID, originalFiles, err)
+		if nerr := notifyImportFailed(ctx, params.Targets, params.Metadata.JobProperty.JobID, originalFiles, err); nerr != nil {
+			logger.Error("Failed to notify about import failure", "error", nerr)
+		}
 		return err
 	}
 
@@ -44,7 +46,9 @@ func RawMaterialForm(ctx workflow.Context, params RawMaterialFormParams) error {
 		Language:         params.Metadata.JobProperty.Language,
 	})
 	if err != nil {
-		notifyImportFailed(ctx, params.Targets, params.Metadata.JobProperty.JobID, originalFiles, err)
+		if nerr := notifyImportFailed(ctx, params.Targets, params.Metadata.JobProperty.JobID, originalFiles, err); nerr != nil {
+			logger.Error("Failed to notify about import failure", "error", nerr)
+		}
 		return err
 	}
 

--- a/workflows/misc/create_thumbnails-vx.go
+++ b/workflows/misc/create_thumbnails-vx.go
@@ -26,7 +26,9 @@ func CreateThumbnailsVX(
 	if params.Delay > 0 {
 		logger := workflow.GetLogger(ctx)
 		logger.Info("Delaying workflow execution", "duration", params.Delay)
-		workflow.Sleep(ctx, params.Delay)
+		if err := workflow.Sleep(ctx, params.Delay); err != nil {
+			return err
+		}
 	}
 
 	logger := workflow.GetLogger(ctx)

--- a/workflows/misc/normalize_audio_test.go
+++ b/workflows/misc/normalize_audio_test.go
@@ -1,7 +1,6 @@
 package miscworkflows
 
 import (
-	"os"
 	"testing"
 
 	"github.com/bcc-code/bcc-media-flows/activities"
@@ -21,7 +20,7 @@ type NormalizeAudioTestSuite struct {
 }
 
 func (s *NormalizeAudioTestSuite) SetupTest() {
-	os.Setenv("TEMPORAL_DEBUG", "true")
+	s.T().Setenv("TEMPORAL_DEBUG", "true")
 	s.env = s.NewTestWorkflowEnvironment()
 }
 
@@ -64,7 +63,7 @@ func (s *NormalizeAudioTestSuite) Test_NormalizeAudio_NegligibleAdjustment_IsNot
 	s.Zero(adjustCalls, "a zero adjustment must not trigger a re-encode")
 
 	var result NormalizeAudioResult
-	s.env.GetWorkflowResult(&result)
+	s.NoError(s.env.GetWorkflowResult(&result))
 	s.Equal(inputPath.Local(), result.FilePath, "the original file should be returned untouched")
 	s.NotNil(result.InputAnalysis)
 }
@@ -106,7 +105,7 @@ func (s *NormalizeAudioTestSuite) Test_NormalizeAudio_LoudAudio_IsReduced() {
 	s.InDelta(-5.0, appliedAdjustment, 0.001)
 
 	var result NormalizeAudioResult
-	s.env.GetWorkflowResult(&result)
+	s.NoError(s.env.GetWorkflowResult(&result))
 	s.Equal(outputPath.Local(), result.FilePath)
 	s.NotNil(result.InputAnalysis)
 }
@@ -155,7 +154,7 @@ func (s *NormalizeAudioTestSuite) Test_NormalizeAudio_WithOutputAnalysis() {
 	s.NoError(err)
 
 	var result NormalizeAudioResult
-	s.env.GetWorkflowResult(&result)
+	s.NoError(s.env.GetWorkflowResult(&result))
 	s.NotNil(result.InputAnalysis)
 	s.NotNil(result.OutputAnalysis)
 	s.InDelta(-23.2, result.OutputAnalysis.IntegratedLoudness, 0.01)
@@ -203,7 +202,7 @@ func (s *NormalizeAudioTestSuite) Test_NormalizeAudio_QuietAudio_IsBoosted() {
 	s.InDelta(3.0, appliedAdjustment, 0.001)
 
 	var result NormalizeAudioResult
-	s.env.GetWorkflowResult(&result)
+	s.NoError(s.env.GetWorkflowResult(&result))
 	s.Equal(outputPath.Local(), result.FilePath)
 }
 

--- a/workflows/misc/transcode_preview-vx.go
+++ b/workflows/misc/transcode_preview-vx.go
@@ -35,7 +35,9 @@ func TranscodePreviewVX(
 	if params.Delay > 0 {
 		logger := workflow.GetLogger(ctx)
 		logger.Info("Delaying workflow execution", "duration", params.Delay)
-		workflow.Sleep(ctx, params.Delay)
+		if err := workflow.Sleep(ctx, params.Delay); err != nil {
+			return err
+		}
 	}
 
 	logger := workflow.GetLogger(ctx)

--- a/workflows/scheduled/scheduled_test.go
+++ b/workflows/scheduled/scheduled_test.go
@@ -1,7 +1,6 @@
 package scheduled
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -22,7 +21,7 @@ type ScheduledTestSuite struct {
 }
 
 func (s *ScheduledTestSuite) SetupTest() {
-	os.Setenv("TEMPORAL_DEBUG", "true")
+	s.T().Setenv("TEMPORAL_DEBUG", "true")
 	s.env = s.NewTestWorkflowEnvironment()
 }
 
@@ -47,7 +46,7 @@ func (s *ScheduledTestSuite) Test_MediabankenPurgeTrash() {
 	s.NoError(err)
 
 	var result MediabankenPurgeTrashResult
-	s.env.GetWorkflowResult(&result)
+	s.NoError(s.env.GetWorkflowResult(&result))
 	s.Equal(trashedIDs, result.DeletedVXIDs)
 }
 
@@ -66,7 +65,7 @@ func (s *ScheduledTestSuite) Test_MediabankenPurgeTrash_Empty() {
 	s.NoError(err)
 
 	var result MediabankenPurgeTrashResult
-	s.env.GetWorkflowResult(&result)
+	s.NoError(s.env.GetWorkflowResult(&result))
 	s.Empty(result.DeletedVXIDs)
 }
 
@@ -83,7 +82,7 @@ func (s *ScheduledTestSuite) Test_CleanupTemp() {
 	s.NoError(err)
 
 	var result CleanupResult
-	s.env.GetWorkflowResult(&result)
+	s.NoError(s.env.GetWorkflowResult(&result))
 	s.Greater(result.DeletedCount, 0)
 
 	// Two files per folder, counted per root rather than listed.

--- a/workflows/vb_export/vb_export_dubbing.go
+++ b/workflows/vb_export/vb_export_dubbing.go
@@ -115,7 +115,12 @@ func postTranscodeAudio(ctx workflow.Context, originalFile paths.Path, destinati
 		baseName := originalFile.BaseNoExt()
 		dstName := res.OutputPath.Dir().Append(fmt.Sprintf("%02d_%s_%s.wav", dubbReaperChannel, baseName, lang))
 
-		wfutils.MoveFile(ctx, res.OutputPath, dstName, rclone.PriorityHigh)
-		wfutils.RcloneCopyFile(ctx, dstName, destinationBase.Append(dstName.Base()), rclone.PriorityHigh)
+		if err := wfutils.MoveFile(ctx, res.OutputPath, dstName, rclone.PriorityHigh); err != nil {
+			logger.Error("Error moving transcoded audio", "error", err)
+			return
+		}
+		if err := wfutils.RcloneCopyFile(ctx, dstName, destinationBase.Append(dstName.Base()), rclone.PriorityHigh); err != nil {
+			logger.Error("Error copying transcoded audio to destination", "error", err)
+		}
 	}
 }

--- a/workflows/vb_export/vb_export_test.go
+++ b/workflows/vb_export/vb_export_test.go
@@ -1,7 +1,6 @@
 package vb_export
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -25,7 +24,7 @@ type VBExportTestSuite struct {
 }
 
 func (s *VBExportTestSuite) SetupTest() {
-	os.Setenv("TEMPORAL_DEBUG", "true")
+	s.T().Setenv("TEMPORAL_DEBUG", "true")
 	s.env = s.NewTestWorkflowEnvironment()
 }
 
@@ -150,7 +149,7 @@ func (s *VBExportTestSuite) Test_VBExport_XDCAM_Success() {
 	s.NoError(err)
 
 	var results []wfutils.ResultOrError[VBExportResult]
-	s.env.GetWorkflowResult(&results)
+	s.NoError(s.env.GetWorkflowResult(&results))
 	s.Len(results, 1)
 	s.NotNil(results[0].Result)
 	s.Equal("VX-123", results[0].Result.ID)
@@ -192,7 +191,7 @@ func (s *VBExportTestSuite) Test_VBExportToXDCAM() {
 	s.NoError(err)
 
 	var result VBExportResult
-	s.env.GetWorkflowResult(&result)
+	s.NoError(s.env.GetWorkflowResult(&result))
 	s.Equal("VX-123", result.ID)
 }
 
@@ -237,7 +236,7 @@ func (s *VBExportTestSuite) Test_VBExportToBStage() {
 	s.Equal("/Delivery/FraMB/B-Stage/test_video.mov", copied.Destination.Path)
 
 	var result VBExportResult
-	s.env.GetWorkflowResult(&result)
+	s.NoError(s.env.GetWorkflowResult(&result))
 	s.Equal("VX-123", result.ID)
 	s.Equal("test_video", result.Title)
 
@@ -290,7 +289,7 @@ func (s *VBExportTestSuite) Test_VBExportToRawAbekas_CopiesWithoutTranscoding() 
 	s.Equal("/Delivery/FraMB/Abekas-RAW/test_video.mxf", copied.Destination.Path)
 
 	var result VBExportResult
-	s.env.GetWorkflowResult(&result)
+	s.NoError(s.env.GetWorkflowResult(&result))
 	s.Equal("test_video", result.Title)
 }
 


### PR DESCRIPTION
Fixes all 85 errcheck findings (the default linter caps hid duplicates beyond the reported 42): best-effort notification sends are logged, consequential errors propagate, deferred closes are explicit, tests use require/assert and t.Setenv. errcheck now reports 0 issues. Also records a newly found bug (AnalyzeEBUR128Activity ignores its probe error) in potential_improvements.md.

Part of the stacked bugfix series fix/00 → fix/20; based on `fix/19-panic-indexing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)